### PR TITLE
populate recording_id for Cut when using Cut.compute_and_store_featur…

### DIFF
--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -256,7 +256,7 @@ class Cut(CutUtilsMixin):
 
     @property
     def recording_id(self) -> str:
-        return self.features.recording_id if self.has_features else self.recording.id
+        return self.recording.id if self.has_recording else self.features.recording_id
 
     @property
     def end(self) -> Seconds:


### PR DESCRIPTION
…es()

Sometimes we might want to know the corresponding recoding of a specific cut for debugging or evaluation, e.g. reference transcripts are usually provided in the format of `<recording_id> <reference>`. 

Currently we use `Cut.compute_and_store_features()` to extract features but this API does not fetch `Cut.recording.id`, so `Cut.recording_id` will return `None`. On the other hand, `Cut.id` is not None but it is a random string, making it a bit difficult to find the corresponding recording of a cut.

This PR is trying to copy `Cut.recording.id` to `Cut.features.recording_id`  when calling `Cut.compute_and_store_features()`.

@pzelasko LMK what you think.