### PR TITLE
Augmentation refactoring and torchaudio SoX effects support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ A short snippet to show how Lhotse can make audio data prepartion quick and easy
 
 ```python
 
-from lhotse import CutSet, Fbank
+from lhotse import CutSet, Fbank, LilcomFilesWriter
 from lhotse.dataset import VadDataset 
 from lhotse.recipes import prepare_switchboard
 
@@ -91,10 +91,11 @@ cuts = CutSet.from_manifests(
 # Then, we pad the cuts to 5 seconds to ensure all cuts are of equal length,
 # as the last window in each recording might have a shorter duration.
 # The padding will be performed once the features are loaded into memory.
-cuts = cuts.compute_and_store_features(
-    extractor=Fbank(),
-    output_dir='make_feats'
-).pad(duration=5.0)
+with LilcomFilesWriter('feats') as storage:
+    cuts = cuts.compute_and_store_features(
+        extractor=Fbank(),
+        storage=storage,
+    ).pad(duration=5.0)
 
 # Construct a Pytorch Dataset class for Voice Activity Detection task:
 dataset = VadDataset(cuts)

--- a/docs/augmentation.rst
+++ b/docs/augmentation.rst
@@ -2,7 +2,7 @@ Augmentation
 ============
 
 We support time-domain data augmentation via `WavAugment`_ and `torchaudio`_ libraries.
-The both leverage libsox to provide about 50 different audio effects like reverb, speed perturbation, pitch, etc.
+They both leverage libsox to provide about 50 different audio effects like reverb, speed perturbation, pitch, etc.
 
 Since ``WavAugment`` depends on libsox, it is an optional depedency for Lhotse, which can be installed using ``tools/install_wavaugment.sh`` (for convenience, the script will also compile libsox from source - note that the ``WavAugment`` authors warn their library is untested on Mac).
 
@@ -13,6 +13,9 @@ Using Lhotse's Python API, you can compose an arbitrary effect chain. On the oth
 
 Python usage
 ************
+
+.. warning::
+    When using WavAugment or torchaudio data augmentation together with a multiprocessing executor (i.e. ``ProcessPoolExecutor``), it is necessary to start it using the "spawn" context. Otherwise the process may hang (or terminate) on some systems due to libsox internals not handling forking well. Use: ``ProcessPoolExecutor(..., mp_context=multiprocessing.get_context("spawn"))``.
 
 Lhotse's ``FeatureExtractor`` and ``Cut`` offer convenience functions for feature extraction with data augmentation
 performed before that. These functions expose an optional parameter called ``augment_fn`` that has a signature like:

--- a/docs/augmentation.rst
+++ b/docs/augmentation.rst
@@ -1,12 +1,31 @@
 Augmentation
 ============
 
-We support time-domain data augmentation via `WavAugment`_ library. ``WavAugment`` combines libsox and its own implementations to provide a range of augmentations. Since ``WavAugment`` depends on libsox, it is an optional depedency for Lhotse, which can be installed using ``tools/install_wavaugment.sh`` (for convenience, on Mac OS X the script will also compile libsox from source - though note that the ``WavAugment`` authors warn their library is untested on Mac).
+We support time-domain data augmentation via `WavAugment`_ and `torchaudio`_ libraries.
+The both leverage libsox to provide about 50 different audio effects like reverb, speed perturbation, pitch, etc.
+
+Since ``WavAugment`` depends on libsox, it is an optional depedency for Lhotse, which can be installed using ``tools/install_wavaugment.sh`` (for convenience, the script will also compile libsox from source - note that the ``WavAugment`` authors warn their library is untested on Mac).
+
+Torchaudio also depends on libsox, but seems to provide it when installed via anaconda.
+This functionality is only available with PyTorch 1.7+ and torchaudio 0.7+.
 
 Using Lhotse's Python API, you can compose an arbitrary effect chain. On the other hand, for the CLI we provide a small number of predefined effect chains, such as ``pitch`` (pitch shifting), ``reverb`` (reverberation), and ``pitch_reverb_tdrop`` (pitch shift + reverberation + time dropout of a 50ms chunk).
 
 Python usage
 ************
+
+Lhotse's ``FeatureExtractor`` and ``Cut`` offer convenience functions for feature extraction with data augmentation
+performed before that. These functions expose an optional parameter called ``augment_fn`` that has a signature like:
+
+.. code-block::
+
+    def augment_fn(audio: Union[np.ndarray, torch.Tensor], sampling_rate: int) -> np.ndarray: ...
+
+For ``torchaudio`` we define a ``SoxEffectTransform`` class:
+
+.. autoclass:: lhotse.augmentation.SoxEffectTransform
+  :members:
+  :noindex:
 
 We define a ``WavAugmenter`` class that is a thin wrapper over ``WavAugment``. It can either be created with a predefined, or a user-supplied effect chain.
 
@@ -33,3 +52,4 @@ You can create a dataset with both clean and augmented features by combining dif
     lhotse yaml combine {clean,pitch,reverb}_feats/feature_manifest.yml.gz combined_feats.yml
 
 .. _WavAugment: https://github.com/facebookresearch/WavAugment
+.. _torchaudio: https://pytorch.org/audio/stable/index.html

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -65,7 +65,7 @@ A short snippet to show how Lhotse can make audio data prepartion quick and easy
 
 .. code-block::
 
-    from lhotse import CutSet, Fbank
+    from lhotse import CutSet, Fbank, LilcomFilesWriter
     from lhotse.dataset import VadDataset
     from lhotse.recipes import prepare_switchboard
 
@@ -88,10 +88,11 @@ A short snippet to show how Lhotse can make audio data prepartion quick and easy
     # Then, we pad the cuts to 5 seconds to ensure all cuts are of equal length,
     # as the last window in each recording might have a shorter duration.
     # The padding will be performed once the features are loaded into memory.
-    cuts = cuts.compute_and_store_features(
-        extractor=Fbank(),
-        output_dir='make_feats'
-    ).pad(duration=5.0)
+    with LilcomFilesWriter('feats') as storage:
+        cuts = cuts.compute_and_store_features(
+            extractor=Fbank(),
+            storage=storage,
+        ).pad(duration=5.0)
 
     # Construct a Pytorch Dataset class for Voice Activity Detection task:
     dataset = VadDataset(cuts)

--- a/lhotse/augmentation/__init__.py
+++ b/lhotse/augmentation/__init__.py
@@ -1,3 +1,3 @@
 from .common import AugmentFn
 from .torchaudio import *
-from .wavaugment import *
+from .wavaugment import WavAugmenter, is_wav_augment_available

--- a/lhotse/augmentation/__init__.py
+++ b/lhotse/augmentation/__init__.py
@@ -3,5 +3,5 @@ import torchaudio as _torchaudio
 from .common import AugmentFn
 from .wavaugment import *
 
-if _torchaudio.__version__ >= '0.7.0':
+if str(_torchaudio.__version__) >= '0.7.0':
     from .torchaudio import *

--- a/lhotse/augmentation/__init__.py
+++ b/lhotse/augmentation/__init__.py
@@ -1,13 +1,3 @@
-import torchaudio as _torchaudio
-from packaging.version import parse as _parse
-
 from .common import AugmentFn
+from .torchaudio import *
 from .wavaugment import *
-
-# Note: we cannot directly compare the Version objects return from _parse because
-# Anaconda torchaudio has a version string '0.7.0a0+ac17b64' that is interpreted as
-# lesser than 0.7.0.
-_ta_version = _parse(_torchaudio.__version__)
-_req_version = _parse('0.7')
-if _ta_version.major >= _req_version.major and _ta_version.minor >= _req_version.minor:
-    from .torchaudio import *

--- a/lhotse/augmentation/__init__.py
+++ b/lhotse/augmentation/__init__.py
@@ -1,7 +1,13 @@
 import torchaudio as _torchaudio
+from packaging.version import parse as _parse
 
 from .common import AugmentFn
 from .wavaugment import *
 
-if str(_torchaudio.__version__) >= '0.7.0':
+# Note: we cannot directly compare the Version objects return from _parse because
+# Anaconda torchaudio has a version string '0.7.0a0+ac17b64' that is interpreted as
+# lesser than 0.7.0.
+_ta_version = _parse(_torchaudio.__version__)
+_req_version = _parse('0.7')
+if _ta_version.major >= _req_version.major and _ta_version.minor >= _req_version.minor:
     from .torchaudio import *

--- a/lhotse/augmentation/__init__.py
+++ b/lhotse/augmentation/__init__.py
@@ -1,0 +1,7 @@
+import torchaudio as _torchaudio
+
+from .common import AugmentFn
+from .wavaugment import *
+
+if _torchaudio.__version__ >= '0.7.0':
+    from .torchaudio import *

--- a/lhotse/augmentation/common.py
+++ b/lhotse/augmentation/common.py
@@ -1,0 +1,6 @@
+from typing import Callable
+
+import numpy as np
+
+# def augment_fn(audio: np.ndarray, sampling_rate: int) -> np.ndarray
+AugmentFn = Callable[[np.ndarray, int], np.ndarray]

--- a/lhotse/augmentation/torchaudio.py
+++ b/lhotse/augmentation/torchaudio.py
@@ -1,4 +1,3 @@
-import random
 import warnings
 from dataclasses import dataclass
 from typing import List, Union
@@ -21,7 +20,7 @@ class RandomValue:
     end: Union[int, float]
 
     def sample(self):
-        return random.uniform(self.start, self.end)
+        return np.random.uniform(self.start, self.end)
 
 
 # Input to the SoxEffectTransform class - the values are either effect names,

--- a/lhotse/augmentation/torchaudio.py
+++ b/lhotse/augmentation/torchaudio.py
@@ -1,10 +1,15 @@
 import random
+import warnings
 from dataclasses import dataclass
 from typing import List, Union
 
 import numpy as np
 import torch
 import torchaudio
+
+if str(torchaudio.__version__) < '0.7.0':
+    warnings.warn('Torchaudio SoX effects chains are only introduced in version 0.7 - '
+                  'please upgrade your PyTorch to 1.7+ and torchaudio to 0.7+ to use them.')
 
 
 @dataclass
@@ -33,7 +38,7 @@ class SoxEffectTransform:
     Example:
         >>> audio = np.random.rand(16000)
         >>> augment_fn = SoxEffectTransform(effects=[
-        >>>    ['reverb', 50, 50, RandomValue(0, 100)],  #
+        >>>    ['reverb', 50, 50, RandomValue(0, 100)],
         >>>    ['speed', RandomValue(0.9, 1.1)],
         >>>    ['rate', 16000],
         >>> ])

--- a/lhotse/augmentation/torchaudio.py
+++ b/lhotse/augmentation/torchaudio.py
@@ -5,8 +5,11 @@ from typing import List, Union
 import numpy as np
 import torch
 import torchaudio
+from packaging.version import parse as _version
 
-if str(torchaudio.__version__) < '0.7.0':
+from lhotse.utils import during_docs_build
+
+if not during_docs_build() and _version(torchaudio.__version__) < _version('0.7'):
     warnings.warn('Torchaudio SoX effects chains are only introduced in version 0.7 - '
                   'please upgrade your PyTorch to 1.7+ and torchaudio to 0.7+ to use them.')
 

--- a/lhotse/augmentation/torchaudio.py
+++ b/lhotse/augmentation/torchaudio.py
@@ -1,0 +1,94 @@
+import random
+from dataclasses import dataclass
+from typing import List, Union
+
+import numpy as np
+import torch
+import torchaudio
+
+
+@dataclass
+class RandomValue:
+    """
+    Represents a uniform distribution in the range [start, end].
+    """
+    start: Union[int, float]
+    end: Union[int, float]
+
+    def sample(self):
+        return random.uniform(self.start, self.end)
+
+
+# Input to the SoxEffectTransform class - the values are either effect names,
+# numeric parameters, or uniform distribution over possible values.
+EffectsList = List[List[Union[str, int, float, RandomValue]]]
+
+
+class SoxEffectTransform:
+    """
+    Class-style wrapper for torchaudio SoX effect chains.
+    It should be initialized with a config-like list of items that define SoX effect to be applied.
+    It supports sampling randomized values for effect parameters through the ``RandomValue`` wrapper.
+
+    Example:
+        >>> audio = np.random.rand(16000)
+        >>> augment_fn = SoxEffectTransform(effects=[
+        >>>    ['reverb', 50, 50, RandomValue(0, 100)],  #
+        >>>    ['speed', RandomValue(0.9, 1.1)],
+        >>>    ['rate', 16000],
+        >>> ])
+        >>> augmented = augment_fn(audio, 16000)
+
+    See SoX manual or ``torchaudio.sox_effects.effect_names()`` for the list of possible effects.
+    The parameters and the meaning of the values are explained in SoX manual/help.
+    """
+
+    def __init__(self, effects: EffectsList):
+        super().__init__()
+        self.effects = effects
+
+    def __call__(self, tensor: Union[torch.Tensor, np.ndarray], sampling_rate: int):
+        if isinstance(tensor, np.ndarray):
+            tensor = torch.from_numpy(tensor)
+        effects = self.sample_effects()
+        augmented, new_sampling_rate = torchaudio.sox_effects.apply_effects_tensor(tensor, sampling_rate, effects)
+        assert sampling_rate == new_sampling_rate, \
+            f"Lhotse does not support changing the sampling rate during data augmentation. " \
+            f"The original SR was '{sampling_rate}', after augmentation it's '{new_sampling_rate}'."
+        return augmented
+
+    def sample_effects(self) -> List[List[str]]:
+        """
+        Resolve a list of effects, replacing random distributions with samples from them.
+        It converts every number to string to match the expectations of torchaudio.
+        """
+        return [
+            [
+                str(item.sample() if isinstance(item, RandomValue) else item)
+                for item in effect
+            ]
+            for effect in self.effects
+        ]
+
+
+def speed(sampling_rate: int) -> List[List[str]]:
+    return [
+        # Random speed perturbation factor between 0.9x and 1.1x the original speed
+        ['speed', RandomValue(0.9, 1.1)],
+        ['rate', sampling_rate],  # Resample back to the original sampling rate (speed changes it)
+    ]
+
+
+def reverb(sampling_rate: int) -> List[List[str]]:
+    return [
+        ['reverb', 50, 50, RandomValue(0, 100)],
+        ['remix', '-'],  # Merge all channels (reverb changes mono to stereo)
+    ]
+
+
+def pitch(sampling_rate: int) -> List[List[str]]:
+    return [
+        # The returned values are 1/100ths of a semitone, meaning the default is up to a minor third shift up or down.
+        ['pitch', '-q', RandomValue(-300, 300)],
+        ['rate', sampling_rate]  # Resample back to the original sampling rate (pitch changes it)
+    ]

--- a/lhotse/augmentation/wavaugment.py
+++ b/lhotse/augmentation/wavaugment.py
@@ -29,6 +29,10 @@ class WavAugmenter:
     """
 
     def __init__(self, effect_chain):
+        warnings.warn('WavAugment support is deprecated and it will eventually be removed from Lhotse. '
+                      'For similar functionality, please use torchaudio based augmentation in '
+                      '"lhotse.augmentation.torchaudio". It requires PyTorch 1.7+ and torchaudio 0.7+.',
+                      category=DeprecationWarning)
         # A local import so that ``augment`` can be optional.
         import augment
         self.chain: augment.EffectChain = effect_chain

--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -1,5 +1,6 @@
 import random
 import warnings
+from concurrent.futures import ProcessPoolExecutor
 from dataclasses import dataclass, field
 from functools import reduce
 from math import ceil, floor
@@ -1304,6 +1305,13 @@ class CutSet(JsonMixin, YamlMixin, Sequence[AnyCut]):
                 )
                 for cut in self
             )
+
+        if isinstance(executor, ProcessPoolExecutor) and executor._mp_context._name == 'fork':
+            warnings.warn('ProcessPoolExecutor using a "fork" multiprocessing detected. '
+                          'In some circumstances this can crash or hang the program, e.g. when using '
+                          ' data augmentation libsox wrappers like WavAugment or torchaudio. '
+                          'We suggest passing an extra argument to initialize the executor: '
+                          'ProcessPoolExecutor(..., mp_context=multiprocessing.get_context("spawn"))')
 
         futures = []
         for cut in self:

--- a/lhotse/dataset/unsupervised.py
+++ b/lhotse/dataset/unsupervised.py
@@ -3,7 +3,7 @@ from typing import Optional
 import torch
 from torch.utils.data import Dataset
 
-from lhotse.augmentation import WavAugmenter
+from lhotse.augmentation import AugmentFn
 from lhotse.cut import CutSet
 from lhotse.features import FeatureExtractor
 
@@ -63,17 +63,17 @@ class DynamicUnsupervisedDataset(UnsupervisedDataset):
             self,
             feature_extractor: FeatureExtractor,
             cuts: CutSet,
-            augmenter: Optional[WavAugmenter] = None,
+            augment_fn: Optional[AugmentFn] = None,
     ):
         super().__init__(cuts)
         self.feature_extractor = feature_extractor
-        self.augmenter = augmenter
+        self.augment_fn = augment_fn
 
     def __getitem__(self, item: int) -> torch.Tensor:
         cut = self.cuts[self.cut_ids[item]]
         features = cut.compute_features(
             extractor=self.feature_extractor,
-            augmenter=self.augmenter,
+            augment_fn=self.augment_fn,
         )
         return torch.from_numpy(features)
 

--- a/lhotse/features/base.py
+++ b/lhotse/features/base.py
@@ -10,7 +10,7 @@ import numpy as np
 import torch
 
 from lhotse.audio import Recording
-from lhotse.augmentation import WavAugmenter
+from lhotse.augmentation import AugmentFn, WavAugmenter
 from lhotse.features.io import FeaturesWriter, get_reader
 from lhotse.utils import (JsonMixin, Pathlike, Seconds, YamlMixin, fastcopy, load_yaml, save_to_yaml, split_sequence,
                           uuid4)
@@ -109,7 +109,7 @@ class FeatureExtractor(metaclass=ABCMeta):
             storage: FeaturesWriter,
             sampling_rate: int,
             offset: Seconds = 0,
-            augmenter: Optional[WavAugmenter] = None,
+            augment_fn: Optional[AugmentFn] = None,
     ):
         """
         Extract the features from an array of audio samples in a full pipeline:
@@ -129,11 +129,11 @@ class FeatureExtractor(metaclass=ABCMeta):
         :param storage: a ``FeaturesWriter`` object that will handle storing the feature matrices.
         :param offset: an offset in seconds for where to start reading the recording - when used for
             ``Cut`` feature extraction, must be equal to ``Cut.start``.
-        :param augmenter: an optional ``WavAugmenter`` instance to modify the waveform before feature extraction.
+        :param augment_fn: an optional ``WavAugmenter`` instance to modify the waveform before feature extraction.
         :return: a ``Features`` manifest item for the extracted feature matrix (it is not written to disk).
         """
-        if augmenter is not None:
-            samples = augmenter.apply(samples)
+        if augment_fn is not None:
+            samples = augment_fn(samples, sampling_rate)
         duration = round(samples.shape[1] / sampling_rate, ndigits=8)
         feats = self.extract(samples=samples, sampling_rate=sampling_rate)
         storage_key = store_feature_array(feats, storage=storage)
@@ -156,7 +156,7 @@ class FeatureExtractor(metaclass=ABCMeta):
             offset: Seconds = 0,
             duration: Optional[Seconds] = None,
             channels: Union[int, List[int]] = None,
-            augmenter: Optional[WavAugmenter] = None,
+            augment_fn: Optional[AugmentFn] = None,
     ):
         """
         Extract the features from a ``Recording`` in a full pipeline:
@@ -173,7 +173,7 @@ class FeatureExtractor(metaclass=ABCMeta):
         :param duration: an optional duration specifying how much audio to load from the recording.
         :param channels: an optional int or list of ints, specifying the channels;
             by default, all channels will be used.
-        :param augmenter: an optional ``WavAugmenter`` instance to modify the waveform before feature extraction.
+        :param augment_fn: an optional ``WavAugmenter`` instance to modify the waveform before feature extraction.
         :return: a ``Features`` manifest item for the extracted feature matrix.
         """
         samples = recording.load_audio(
@@ -181,8 +181,8 @@ class FeatureExtractor(metaclass=ABCMeta):
             duration_seconds=duration,
             channels=channels,
         )
-        if augmenter is not None:
-            samples = augmenter.apply(samples)
+        if augment_fn is not None:
+            samples = augment_fn(samples, recording.sampling_rate)
         feats = self.extract(samples=samples, sampling_rate=recording.sampling_rate)
         storage_key = store_feature_array(feats, storage=storage)
         return Features(
@@ -555,7 +555,7 @@ class FeatureSetBuilder:
                 recording=recording,
                 storage=self.storage,
                 channels=channel,
-                augmenter=self.augmenter,
+                augment_fn=self.augmenter,
             ))
         return results
 

--- a/lhotse/utils.py
+++ b/lhotse/utils.py
@@ -264,3 +264,8 @@ def compute_num_frames(duration: Seconds, frame_shift: Seconds) -> int:
             round(duration / frame_shift, ndigits=8)
         ).quantize(0, rounding=ROUND_HALF_UP)
     )
+
+
+def during_docs_build() -> bool:
+    import os
+    return bool(os.environ.get('READTHEDOCS'))

--- a/test/augmentation/test_torchaudio.py
+++ b/test/augmentation/test_torchaudio.py
@@ -29,7 +29,7 @@ def test_speed_does_not_change_num_samples(audio):
     # will yield either slower (more samples) or faster (less samples) signal.
     # The truncation/padding is performed inside of SoxEffectTransform so the user should not
     # see these changes.
-    for _ in range(100):
+    for _ in range(10):
         augmented_audio = augment_fn(audio, sampling_rate=SAMPLING_RATE)
         assert augmented_audio.shape == audio.shape
         assert augmented_audio != audio

--- a/test/augmentation/test_torchaudio.py
+++ b/test/augmentation/test_torchaudio.py
@@ -1,0 +1,21 @@
+import math
+
+import pytest
+import torch
+
+torchaudio = pytest.importorskip('torchaudio', minversion='0.6')
+
+from lhotse.augmentation import SoxEffectTransform, pitch, reverb, speed
+
+
+@pytest.fixture
+def audio():
+    return torch.sin(2 * math.pi * torch.linspace(0, 1, 16000)).unsqueeze(0).numpy()
+
+
+@pytest.mark.parametrize('effect', [reverb, pitch, speed])
+def test_example_augmentation(audio, effect):
+    augment_fn = SoxEffectTransform(effects=effect(16000))
+    augmented_audio = augment_fn(audio, sampling_rate=16000)
+    assert augmented_audio.shape == audio.shape
+    assert augmented_audio != audio

--- a/test/augmentation/test_wav_augmentation.py
+++ b/test/augmentation/test_wav_augmentation.py
@@ -13,9 +13,9 @@ def audio():
     return torch.sin(2 * math.pi * torch.linspace(0, 1, 16000)).unsqueeze(0).numpy()
 
 
-@pytest.mark.parametrize('name', ['reverb', 'pitch', 'pitch_reverb_tdrop'])
+@pytest.mark.parametrize('name', ['reverb', 'pitch', 'pitch_reverb_tdrop', 'speed'])
 def test_predefined_augmentation_setups(audio, name):
     augmenter = WavAugmenter.create_predefined(name=name, sampling_rate=16000)
-    augmented_audio = augmenter(audio)
+    augmented_audio = augmenter(audio, sampling_rate=16000)
     assert augmented_audio.shape == audio.shape
     assert (augmented_audio != audio).any()

--- a/test/cut/test_feature_extraction.py
+++ b/test/cut/test_feature_extraction.py
@@ -1,12 +1,14 @@
+import multiprocessing
 from concurrent.futures.process import ProcessPoolExecutor
 from concurrent.futures.thread import ThreadPoolExecutor
 from contextlib import nullcontext as no_executor
+from functools import partial
 from tempfile import TemporaryDirectory
 from unittest.mock import Mock
 
 import pytest
 
-from lhotse import Recording, Cut, Fbank, CutSet
+from lhotse import Cut, CutSet, Fbank, Recording
 from lhotse.audio import AudioSource
 from lhotse.cut import MixedCut
 from lhotse.features.io import LilcomFilesWriter
@@ -92,7 +94,7 @@ def is_dask_availabe():
     'executor', [
         None,
         ThreadPoolExecutor,
-        pytest.param(ProcessPoolExecutor, marks=pytest.mark.skip(reason='Hangs CI but otherwise seems to work...')),
+        partial(ProcessPoolExecutor, mp_context=multiprocessing.get_context("spawn")),
         pytest.param(distributed.Client, marks=pytest.mark.skipif(not is_dask_availabe(), reason='Requires Dask'))
     ]
 )

--- a/test/dataset/test_unsupervised_dataset.py
+++ b/test/dataset/test_unsupervised_dataset.py
@@ -55,7 +55,7 @@ def test_on_the_fly_feature_extraction_unsupervised_dataset_with_augmentation(li
     tested_dataset = DynamicUnsupervisedDataset(
         feature_extractor=Fbank(),
         cuts=libri_cut_set,
-        augmenter=WavAugmenter.create_predefined('reverb', sampling_rate=16000)
+        augment_fn=WavAugmenter.create_predefined('reverb', sampling_rate=16000)
     )
     # Just test that it runs
     tested_feats = tested_dataset[0]

--- a/test/known_issues/test_augment_with_executor.py
+++ b/test/known_issues/test_augment_with_executor.py
@@ -1,4 +1,6 @@
+import multiprocessing
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
+from functools import partial
 from tempfile import TemporaryDirectory
 
 import pytest
@@ -9,12 +11,20 @@ from test.known_issues.utils import make_cut
 torchaudio = pytest.importorskip('torchaudio', minversion='0.6')
 
 
-@pytest.mark.parametrize('exec_type', [ProcessPoolExecutor, ThreadPoolExecutor])
+@pytest.mark.parametrize(
+    'exec_type',
+    [
+        # Multithreading works
+        ThreadPoolExecutor,
+        # Multiprocessing works, but only when using the "spawn" context
+        partial(ProcessPoolExecutor, mp_context=multiprocessing.get_context("spawn")),
+    ]
+)
 def test_wav_augment_with_executor(exec_type):
     with make_cut(sampling_rate=16000, num_samples=16000) as cut, \
             TemporaryDirectory() as d, \
             LilcomFilesWriter(storage_path=d) as storage, \
-            exec_type(1) as ex:
+            exec_type(max_workers=4) as ex:
         cut_set = CutSet.from_cuts(
             cut.with_id(str(i)) for i in range(100)
         )

--- a/test/test_feature_set.py
+++ b/test/test_feature_set.py
@@ -8,17 +8,9 @@ import torchaudio
 from pytest import mark, raises
 
 from lhotse.audio import RecordingSet
-from lhotse.augmentation import is_wav_augment_available, WavAugmenter
-from lhotse.features import (
-    FeatureSet,
-    Features,
-    FeatureMixer,
-    FeatureSetBuilder,
-    create_default_feature_extractor,
-    Fbank,
-    Mfcc,
-    Spectrogram, FeatureExtractor
-)
+from lhotse.augmentation import WavAugmenter, is_wav_augment_available
+from lhotse.features import (Fbank, FeatureExtractor, FeatureMixer, FeatureSet, FeatureSetBuilder, Features, Mfcc,
+                             Spectrogram, create_default_feature_extractor)
 from lhotse.features.io import LilcomFilesWriter, LilcomHdf5Writer, NumpyFilesWriter, NumpyHdf5Writer
 from lhotse.test_utils import DummyManifest
 from lhotse.utils import Seconds, time_diff_to_num_frames
@@ -193,13 +185,13 @@ def test_feature_set_builder(storage):
 @pytest.mark.skipif(not is_wav_augment_available(), reason='WavAugment required')
 def test_feature_set_builder_with_augmentation():
     recordings: RecordingSet = RecordingSet.from_json('test/fixtures/audio.json')
-    augmenter = WavAugmenter.create_predefined('pitch_reverb_tdrop', sampling_rate=8000)
+    augment_fn = WavAugmenter.create_predefined('pitch_reverb_tdrop', sampling_rate=8000)
     extractor = Fbank()
     with TemporaryDirectory() as d, LilcomFilesWriter(d) as storage:
         builder = FeatureSetBuilder(
             feature_extractor=extractor,
             storage=storage,
-            augmenter=augmenter
+            augment_fn=augment_fn
         )
         feature_set = builder.process_and_store_recordings(recordings=recordings)
 

--- a/test/test_wav_augmentation.py
+++ b/test/test_wav_augmentation.py
@@ -16,6 +16,6 @@ def audio():
 @pytest.mark.parametrize('name', ['reverb', 'pitch', 'pitch_reverb_tdrop'])
 def test_predefined_augmentation_setups(audio, name):
     augmenter = WavAugmenter.create_predefined(name=name, sampling_rate=16000)
-    augmented_audio = augmenter.apply(audio)
+    augmented_audio = augmenter(audio)
     assert augmented_audio.shape == audio.shape
     assert (augmented_audio != audio).any()


### PR DESCRIPTION
TL;DR 

- Changing the data augmentation APIs in Lhotse to accept a callable with signature like: `def augment_fn(audio: Union[torch.tensor, np.ndarray], sampling_rate: int) -> np.ndarray`
- mirroring `WavAugment` capabilities with `torchaudio.sox_effects`