### PR TITLE
Add codecov YAML that disables the PR comments

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,1 @@
+comment: false


### PR DESCRIPTION
Attempting to fix Codecov which got broken along with ReadTheDocs when I moved the repo to the organization.