### PR TITLE
Iterable Dataset for K2 ASR

### DIFF
--- a/lhotse/audio.py
+++ b/lhotse/audio.py
@@ -83,9 +83,9 @@ def read_audio(path: Pathlike, offset: Seconds, duration: Seconds) -> Tuple[np.n
         sampling_rate = sf_desc.samplerate
         if offset:
             # Seek to the start of the target read
-            sf_desc.seek(int(offset * sampling_rate))
+            sf_desc.seek(round(offset * sampling_rate))
         if duration is not None:
-            frame_duration = int(duration * sampling_rate)
+            frame_duration = round(duration * sampling_rate)
         else:
             frame_duration = -1
         # Load the target number of frames, and transpose to match librosa form

--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -8,7 +8,6 @@ from typing import Any, Callable, Dict, FrozenSet, Iterable, List, Optional, Seq
 import numpy as np
 from cytoolz import sliding_window
 from cytoolz.itertoolz import groupby
-from tqdm import tqdm
 
 from lhotse import WavAugmenter
 from lhotse.audio import AudioMixer, Recording, RecordingSet
@@ -1288,7 +1287,7 @@ class CutSet(JsonMixin, YamlMixin, Sequence[AnyCut]):
                     mix_eagerly=mix_eagerly
                 )
             )
-        cut_set = CutSet.from_cuts(tqdm(f.result() for f in futures))
+        cut_set = CutSet.from_cuts(f.result() for f in futures)
         return cut_set
 
     def with_features_path_prefix(self, path: Pathlike) -> 'CutSet':

--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -273,7 +273,7 @@ class Cut(CutUtilsMixin):
 
     @property
     def num_frames(self) -> Optional[int]:
-        return round(self.duration / self.frame_shift) if self.has_features else None
+        return self.features.num_frames if self.has_features else None
 
     @property
     def num_samples(self) -> Optional[int]:

--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -259,7 +259,7 @@ class Cut(CutUtilsMixin):
 
     @property
     def end(self) -> Seconds:
-        return round(self.start + self.duration, ndigits=3)
+        return round(self.start + self.duration, ndigits=8)
 
     @property
     def has_features(self) -> bool:
@@ -375,9 +375,9 @@ class Cut(CutUtilsMixin):
         if duration_past_end > 0:
             # When the end of the Cut has been exceeded, trim the new duration to not exceed the old Cut's end.
             new_duration -= duration_past_end
-        # Round the duration to 1ms to avoid the possible loss of a single audio sample due to floating point
+        # Round the duration to avoid the possible loss of a single audio sample due to floating point
         # additions and subtractions.
-        new_duration = round(new_duration, ndigits=3)
+        new_duration = round(new_duration, ndigits=8)
         new_time_span = TimeSpan(start=0, end=new_duration)
         criterion = overlaps if keep_excessive_supervisions else overspans
         new_supervisions = (segment.with_offset(-offset) for segment in self.supervisions)
@@ -616,7 +616,7 @@ class MixedCut(CutUtilsMixin):
     @property
     def duration(self) -> Seconds:
         track_durations = (track.offset + track.cut.duration for track in self.tracks)
-        return round(max(track_durations), ndigits=3)
+        return round(max(track_durations), ndigits=8)
 
     @property
     def has_features(self) -> bool:
@@ -736,7 +736,7 @@ class MixedCut(CutUtilsMixin):
             return self
         total_num_frames = round(duration / self.frame_shift) if self.has_features else None
         total_num_samples = round(duration * self.sampling_rate) if self.has_recording else None
-        padding_duration = round(duration - self.duration, ndigits=3)
+        padding_duration = round(duration - self.duration, ndigits=8)
         return self.append(PaddingCut(
             id=str(uuid4()),
             duration=padding_duration,
@@ -1288,7 +1288,7 @@ class CutSet(JsonMixin, YamlMixin, Sequence[AnyCut]):
                     mix_eagerly=mix_eagerly
                 )
             )
-        cut_set = CutSet.from_cuts(f.result() for f in futures)
+        cut_set = CutSet.from_cuts(tqdm(f.result() for f in futures))
         return cut_set
 
     def with_features_path_prefix(self, path: Pathlike) -> 'CutSet':

--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -814,6 +814,10 @@ class MixedCut(CutUtilsMixin):
             #   For now we're duplicating the last frame to match the declared "num_frames" of this cut.
             if feats.shape[0] - self.num_frames == -1:
                 feats = np.concatenate((feats, feats[-1:, :]), axis=0)
+            assert feats.shape[0] == self.num_frames, "Inconsistent number of frames in a MixedCut: please report " \
+                                                      "this issue at https://github.com/lhotse-speech/lhotse/issues " \
+                                                      "showing the output of print(cut) or str(cut) on which" \
+                                                      "load_features() was called."
             return feats
         else:
             return mixer.unmixed_feats

--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -809,6 +809,11 @@ class MixedCut(CutUtilsMixin):
             #  1013 + 572 = 1585. If the frame_shift is 0.01, we have gained an extra 0.01s...
             if feats.shape[0] - self.num_frames == 1:
                 feats = feats[:self.num_frames, :]
+            # TODO(pzelasko): This can sometimes happen in a MixedCut with >= 5 different Cuts,
+            #   with a regular Cut at the end, when the mix offsets are floats with a lot of decimals.
+            #   For now we're duplicating the last frame to match the declared "num_frames" of this cut.
+            if feats.shape[0] - self.num_frames == -1:
+                feats = np.concatenate((feats, feats[-1:, :]), axis=0)
             return feats
         else:
             return mixer.unmixed_feats

--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -750,8 +750,10 @@ class MixedCut(CutUtilsMixin):
         """
         if duration <= self.duration:
             return self
-        total_num_frames = round(duration / self.frame_shift) if self.has_features else None
-        total_num_samples = round(duration * self.sampling_rate) if self.has_recording else None
+        if self.has_features:
+            total_num_frames = compute_num_frames(duration=duration, frame_shift=self.frame_shift)
+        if self.has_recording:
+            total_num_samples = round(duration * self.sampling_rate)
         padding_duration = round(duration - self.duration, ndigits=8)
         return self.append(PaddingCut(
             id=str(uuid4()),

--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -469,6 +469,14 @@ class PaddingCut(CutUtilsMixin):
     num_samples: Optional[int] = None
 
     @property
+    def start(self) -> Seconds:
+        return 0
+
+    @property
+    def end(self) -> Seconds:
+        return self.duration
+
+    @property
     def supervisions(self):
         return []
 
@@ -611,6 +619,14 @@ class MixedCut(CutUtilsMixin):
             for track in self.tracks
             for segment in track.cut.supervisions
         ]
+
+    @property
+    def start(self) -> Seconds:
+        return 0
+
+    @property
+    def end(self) -> Seconds:
+        return self.duration
 
     @property
     def duration(self) -> Seconds:

--- a/lhotse/dataset/__init__.py
+++ b/lhotse/dataset/__init__.py
@@ -1,14 +1,12 @@
 from .diarization import DiarizationDataset
-from .source_separation import (
-    SourceSeparationDataset,
-    PreMixedSourceSeparationDataset,
-    DynamicallyMixedSourceSeparationDataset
+from .source_separation import (DynamicallyMixedSourceSeparationDataset, PreMixedSourceSeparationDataset,
+                                SourceSeparationDataset)
+from .speech_recognition import (
+    K2DataLoader,
+    K2SpeechRecognitionDataset,
+    K2SpeechRecognitionIterableDataset,
+    SpeechRecognitionDataset,
 )
-from .speech_recognition import SpeechRecognitionDataset
 from .speech_synthesis import SpeechSynthesisDataset
-from .unsupervised import (
-    UnsupervisedDataset,
-    UnsupervisedWaveformDataset,
-    DynamicUnsupervisedDataset
-)
+from .unsupervised import (DynamicUnsupervisedDataset, UnsupervisedDataset, UnsupervisedWaveformDataset)
 from .vad import VadDataset

--- a/lhotse/dataset/speech_recognition.py
+++ b/lhotse/dataset/speech_recognition.py
@@ -222,9 +222,7 @@ def _collate_features(cuts: CutSet) -> torch.Tensor:
     first_cut = next(iter(cuts))
     features = torch.empty(len(cuts), first_cut.num_frames, first_cut.num_features)
     for idx, cut in enumerate(cuts):
-        # TODO(pzelasko): The last index part is a hack, because we failed to guarantee
-        #  that cut.num_frames always provides a correct value. This will require a deeper fix.
-        features[idx] = torch.from_numpy(cut.load_features())[:first_cut.num_frames, :]
+        features[idx] = torch.from_numpy(cut.load_features())
     return features
 
 

--- a/lhotse/dataset/speech_recognition.py
+++ b/lhotse/dataset/speech_recognition.py
@@ -222,7 +222,9 @@ def _collate_features(cuts: CutSet) -> torch.Tensor:
     first_cut = next(iter(cuts))
     features = torch.empty(len(cuts), first_cut.num_frames, first_cut.num_features)
     for idx, cut in enumerate(cuts):
-        features[idx] = torch.from_numpy(cut.load_features())
+        # TODO(pzelasko): The last index part is a hack, because we failed to guarantee
+        #  that cut.num_frames always provides a correct value. This will require a deeper fix.
+        features[idx] = torch.from_numpy(cut.load_features())[:first_cut.num_frames, :]
     return features
 
 

--- a/lhotse/dataset/speech_recognition.py
+++ b/lhotse/dataset/speech_recognition.py
@@ -7,7 +7,6 @@ from torch.utils.data.dataloader import DataLoader
 
 from lhotse.cut import AnyCut, CutSet
 from lhotse.utils import Seconds
-from test.cut.test_padding_cut import PADDING_LOG_ENERGY
 
 EPS = 1e-8
 
@@ -275,13 +274,10 @@ class K2SpeechRecognitionIterableDataset(torch.utils.data.IterableDataset):
 
 
 def _collate_features(cuts: CutSet) -> torch.Tensor:
-    # TODO(pzelasko): because MixedCut's currently suffer from some off-by-one errors in number of
-    #  frames calculation, we have to do extra slicing in this function to safe-guard against it.
     first_cut = next(iter(cuts))
-    features = torch.ones(len(cuts), first_cut.num_frames, first_cut.num_features) * PADDING_LOG_ENERGY
+    features = torch.empty(len(cuts), first_cut.num_frames, first_cut.num_features)
     for idx, cut in enumerate(cuts):
-        feats_arr = torch.from_numpy(cut.load_features())[:first_cut.num_frames, :]
-        features[idx, :feats_arr.shape[0], :] = feats_arr
+        features[idx] = torch.from_numpy(cut.load_features())
     return features
 
 

--- a/lhotse/dataset/speech_recognition.py
+++ b/lhotse/dataset/speech_recognition.py
@@ -293,8 +293,6 @@ def concat_cuts(
     going from the back (i.e. the shortest cuts) we'll try to concat them to the longest cut
     that still has some "space" at the end.
 
-    This function expects that the input is sorted descendingly by duration.
-
     :param cuts: a list of cuts to pack.
     :param gap: the duration of silence inserted between concatenated cuts.
     :param max_duration: the maximum duration for the concatenated cuts
@@ -303,6 +301,7 @@ def concat_cuts(
     """
     if len(cuts) <= 1:
         return cuts
+    cuts = sorted(cuts, key=lambda c: c.duration, reverse=True)
     max_duration = cuts[0].duration if max_duration is None else max_duration
     current_idx = 1
     while True:

--- a/lhotse/features/base.py
+++ b/lhotse/features/base.py
@@ -130,7 +130,7 @@ class FeatureExtractor(metaclass=ABCMeta):
         """
         if augmenter is not None:
             samples = augmenter.apply(samples)
-        duration = round(samples.shape[1] / sampling_rate, ndigits=3)
+        duration = round(samples.shape[1] / sampling_rate, ndigits=8)
         feats = self.extract(samples=samples, sampling_rate=sampling_rate)
         storage_key = store_feature_array(feats, storage=storage)
         return Features(

--- a/lhotse/features/base.py
+++ b/lhotse/features/base.py
@@ -85,7 +85,9 @@ class FeatureExtractor(metaclass=ABCMeta):
             where to apply ``energy_scaling_factor_b`` to the signal is determined by the implementer.
         :return: A mixed feature matrix.
         """
-        raise ValueError('The feature extractor\'s "mix" operation is undefined.')
+        raise ValueError('The feature extractor\'s "mix" operation is undefined. '
+                         'It does not support feature-domain mix, consider computing the features '
+                         'after, rather than before mixing the cuts.')
 
     @staticmethod
     def compute_energy(features: np.ndarray) -> float:
@@ -97,7 +99,9 @@ class FeatureExtractor(metaclass=ABCMeta):
         :param features: A feature matrix.
         :return: A positive float value of the signal energy.
         """
-        raise ValueError('The feature extractor\'s "compute_energy" is undefined.')
+        raise ValueError('The feature extractor\'s "compute_energy" operation is undefined. '
+                         'It does not support feature-domain mix, consider computing the features '
+                         'after, rather than before mixing the cuts.')
 
     def extract_from_samples_and_store(
             self,

--- a/lhotse/features/base.py
+++ b/lhotse/features/base.py
@@ -130,13 +130,16 @@ class FeatureExtractor(metaclass=ABCMeta):
         """
         if augmenter is not None:
             samples = augmenter.apply(samples)
+        duration = round(samples.shape[1] / sampling_rate, ndigits=3)
         feats = self.extract(samples=samples, sampling_rate=sampling_rate)
+        feats = self._trim_features_when_inconsistent(
+            feats=feats,
+            expected_duration=duration,
+        )
         storage_key = store_feature_array(feats, storage=storage)
         return Features(
             start=offset,
-            # We simplify the relationship between num_frames and duration - we guarantee that
-            #  the duration is always num_frames * frame_shift
-            duration=feats.shape[0] * self.frame_shift,
+            duration=duration,
             type=self.name,
             num_frames=feats.shape[0],
             num_features=feats.shape[1],
@@ -145,6 +148,28 @@ class FeatureExtractor(metaclass=ABCMeta):
             storage_path=str(storage.storage_path),
             storage_key=storage_key
         )
+
+    def _trim_features_when_inconsistent(self, feats: np.ndarray, expected_duration: Seconds) -> np.ndarray:
+        # This will take some context to explain, so bear with me.
+        # Python 3 rounding behaviour is called "banker's rounding", and will go either
+        # towards or away from zero depending which is closer. When the value is exactly in the middle, e.g. 0.5,
+        # it will round towards zero: round(0.5) == 0.
+        # What's the problem?
+        # - When we compute "num_frames" for composite (mixed) cuts, we have to compute their total duration,
+        # and divide that by the "frame_shift." In case of 16.405 seconds, that results in 16.405 / 0.01 = 1640.5
+        # frames. When we round(1640.5) we get 1640, but some feature extractors tend to return 1641 frames.
+        # So we might end up with incosistent data and metadata.
+        # What's the solution?
+        # - Remove the last frame if that's the case.
+        # ...
+        # ... (1h later) ...
+        # ...
+        # Update: actually round(1648.5) == 1648, but round(1649.5) == 1650 🤯
+        # I will have to fix this another time and work around for now...
+        expected_num_frames = round(expected_duration / self.frame_shift)
+        if feats.shape[0] - expected_num_frames == 1:
+            feats = feats[:-1, :]
+        return feats
 
     def extract_from_recording_and_store(
             self,
@@ -181,15 +206,17 @@ class FeatureExtractor(metaclass=ABCMeta):
         if augmenter is not None:
             samples = augmenter.apply(samples)
         feats = self.extract(samples=samples, sampling_rate=recording.sampling_rate)
+        feats = self._trim_features_when_inconsistent(
+            feats=feats,
+            expected_duration=recording.duration
+        )
         storage_key = store_feature_array(feats, storage=storage)
         return Features(
             recording_id=recording.id,
             channels=channels if channels is not None else recording.channel_ids,
             # The start is relative to the beginning of the recording.
             start=offset,
-            # We simplify the relationship between num_frames and duration - we guarantee that
-            #  the duration is always num_frames * frame_shift
-            duration=feats.shape[0] * self.frame_shift,
+            duration=recording.duration,
             type=self.name,
             num_frames=feats.shape[0],
             num_features=feats.shape[1],

--- a/lhotse/features/mixer.py
+++ b/lhotse/features/mixer.py
@@ -3,7 +3,7 @@ from typing import Optional
 import numpy as np
 
 from lhotse.features.base import FeatureExtractor
-from lhotse.utils import Seconds, Decibels
+from lhotse.utils import Decibels, Seconds, compute_num_frames
 
 
 class FeatureMixer:
@@ -95,7 +95,7 @@ class FeatureMixer:
         assert offset >= 0.0, "Negative offset in mixing is not supported."
 
         reference_feats = self.tracks[0]
-        num_frames_offset = round(offset / self.frame_shift)
+        num_frames_offset = compute_num_frames(duration=offset, frame_shift=self.frame_shift)
         current_num_frames = reference_feats.shape[0]
         incoming_num_frames = feats.shape[0] + num_frames_offset
         mix_num_frames = max(current_num_frames, incoming_num_frames)

--- a/lhotse/recipes/broadcast_news.py
+++ b/lhotse/recipes/broadcast_news.py
@@ -13,13 +13,13 @@ This data is not available for free - your institution needs to have an LDC subs
 import re
 from itertools import chain
 from pathlib import Path
-from typing import Dict, Union, Optional, List
+from typing import Dict, List, Optional, Union
 
 from cytoolz import sliding_window
 
 from lhotse.audio import Recording, RecordingSet
 from lhotse.supervision import SupervisionSegment, SupervisionSet
-from lhotse.utils import Pathlike, recursion_limit, check_and_rglob
+from lhotse.utils import Pathlike, check_and_rglob, recursion_limit
 
 # Since BroadcastNews SGML does not include </time> tags, BeautifulSoup hallucinates them
 # in incorrect positions - it nests the <time> segments in each other, making parsing more difficult...
@@ -131,7 +131,7 @@ def make_supervisions(sgml_path: Pathlike, recording: Recording) -> Dict[str, Li
                         id=f'{recording.id}_segment{text_idx:04d}',
                         recording_id=recording.id,
                         start=start,
-                        duration=round(end - start, ndigits=3),
+                        duration=round(end - start, ndigits=8),
                         channel=0,
                         language=episode.attrs['language'],
                         text=text.strip(),

--- a/lhotse/recipes/librispeech.py
+++ b/lhotse/recipes/librispeech.py
@@ -111,7 +111,7 @@ def prepare_librispeech(
                 ],
                 sampling_rate=int(metadata[idx].audio_info.rate),
                 num_samples=metadata[idx].audio_info.length,
-                duration=(metadata[idx].audio_info.length / metadata[idx].audio_info.rate)
+                duration=round(metadata[idx].audio_info.length / metadata[idx].audio_info.rate, ndigits=3)
             )
             for idx in metadata
         )

--- a/lhotse/recipes/librispeech.py
+++ b/lhotse/recipes/librispeech.py
@@ -111,7 +111,7 @@ def prepare_librispeech(
                 ],
                 sampling_rate=int(metadata[idx].audio_info.rate),
                 num_samples=metadata[idx].audio_info.length,
-                duration=round(metadata[idx].audio_info.length / metadata[idx].audio_info.rate, ndigits=3)
+                duration=metadata[idx].audio_info.length / metadata[idx].audio_info.rate
             )
             for idx in metadata
         )

--- a/lhotse/recipes/switchboard.py
+++ b/lhotse/recipes/switchboard.py
@@ -14,10 +14,10 @@ import tarfile
 import urllib
 from itertools import chain
 from pathlib import Path
-from typing import Dict, Union, Optional
+from typing import Dict, Optional, Union
 
-from lhotse.audio import RecordingSet, Recording
-from lhotse.supervision import SupervisionSet, SupervisionSegment
+from lhotse.audio import Recording, RecordingSet
+from lhotse.supervision import SupervisionSegment, SupervisionSet
 from lhotse.utils import Pathlike, check_and_rglob
 
 SWBD_TEXT_URL = 'http://www.isip.piconepress.com/projects/switchboard/releases/switchboard_word_alignments.tar.gz'
@@ -92,7 +92,7 @@ def make_segments(transcript_path: Path, recording: Recording, channel: int, omi
             id=segment_id,
             recording_id=recording.id,
             start=float(start),
-            duration=round(float(end) - float(start), ndigits=3),
+            duration=round(float(end) - float(start), ndigits=8),
             channel=channel,
             text=' '.join(words),
             language='English',

--- a/lhotse/recipes/tedlium.py
+++ b/lhotse/recipes/tedlium.py
@@ -108,7 +108,7 @@ def prepare_tedlium(
                             id=f'{rec_id}-{idx}',
                             recording_id=rec_id,
                             start=start,
-                            duration=round(end - start, ndigits=3),
+                            duration=round(end - start, ndigits=8),
                             channel=0,
                             text=text,
                             language='English',

--- a/lhotse/supervision.py
+++ b/lhotse/supervision.py
@@ -19,12 +19,11 @@ class SupervisionSegment:
 
     @property
     def end(self) -> Seconds:
-        # Precision up to 1ms to avoid float numeric artifacts
-        return round(self.start + self.duration, ndigits=3)
+        return round(self.start + self.duration, ndigits=8)
 
     def with_offset(self, offset: Seconds) -> 'SupervisionSegment':
         """Return an identical ``SupervisionSegment``, but with the ``offset`` added to the ``start`` field."""
-        return fastcopy(self, start=round(self.start + offset, ndigits=3))
+        return fastcopy(self, start=round(self.start + offset, ndigits=8))
 
     def trim(self, end: Seconds) -> 'SupervisionSegment':
         """

--- a/lhotse/test_utils.py
+++ b/lhotse/test_utils.py
@@ -19,7 +19,9 @@ def DummyManifest(type_: Type, *, begin_id: int, end_id: int) -> Manifest:
         return FeatureSet.from_features(dummy_features(idx) for idx in range(begin_id, end_id))
     if type_ == CutSet:
         # noinspection PyTypeChecker
-        return CutSet.from_cuts(dummy_cut(idx) for idx in range(begin_id, end_id))
+        return CutSet.from_cuts(
+            dummy_cut(idx, supervisions=[dummy_supervision(idx)]) for idx in range(begin_id, end_id)
+        )
 
 
 def dummy_recording(unique_id: int) -> Recording:
@@ -37,7 +39,8 @@ def dummy_supervision(unique_id: int, start: float = 0.0, duration: float = 1.0)
         id=f'dummy-segment-{unique_id:04d}',
         recording_id='dummy-recording',
         start=start,
-        duration=duration
+        duration=duration,
+        text='irrelevant'
     )
 
 
@@ -49,11 +52,11 @@ def dummy_features(unique_id: int) -> Features:
         duration=1.0,
         type='fbank',
         num_frames=100,
-        num_features=20,
+        num_features=23,
         sampling_rate=16000,
-        storage_type='irrelevant',
-        storage_path='irrelevant',
-        storage_key='irrelevant'
+        storage_type='lilcom_files',
+        storage_path='test/fixtures/dummy_feats/storage',
+        storage_key='dbf9a0ec-f79d-4eb8-ae83-143a6d5de64d.llc'
     )
 
 

--- a/lhotse/utils.py
+++ b/lhotse/utils.py
@@ -251,13 +251,16 @@ def compute_num_frames(duration: Seconds, frame_shift: Seconds) -> int:
       1616
     >>> Decimal(num_frames).quantize(0, rounding=ROUND_HALF_UP)
       1616
-    >>> round(num_frames, ndigits=1)
+    >>> round(num_frames, ndigits=8)
       1616.5
-    >>> Decimal(round(num_frames, ndigits=1)).quantize(0, rounding=ROUND_HALF_UP)
+    >>> Decimal(round(num_frames, ndigits=8)).quantize(0, rounding=ROUND_HALF_UP)
       1617
     """
     return int(
         Decimal(
-            round(duration / frame_shift, ndigits=1)
+            # 8 is a good number because cases like 14.49175 still work correctly,
+            # while problematic cases like 14.49999999998 are typically breaking much later than 8th decimal
+            # with double-precision floats.
+            round(duration / frame_shift, ndigits=8)
         ).quantize(0, rounding=ROUND_HALF_UP)
     )

--- a/lhotse/utils.py
+++ b/lhotse/utils.py
@@ -5,6 +5,7 @@ import random
 import uuid
 from contextlib import contextmanager
 from dataclasses import asdict, dataclass
+from decimal import Decimal, ROUND_HALF_UP
 from math import ceil, isclose
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Sequence, TypeVar, Union
@@ -233,3 +234,30 @@ def split_sequence(seq: Sequence[Any], num_splits: int, randomize: bool = False)
     chunk_size = int(ceil(num_items / num_splits))
     split_indices = [(i * chunk_size, min(num_items, (i + 1) * chunk_size)) for i in range(num_splits)]
     return [seq[begin: end] for begin, end in split_indices]
+
+
+def compute_num_frames(duration: Seconds, frame_shift: Seconds) -> int:
+    """
+    Compute the number of frames from duration and frame_shift in a safe way.
+
+    The need for this function is best illustrated with an example edge case:
+
+    >>> duration = 16.165
+    >>> frame_shift = 0.01
+    >>> num_frames = duration / frame_shift  # we expect it to finally be 1617
+    >>> num_frames
+      1616.4999999999998
+    >>> round(num_frames)
+      1616
+    >>> Decimal(num_frames).quantize(0, rounding=ROUND_HALF_UP)
+      1616
+    >>> round(num_frames, ndigits=1)
+      1616.5
+    >>> Decimal(round(num_frames, ndigits=1)).quantize(0, rounding=ROUND_HALF_UP)
+      1617
+    """
+    return int(
+        Decimal(
+            round(duration / frame_shift, ndigits=1)
+        ).quantize(0, rounding=ROUND_HALF_UP)
+    )

--- a/test/cut/test_cut_set.py
+++ b/test/cut/test_cut_set.py
@@ -2,9 +2,9 @@ from tempfile import NamedTemporaryFile
 
 import pytest
 
-from lhotse import SupervisionSegment, Features, Recording
+from lhotse import Features, Recording, SupervisionSegment
 from lhotse.audio import AudioSource
-from lhotse.cut import Cut, CutSet, MixedCut, MixTrack
+from lhotse.cut import Cut, CutSet, MixTrack, MixedCut
 from lhotse.test_utils import remove_spaces_from_segment_text
 
 
@@ -15,6 +15,18 @@ def cut_set_with_mixed_cut(cut1, cut2):
         MixTrack(cut=cut2, offset=1.0, snr=10)
     ])
     return CutSet({cut.id: cut for cut in [cut1, cut2, mixed_cut]})
+
+
+@pytest.mark.parametrize(
+    ['ascending', 'expected'],
+    [
+        (False, [11.0, 10.0, 10.0]),
+        (True, [10.0, 10.0, 11.0]),
+    ]
+)
+def test_cut_set_sort_by_duration(cut_set_with_mixed_cut, ascending, expected):
+    cs = cut_set_with_mixed_cut.sort_by_duration(ascending=ascending)
+    assert [c.duration for c in cs] == expected
 
 
 def test_cut_set_iteration(cut_set_with_mixed_cut):

--- a/test/cut/test_masks.py
+++ b/test/cut/test_masks.py
@@ -13,7 +13,8 @@ class TestMasksWithoutSupervisions:
         assert mask.sum() == 0
 
     def test_cut_features_mask(self):
-        cut = Cut('cut', start=0, duration=2, channel=0, features=Mock(sampling_rate=16000, frame_shift=0.01))
+        cut = Cut('cut', start=0, duration=2, channel=0,
+                  features=Mock(sampling_rate=16000, frame_shift=0.01, num_frames=2000))
         mask = cut.supervisions_feature_mask()
         assert mask.sum() == 0
 
@@ -54,7 +55,8 @@ class TestMasksWithSupervisions:
         assert (mask[8000:] == 0).all()
 
     def test_cut_features_mask(self, supervisions):
-        cut = Cut('cut', start=0, duration=2, channel=0, features=Mock(sampling_rate=16000, frame_shift=0.01),
+        cut = Cut('cut', start=0, duration=2, channel=0,
+                  features=Mock(sampling_rate=16000, frame_shift=0.01, num_frames=2000),
                   supervisions=supervisions)
         mask = cut.supervisions_feature_mask()
         assert (mask[:50] == 1).all()

--- a/test/dataset/test_speech_recognition_dataset.py
+++ b/test/dataset/test_speech_recognition_dataset.py
@@ -5,8 +5,8 @@ from torch.utils.data import DataLoader
 from lhotse.cut import CutSet
 from lhotse.dataset import SpeechRecognitionDataset
 from lhotse.dataset.speech_recognition import K2DataLoader, K2SpeechRecognitionDataset, \
-    K2SpeechRecognitionIterableDataset
-from lhotse.test_utils import DummyManifest
+    K2SpeechRecognitionIterableDataset, concat_cuts
+from lhotse.test_utils import DummyManifest, dummy_cut
 
 
 @pytest.fixture
@@ -134,3 +134,21 @@ def test_k2_speech_recognition_iterable_dataset_shuffling():
     assert len(set(dloader_cut_ids)) == len(dloader_cut_ids)
     # Invariant 3: the items are shuffled, i.e. the order is different than that in the CutSet
     assert dloader_cut_ids != [c.id for c in cut_set]
+
+
+def test_concat_cuts():
+    cuts = [
+        dummy_cut(duration=30.0),
+        dummy_cut(duration=20.0),
+        dummy_cut(duration=10.0),
+        dummy_cut(duration=5.0),
+        dummy_cut(duration=4.0),
+        dummy_cut(duration=3.0),
+        dummy_cut(duration=2.0),
+    ]
+    concat = concat_cuts(cuts, gap=1.0)
+    assert [c.duration for c in concat] == [
+        30.0,
+        20.0 + 1.0 + 2.0 + 1.0 + 3.0,  # == 27.0
+        10.0 + 1.0 + 4.0 + 1.0 + 5.0,  # == 21.0
+    ]

--- a/test/known_issues/test_cut_consistency.py
+++ b/test/known_issues/test_cut_consistency.py
@@ -1,47 +1,9 @@
-from contextlib import contextmanager
-from tempfile import NamedTemporaryFile, TemporaryDirectory
+from tempfile import TemporaryDirectory
 
-import numpy as np
 import pytest
-import soundfile
 
-from lhotse import AudioSource, Cut, Fbank, LilcomFilesWriter, Recording
-
-
-@contextmanager
-def make_recording(sampling_rate: int, num_samples: int) -> Recording:
-    # The idea is that we're going to write to a temporary file with a sine wave recording
-    # of specified duration and sampling rate, and clean up only after the test is executed.
-    with NamedTemporaryFile('wb', suffix='.wav') as f:
-        duration = num_samples / sampling_rate
-        samples: np.ndarray = np.sin(2 * np.pi * np.arange(0, num_samples) / sampling_rate)
-        soundfile.write(f, samples, samplerate=sampling_rate)
-        yield Recording(
-            id=f'recording-{sampling_rate}-{duration}',
-            sources=[
-                AudioSource(
-                    type='file',
-                    channels=[0],
-                    source=f.name
-                )
-            ],
-            sampling_rate=sampling_rate,
-            num_samples=num_samples,
-            duration=duration
-        )
-
-
-@contextmanager
-def make_cut(sampling_rate: int, num_samples: int) -> Cut:
-    with make_recording(sampling_rate, num_samples) as recording:
-        duration = num_samples / sampling_rate
-        yield Cut(
-            id=f'cut-{sampling_rate}-{duration}',
-            start=0,
-            duration=duration,
-            channel=0,
-            recording=recording
-        )
+from lhotse import Fbank, LilcomFilesWriter
+from test.known_issues.utils import make_cut
 
 
 @pytest.mark.parametrize(

--- a/test/known_issues/test_mixed_cut_num_frames.py
+++ b/test/known_issues/test_mixed_cut_num_frames.py
@@ -22,7 +22,33 @@ def test_mixed_cut_num_frames_example_1():
         assert mixed.duration == 31.445  # Padded correctly
         assert mixed.num_frames == 3145  # Round last 5 up
         assert sum(t.cut.num_frames for t in mixed.tracks) == 3145  # Since the tracks do not overlap in this example,
-        # the sum of individual cut num_frames should be
-        # equal to the total num_frames
+        # The sum of individual cut num_frames should be equal to the total num_frames
         features = mixed.load_features()
         assert features.shape[0] == 3145  # Loaded features num frames matches the meta-data
+
+
+def test_mixed_cut_num_frames_example_2():
+    fbank = Fbank()
+    with make_cut(sampling_rate=16000, num_samples=252879) as cut1, \
+            make_cut(sampling_rate=16000, num_samples=185280) as cut2, \
+            make_cut(sampling_rate=16000, num_samples=204161) as cut3, \
+            TemporaryDirectory() as d, \
+            LilcomFilesWriter(d) as storage:
+        # These are two cuts of similar duration, concatenated together with 1 second of silence
+        # in between, and padded to duration of 31.445.
+        mixed: MixedCut = (
+            cut1.compute_and_store_features(fbank, storage)
+                .pad(duration=cut1.duration + 1.0)
+                .append(cut2.compute_and_store_features(fbank, storage))
+        )
+        mixed = (
+            mixed.pad(duration=mixed.duration + 1.0)
+                .append(cut3.compute_and_store_features(fbank, storage))
+        )
+        assert mixed.duration == 42.145  # Padded correctly
+        assert mixed.num_frames == 4215  # Round last 5 up
+        # TODO(pzelasko): This assertion would not pass for now, as we're adding an extra frame during load_features.
+        # assert sum(t.cut.num_frames for t in mixed.tracks) == 4215  # Since the tracks do not overlap in this example,
+        # The sum of individual cut num_frames should be equal to the total num_frames
+        features = mixed.load_features()
+        assert features.shape[0] == 4215  # Loaded features num frames matches the meta-data

--- a/test/known_issues/test_mixed_cut_num_frames.py
+++ b/test/known_issues/test_mixed_cut_num_frames.py
@@ -1,0 +1,28 @@
+from tempfile import TemporaryDirectory
+
+from lhotse import Fbank, LilcomFilesWriter
+from lhotse.cut import MixedCut
+from test.known_issues.utils import make_cut
+
+
+def test_mixed_cut_num_frames_example_1():
+    fbank = Fbank()
+    with make_cut(sampling_rate=16000, num_samples=237920) as cut1, \
+            make_cut(sampling_rate=16000, num_samples=219600) as cut2, \
+            TemporaryDirectory() as d, \
+            LilcomFilesWriter(d) as storage:
+        # These are two cuts of similar duration, concatenated together with 1 second of silence
+        # in between, and padded to duration of 31.445.
+        mixed: MixedCut = (
+            cut1.compute_and_store_features(fbank, storage)
+                .pad(duration=cut1.duration + 1.0)
+                .append(cut2.compute_and_store_features(fbank, storage))
+                .pad(duration=31.445)
+        )
+        assert mixed.duration == 31.445  # Padded correctly
+        assert mixed.num_frames == 3145  # Round last 5 up
+        assert sum(t.cut.num_frames for t in mixed.tracks) == 3145  # Since the tracks do not overlap in this example,
+        # the sum of individual cut num_frames should be
+        # equal to the total num_frames
+        features = mixed.load_features()
+        assert features.shape[0] == 3145  # Loaded features num frames matches the meta-data

--- a/test/known_issues/utils.py
+++ b/test/known_issues/utils.py
@@ -1,0 +1,43 @@
+from contextlib import contextmanager
+from tempfile import NamedTemporaryFile
+
+import numpy as np
+import soundfile
+
+from lhotse import AudioSource, Cut, Recording
+
+
+@contextmanager
+def make_recording(sampling_rate: int, num_samples: int) -> Recording:
+    # The idea is that we're going to write to a temporary file with a sine wave recording
+    # of specified duration and sampling rate, and clean up only after the test is executed.
+    with NamedTemporaryFile('wb', suffix='.wav') as f:
+        duration = num_samples / sampling_rate
+        samples: np.ndarray = np.sin(2 * np.pi * np.arange(0, num_samples) / sampling_rate)
+        soundfile.write(f, samples, samplerate=sampling_rate)
+        yield Recording(
+            id=f'recording-{sampling_rate}-{duration}',
+            sources=[
+                AudioSource(
+                    type='file',
+                    channels=[0],
+                    source=f.name
+                )
+            ],
+            sampling_rate=sampling_rate,
+            num_samples=num_samples,
+            duration=duration
+        )
+
+
+@contextmanager
+def make_cut(sampling_rate: int, num_samples: int) -> Cut:
+    with make_recording(sampling_rate, num_samples) as recording:
+        duration = num_samples / sampling_rate
+        yield Cut(
+            id=f'cut-{sampling_rate}-{duration}',
+            start=0,
+            duration=duration,
+            channel=0,
+            recording=recording
+        )

--- a/test/test_num_frames.py
+++ b/test/test_num_frames.py
@@ -1,0 +1,120 @@
+from contextlib import contextmanager
+from tempfile import NamedTemporaryFile, TemporaryDirectory
+
+import numpy as np
+import pytest
+import soundfile
+
+from lhotse import AudioSource, Cut, Fbank, LilcomFilesWriter, Recording
+
+
+@contextmanager
+def make_recording(sampling_rate: int, num_samples: int) -> Recording:
+    # The idea is that we're going to write to a temporary file with a sine wave recording
+    # of specified duration and sampling rate, and clean up only after the test is executed.
+    with NamedTemporaryFile('wb', suffix='.wav') as f:
+        duration = num_samples / sampling_rate
+        samples: np.ndarray = np.sin(2 * np.pi * np.arange(0, num_samples) / sampling_rate)
+        soundfile.write(f, samples, samplerate=sampling_rate)
+        yield Recording(
+            id=f'recording-{sampling_rate}-{duration}',
+            sources=[
+                AudioSource(
+                    type='file',
+                    channels=[0],
+                    source=f.name
+                )
+            ],
+            sampling_rate=sampling_rate,
+            num_samples=num_samples,
+            duration=duration
+        )
+
+
+@contextmanager
+def make_cut(sampling_rate: int, num_samples: int) -> Cut:
+    with make_recording(sampling_rate, num_samples) as recording:
+        duration = num_samples / sampling_rate
+        yield Cut(
+            id=f'cut-{sampling_rate}-{duration}',
+            start=0,
+            duration=duration,
+            channel=0,
+            recording=recording
+        )
+
+
+@pytest.mark.parametrize(
+    ['sampling_rate', 'num_samples'],
+    [
+        (16000, 15995),
+        (16000, 15996),
+        (16000, 15997),
+        (16000, 15998),
+        (16000, 15999),
+        (16000, 16000),
+        (16000, 16001),
+        (16000, 16002),
+        (16000, 16003),
+        (16000, 16004),
+        (16000, 16005),
+    ]
+)
+def test_simple_cut_num_frames_and_samples_are_consistent(sampling_rate, num_samples):
+    with make_cut(sampling_rate, num_samples) as cut, \
+            TemporaryDirectory() as dir, \
+            LilcomFilesWriter(dir) as storage:
+        cut = cut.compute_and_store_features(
+            extractor=Fbank(),
+            storage=storage
+        )
+        feats = cut.load_features()
+        samples = cut.load_audio()
+
+        assert cut.has_features
+        assert feats.shape[0] == cut.features.num_frames
+        assert feats.shape[0] == cut.num_frames
+        assert feats.shape[1] == cut.features.num_features
+        assert feats.shape[1] == cut.num_features
+
+        assert cut.has_recording
+        assert samples.shape[0] == 1
+        assert samples.shape[1] == cut.recording.num_samples
+        assert samples.shape[1] == cut.num_samples
+
+
+@pytest.mark.parametrize(
+    ['sampling_rate', 'num_samples', 'padded_duration'],
+    [
+        (16000, 15995, 1.5),
+        (16000, 15996, 1.5),
+        (16000, 15997, 1.5),
+        (16000, 15998, 1.5),
+        (16000, 15999, 1.5),
+        (16000, 16000, 1.5),
+        (16000, 16001, 1.5),
+        (16000, 16002, 1.5),
+        (16000, 16003, 1.5),
+        (16000, 16004, 1.5),
+        (16000, 16005, 1.5),
+    ]
+)
+def test_padded_cut_num_frames_and_samples_are_consistent(sampling_rate, num_samples, padded_duration):
+    with make_cut(sampling_rate, num_samples) as cut, \
+            TemporaryDirectory() as dir, \
+            LilcomFilesWriter(dir) as storage:
+        cut = cut.compute_and_store_features(
+            extractor=Fbank(),
+            storage=storage
+        )
+        cut = cut.pad(padded_duration)
+        feats = cut.load_features()
+        samples = cut.load_audio()
+
+        assert cut.has_features
+        assert feats.shape[0] == cut.num_frames
+        assert feats.shape[1] == cut.num_features
+
+        assert cut.has_recording
+        assert samples.shape[0] == 1
+        assert samples.shape[1] == cut.num_samples


### PR DESCRIPTION
This PR explores how to go forward with #113 and should resolve #115 

I managed to implement a first, working version of the iterable ASR dataset for K2. I also tested it with LibriSpeech train-clean-100 and discovered that I failed to guarantee that `num_frames` field in the manifests always returns correct values (this is mostly related to incosistent rounding behaviour for durations like 16.475). I put some workarounds in the code so that it can collate without issues (a dataloader on train-clean-100 works without issues). I will resolve them at some other time...
