### PR TITLE
National Speech Corpus data prep, optimizations in Cut, limited export to Kaldi data dir

### DIFF
--- a/lhotse/bin/modes/kaldi.py
+++ b/lhotse/bin/modes/kaldi.py
@@ -2,18 +2,23 @@ from pathlib import Path
 
 import click
 
+from lhotse import load_manifest
 from lhotse.bin.modes.cli_base import cli
-from lhotse.kaldi import load_kaldi_data_dir
+from lhotse.kaldi import export_to_kaldi, load_kaldi_data_dir
 from lhotse.utils import Pathlike
 
-__all__ = ['convert_kaldi']
+
+@cli.group()
+def kaldi():
+    """Kaldi import/export related commands."""
+    pass
 
 
-@cli.command()
+@kaldi.command(name='import')
 @click.argument('data_dir', type=click.Path(exists=True, file_okay=False))
 @click.argument('sampling_rate', type=int)
 @click.argument('manifest_dir', type=click.Path())
-def convert_kaldi(data_dir: Pathlike, sampling_rate: int, manifest_dir: Pathlike):
+def import_(data_dir: Pathlike, sampling_rate: int, manifest_dir: Pathlike):
     """
     Convert a Kaldi data dir DATA_DIR into a directory MANIFEST_DIR of lhotse manifests. Ignores feats.scp.
     The SAMPLING_RATE has to be explicitly specified as it is not available to read from DATA_DIR.
@@ -24,3 +29,18 @@ def convert_kaldi(data_dir: Pathlike, sampling_rate: int, manifest_dir: Pathlike
     recording_set.to_json(manifest_dir / 'audio.json')
     if maybe_supervision_set is not None:
         maybe_supervision_set.to_json(manifest_dir / 'supervision.json')
+
+
+@kaldi.command()
+@click.argument('recordings', type=click.Path(exists=True, dir_okay=False))
+@click.argument('supervisions', type=click.Path(exists=True, dir_okay=False))
+@click.argument('output_dir', type=click.Path())
+def export(recordings: Pathlike, supervisions: Pathlike, output_dir: Pathlike):
+    """
+    Convert a pair of ``RecordingSet`` and ``SupervisionSet`` manifests into a Kaldi-style data directory.
+    """
+    export_to_kaldi(
+        recordings=load_manifest(recordings),
+        supervisions=load_manifest(supervisions),
+        output_dir=output_dir
+    )

--- a/lhotse/bin/modes/recipes/__init__.py
+++ b/lhotse/bin/modes/recipes/__init__.py
@@ -2,5 +2,6 @@ from .broadcast_news import *
 from .heroico import *
 from .librimix import *
 from .mini_librispeech import *
+from .nsc import *
 from .switchboard import *
 from .tedlium import *

--- a/lhotse/bin/modes/recipes/nsc.py
+++ b/lhotse/bin/modes/recipes/nsc.py
@@ -1,0 +1,21 @@
+import click
+
+from lhotse.bin.modes import prepare
+from lhotse.recipes.nsc import NSC_PARTS, prepare_nsc
+from lhotse.utils import Pathlike
+
+
+@prepare.command(context_settings=dict(show_default=True))
+@click.argument('corpus_dir', type=click.Path(exists=True, dir_okay=True))
+@click.argument('output_dir', type=click.Path())
+@click.option('-p', '--dataset-part', type=click.Choice(NSC_PARTS), default='PART3_SameCloseMic',
+              help='Which part of NSC should be prepared')
+def mini_librispeech(
+        corpus_dir: Pathlike,
+        output_dir: Pathlike,
+        dataset_part: str
+):
+    """
+    This is a data preparation recipe for the National Corpus of Speech in Singaporean English.
+    """
+    prepare_nsc(corpus_dir, dataset_part=dataset_part, output_dir=output_dir)

--- a/lhotse/bin/modes/recipes/nsc.py
+++ b/lhotse/bin/modes/recipes/nsc.py
@@ -10,7 +10,7 @@ from lhotse.utils import Pathlike
 @click.argument('output_dir', type=click.Path())
 @click.option('-p', '--dataset-part', type=click.Choice(NSC_PARTS), default='PART3_SameCloseMic',
               help='Which part of NSC should be prepared')
-def mini_librispeech(
+def nsc(
         corpus_dir: Pathlike,
         output_dir: Pathlike,
         dataset_part: str

--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -384,13 +384,13 @@ class Cut(CutUtilsMixin):
         # new_supervisions = (segment.with_offset(-offset) for segment in self.supervisions)
         from intervaltree import IntervalTree, Interval
         new_supervisions = IntervalTree(Interval(s.start, s.end, s) for s in self.supervisions)
-        new_time_span = TimeSpan(start=offset, end=new_duration)
+        new_time_span = TimeSpan(start=offset, end=offset + new_duration)
 
         if keep_excessive_supervisions:  # overlaps
-            supervisions = [interval.data for interval in
+            supervisions = [interval.data.with_offset(-offset) for interval in
                             new_supervisions.overlap(new_time_span.start, new_time_span.end)]
         else:
-            supervisions = [interval.data for interval in
+            supervisions = [interval.data.with_offset(-offset) for interval in
                             new_supervisions.envelop(new_time_span.start, new_time_span.end)]  # overspans
 
         return Cut(
@@ -401,7 +401,7 @@ class Cut(CutUtilsMixin):
             # supervisions=[
             #     segment for segment in new_supervisions if criterion(new_time_span, segment)
             # ],
-            supervisions=supervisions,
+            supervisions=sorted(supervisions, key=lambda s: s.start),
             features=self.features,
             recording=self.recording
         )

--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -18,7 +18,7 @@ from lhotse.features.io import FeaturesWriter
 from lhotse.supervision import SupervisionSegment, SupervisionSet
 from lhotse.utils import (Decibels, EPSILON, JsonMixin, Pathlike, Seconds, TimeSpan, YamlMixin, asdict_nonull,
                           compute_num_frames, fastcopy,
-                          overlaps, overspans, split_sequence, uuid4)
+                          overlaps, split_sequence, uuid4)
 
 # One of the design principles for Cuts is a maximally "lazy" implementation, e.g. when mixing Cuts,
 # we'd rather sum the feature matrices only after somebody actually calls "load_features". It helps to avoid
@@ -379,17 +379,29 @@ class Cut(CutUtilsMixin):
         # Round the duration to avoid the possible loss of a single audio sample due to floating point
         # additions and subtractions.
         new_duration = round(new_duration, ndigits=8)
-        new_time_span = TimeSpan(start=0, end=new_duration)
-        criterion = overlaps if keep_excessive_supervisions else overspans
-        new_supervisions = (segment.with_offset(-offset) for segment in self.supervisions)
+        # criterion = overlaps if keep_excessive_supervisions else overspans
+        # new_time_span = TimeSpan(start=0, end=new_duration)
+        # new_supervisions = (segment.with_offset(-offset) for segment in self.supervisions)
+        from intervaltree import IntervalTree, Interval
+        new_supervisions = IntervalTree(Interval(s.start, s.end, s) for s in self.supervisions)
+        new_time_span = TimeSpan(start=offset, end=new_duration)
+
+        if keep_excessive_supervisions:  # overlaps
+            supervisions = [interval.data for interval in
+                            new_supervisions.overlap(new_time_span.start, new_time_span.end)]
+        else:
+            supervisions = [interval.data for interval in
+                            new_supervisions.envelop(new_time_span.start, new_time_span.end)]  # overspans
+
         return Cut(
             id=self.id if preserve_id else str(uuid4()),
             start=new_start,
             duration=new_duration,
             channel=self.channel,
-            supervisions=[
-                segment for segment in new_supervisions if criterion(new_time_span, segment)
-            ],
+            # supervisions=[
+            #     segment for segment in new_supervisions if criterion(new_time_span, segment)
+            # ],
+            supervisions=supervisions,
             features=self.features,
             recording=self.recording
         )

--- a/lhotse/kaldi.py
+++ b/lhotse/kaldi.py
@@ -1,7 +1,8 @@
 from collections import defaultdict
 from pathlib import Path
-from typing import Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
+from lhotse import CutSet
 from lhotse.audio import AudioSource, Recording, RecordingSet
 from lhotse.supervision import SupervisionSegment, SupervisionSet
 from lhotse.utils import Pathlike
@@ -78,6 +79,77 @@ def load_kaldi_data_dir(path: Pathlike, sampling_rate: int) -> Tuple[RecordingSe
     return audio_set, supervision_set
 
 
+def export_to_kaldi(recordings: RecordingSet, supervisions: SupervisionSet, output_dir: Pathlike):
+    """
+    Export a pair of ``RecordingSet`` and ``SupervisionSet`` to a Kaldi data directory.
+    Currently, it only supports single-channel recordings that have a single ``AudioSource``.
+
+    The ``RecordingSet`` and ``SupervisionSet`` must be compatible, i.e. it must be possible to create a
+    ``CutSet`` out of them.
+
+    :param recordings: a ``RecordingSet`` manifest.
+    :param supervisions: a ``SupervisionSet`` manifest.
+    :param output_dir: path where the Kaldi-style data directory will be created.
+    """
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    assert all(len(r.sources) == 1 for r in recordings), "Kaldi export of Recordings with multiple audio sources " \
+                                                         "is currently not supported."
+    assert all(r.num_channels == 1 for r in recordings), "Kaldi export of multi-channel Recordings is currently " \
+                                                         "not supported."
+
+    # Create a simple CutSet that ties together the recording <-> supervision information.
+    cuts = CutSet.from_manifests(recordings=recordings, supervisions=supervisions)
+
+    # wav.scp
+    save_kaldi_text_mapping(
+        data={
+            recording.id: f'{source.source} |' if source.type == 'command' else source.source
+            for recording in recordings
+            for src_idx, source in enumerate(recording.sources)
+        },
+        path=output_dir / 'wav.scp'
+    )
+    # segments
+    save_kaldi_text_mapping(
+        data={cut.supervisions[0].id: f'{cut.recording_id} {cut.start} {cut.end}' for cut in cuts},
+        path=output_dir / 'segments'
+    )
+    # text
+    save_kaldi_text_mapping(
+        data={cut.supervisions[0].id: cut.supervisions[0].text for cut in cuts},
+        path=output_dir / 'text'
+    )
+    # utt2spk
+    save_kaldi_text_mapping(
+        data={cut.supervisions[0].id: cut.supervisions[0].speaker for cut in cuts},
+        path=output_dir / 'utt2spk'
+    )
+    # utt2dur
+    save_kaldi_text_mapping(
+        data={cut.supervisions[0].id: cut.duration for cut in cuts},
+        path=output_dir / 'utt2dur'
+    )
+    # reco2dur
+    save_kaldi_text_mapping(
+        data={recording.id: recording.duration for recording in recordings},
+        path=output_dir / 'reco2dur'
+    )
+    # utt2lang [optional]
+    if all(s.language is not None for s in supervisions):
+        save_kaldi_text_mapping(
+            data={cut.supervisions[0].id: cut.supervisions[0].language for cut in cuts},
+            path=output_dir / 'utt2lang'
+        )
+    # utt2gender [optional]
+    if all(s.gender is not None for s in supervisions):
+        save_kaldi_text_mapping(
+            data={cut.supervisions[0].id: cut.supervisions[0].gender for cut in cuts},
+            path=output_dir / 'utt2gender'
+        )
+
+
 def load_kaldi_text_mapping(path: Path, must_exist: bool = False) -> Dict[str, Optional[str]]:
     """Load Kaldi files such as utt2spk, spk2gender, text, etc. as a dict."""
     mapping = defaultdict(lambda: None)
@@ -87,3 +159,10 @@ def load_kaldi_text_mapping(path: Path, must_exist: bool = False) -> Dict[str, O
     elif must_exist:
         raise ValueError(f"No such file: {path}")
     return mapping
+
+
+def save_kaldi_text_mapping(data: Dict[str, Any], path: Path):
+    """Save flat dicts to Kaldi files such as utt2spk, spk2gender, text, etc."""
+    with path.open('w') as f:
+        for key, value in data.items():
+            print(key, value, file=f)

--- a/lhotse/kaldi.py
+++ b/lhotse/kaldi.py
@@ -100,7 +100,7 @@ def export_to_kaldi(recordings: RecordingSet, supervisions: SupervisionSet, outp
                                                          "not supported."
 
     # Create a simple CutSet that ties together the recording <-> supervision information.
-    cuts = CutSet.from_manifests(recordings=recordings, supervisions=supervisions)
+    cuts = CutSet.from_manifests(recordings=recordings, supervisions=supervisions).trim_to_supervisions()
 
     # wav.scp
     save_kaldi_text_mapping(

--- a/lhotse/recipes/nsc.py
+++ b/lhotse/recipes/nsc.py
@@ -74,7 +74,10 @@ def prepare_same_close_mic(part3_path):
     from textgrids import TextGrid
     recordings = []
     supervisions = []
-    for audio_path in tqdm((part3_path / 'AudioSameCloseMic').glob('*.wav')):
+    for audio_path in tqdm(
+            (part3_path / 'AudioSameCloseMic').glob('*.wav'),
+            desc='Creating manifests for SameCloseMic'
+    ):
         try:
             recording_id = audio_path.stem
             recording = Recording.from_wav(audio_path)
@@ -109,7 +112,10 @@ def prepare_separate_phone_mic(part3_path):
     from textgrids import TextGrid
     recordings = []
     supervisions = []
-    for audio_path in tqdm((part3_path / 'AudioSeparateIVR').rglob('**/*.wav')):
+    for audio_path in tqdm(
+            (part3_path / 'AudioSeparateIVR').rglob('**/*.wav'),
+            desc='Creating manifests for SeparateIVR'
+    ):
         try:
             recording_id = f'{audio_path.parent.name}_{audio_path.stem}'
             recording = Recording.from_wav(audio_path)

--- a/lhotse/recipes/nsc.py
+++ b/lhotse/recipes/nsc.py
@@ -84,17 +84,20 @@ def prepare_same_close_mic(part3_path):
 
             tg = TextGrid(part3_path / f'ScriptsSame/{recording_id}.TextGrid', coding='utf-16')
             segments = [
-                SupervisionSegment(
-                    id=f'{recording_id}-{idx}',
-                    recording_id=recording_id,
-                    start=segment.xmin,
-                    duration=round(segment.xmax - segment.xmin, ndigits=8),
-                    text=segment.text,
-                    language='Singaporean English',
-                    speaker=recording_id,
+                s for s in (
+                    SupervisionSegment(
+                        id=f'{recording_id}-{idx}',
+                        recording_id=recording_id,
+                        start=segment.xmin,
+                        duration=round(segment.xmax - segment.xmin, ndigits=8),
+                        text=segment.text,
+                        language='Singaporean English',
+                        speaker=recording_id,
+                    )
+                    for idx, segment in enumerate(tg[recording_id])
+                    if segment.text != '<S>'  # skip silences
                 )
-                for idx, segment in enumerate(tg[recording_id])
-                if segment.text != '<S>'  # skip silences
+                if s.duration > 0  # NSC has some bad segments
             ]
 
             recordings.append(recording)
@@ -122,17 +125,20 @@ def prepare_separate_phone_mic(part3_path):
 
             tg = TextGrid(part3_path / f'ScriptsSeparate/{recording_id}.TextGrid', coding='utf-16')
             segments = [
-                SupervisionSegment(
-                    id=f'{recording_id}-{idx}',
-                    recording_id=recording_id,
-                    start=segment.xmin,
-                    duration=round(segment.xmax - segment.xmin, ndigits=8),
-                    text=segment.text,
-                    language='Singaporean English',
-                    speaker=recording_id,
+                s for s in (
+                    SupervisionSegment(
+                        id=f'{recording_id}-{idx}',
+                        recording_id=recording_id,
+                        start=segment.xmin,
+                        duration=round(segment.xmax - segment.xmin, ndigits=8),
+                        text=segment.text,
+                        language='Singaporean English',
+                        speaker=recording_id,
+                    )
+                    for idx, segment in enumerate(tg[recording_id])
+                    if segment.text != '<S>'  # skip silences
                 )
-                for idx, segment in enumerate(tg[recording_id])
-                if segment.text != '<S>'  # skip silences
+                if s.duration > 0  # NSC has some bad segments
             ]
 
             supervisions.extend(segments)

--- a/lhotse/recipes/nsc.py
+++ b/lhotse/recipes/nsc.py
@@ -78,7 +78,6 @@ def prepare_same_close_mic(part3_path):
         try:
             recording_id = audio_path.stem
             recording = Recording.from_wav(audio_path)
-            recordings.append(recording)
 
             tg = TextGrid(part3_path / f'ScriptsSame/{recording_id}.TextGrid', coding='utf-16')
             segments = [

--- a/lhotse/recipes/nsc.py
+++ b/lhotse/recipes/nsc.py
@@ -95,7 +95,7 @@ def prepare_same_close_mic(part3_path):
                         speaker=recording_id,
                     )
                     for idx, segment in enumerate(tg[recording_id])
-                    if segment.text != '<S>'  # skip silences
+                    if segment.text not in ('<S>', '<Z>')  # skip silences
                 )
                 if s.duration > 0  # NSC has some bad segments
             ]
@@ -136,7 +136,7 @@ def prepare_separate_phone_mic(part3_path):
                         speaker=recording_id,
                     )
                     for idx, segment in enumerate(tg[recording_id])
-                    if segment.text != '<S>'  # skip silences
+                    if segment.text not in ('<S>', '<Z>')  # skip silences
                 )
                 if s.duration > 0  # NSC has some bad segments
             ]

--- a/lhotse/recipes/nsc.py
+++ b/lhotse/recipes/nsc.py
@@ -1,0 +1,140 @@
+"""
+This is a data preparation recipe for the National Corpus of Speech in Singaporean English.
+
+The entire corpus is organised into a few parts.
+
+Part 1 features about 1000 hours of prompted recordings of phonetically-balanced scripts from about 1000 local English speakers.
+
+Part 2 presents about 1000 hours of prompted recordings of sentences randomly generated from words based on people, food, location, brands, etc, from about 1000 local English speakers as well. Transcriptions of the recordings have been done orthographically and are available for download.
+
+Part 3 consists of about 1000 hours of conversational data recorded from about 1000 local English speakers, split into pairs. The data includes conversations covering daily life and of speakers playing games provided.
+
+Parts 1 and 2 were recorded in quiet rooms using 3 microphones: a headset/ standing microphone (channel 0), a boundary microphone (channel 1), and a mobile phone (channel 3). Recordings that are available for download here have been down-sampled to 16kHz. Details of the microphone models used for each speaker as well as some corresponding non-personal and anonymized information can be found in the accompanying spreadsheets.
+
+Part 3's recordings were split into 2 environments. In the Same Room environment where speakers were in same room, the recordings were done using 2 microphones: a close-talk mic and a boundary mic. In the Separate Room environment, speakers were separated into individual rooms. The recordings were done using 2 microphones in each room: a standing mic and a telephone.
+
+We currently only support the part 3 recordings, in "same room close mic" and "separate rooms phone mic" environments.
+"""
+from pathlib import Path
+from typing import Dict, Optional, Union
+
+from tqdm.auto import tqdm
+
+from lhotse import Recording, RecordingSet, SupervisionSegment, SupervisionSet
+from lhotse.utils import Pathlike
+
+NSC_PARTS = ['PART3_SameCloseMic', 'PART3_SeparateIVR']
+
+
+def check_dependencies():
+    try:
+        import textgrids
+    except:
+        raise ImportError("NSC data preparation requires the forked 'textgrids' package to be installed. "
+                          "Please install it with 'pip install git+https://github.com/pzelasko/Praat-textgrids' "
+                          "and try again.")
+
+
+def prepare_nsc(
+        corpus_dir: Pathlike,
+        dataset_part: str = 'PART3_SameCloseMic',
+        output_dir: Optional[Pathlike] = None
+) -> Dict[str, Union[RecordingSet, SupervisionSet]]:
+    """
+    Returns the manifests which consist of the Recordings and Supervisions.
+    When all the manifests are available in the ``output_dir``, it will simply read and return them.
+
+    :param corpus_dir: Pathlike, the path to the raw corpus distribution.
+    :param dataset_part: str, name of the dataset part to be prepared.
+    :param output_dir: Pathlike, the path where to write the manifests.
+    :return: a Dict whose key is the dataset part, and the value is Dicts with the keys 'audio' and 'supervisions'.
+    """
+    check_dependencies()
+    corpus_dir = Path(corpus_dir)
+    assert corpus_dir.is_dir(), f'No such directory: {corpus_dir}'
+
+    if dataset_part == 'PART3_SameCloseMic':
+        manifests = prepare_same_close_mic(corpus_dir / 'PART3')
+    elif dataset_part == 'PART3_SeparateIVR':
+        manifests = prepare_separate_phone_mic(corpus_dir / 'PART3')
+    else:
+        raise ValueError(f"Unknown dataset part: {dataset_part}")
+
+    if output_dir is not None:
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        manifests['supervisions'].to_json(output_dir / f'supervisions_{dataset_part}.json')
+        manifests['recordings'].to_json(output_dir / f'recordings_{dataset_part}.json')
+
+    return manifests
+
+
+def prepare_same_close_mic(part3_path):
+    check_dependencies()
+    from textgrids import TextGrid
+    recordings = []
+    supervisions = []
+    for audio_path in tqdm((part3_path / 'AudioSameCloseMic').glob('*.wav')):
+        try:
+            recording_id = audio_path.stem
+            recording = Recording.from_wav(audio_path)
+            recordings.append(recording)
+
+            tg = TextGrid(part3_path / f'ScriptsSame/{recording_id}.TextGrid', coding='utf-16')
+            segments = [
+                SupervisionSegment(
+                    id=f'{recording_id}-{idx}',
+                    recording_id=recording_id,
+                    start=segment.xmin,
+                    duration=round(segment.xmax - segment.xmin, ndigits=8),
+                    text=segment.text,
+                    language='Singaporean English',
+                    speaker=recording_id,
+                )
+                for idx, segment in enumerate(tg[recording_id])
+                if segment.text != '<S>'  # skip silences
+            ]
+
+            recordings.append(recording)
+            supervisions.extend(segments)
+        except:
+            print(f'Error when processing {audio_path} - skipping...')
+    return {
+        'recordings': RecordingSet.from_recordings(recordings),
+        'supervisions': SupervisionSet.from_segments(supervisions)
+    }
+
+
+def prepare_separate_phone_mic(part3_path):
+    check_dependencies()
+    from textgrids import TextGrid
+    recordings = []
+    supervisions = []
+    for audio_path in tqdm((part3_path / 'AudioSeparateIVR').rglob('**/*.wav')):
+        try:
+            recording_id = f'{audio_path.parent.name}_{audio_path.stem}'
+            recording = Recording.from_wav(audio_path)
+
+            tg = TextGrid(part3_path / f'ScriptsSeparate/{recording_id}.TextGrid', coding='utf-16')
+            segments = [
+                SupervisionSegment(
+                    id=f'{recording_id}-{idx}',
+                    recording_id=recording_id,
+                    start=segment.xmin,
+                    duration=round(segment.xmax - segment.xmin, ndigits=8),
+                    text=segment.text,
+                    language='Singaporean English',
+                    speaker=recording_id,
+                )
+                for idx, segment in enumerate(tg[recording_id])
+                if segment.text != '<S>'  # skip silences
+            ]
+
+            supervisions.extend(segments)
+            recordings.append(recording)
+        except:
+            print(f'Error when processing {audio_path} - skipping...')
+    return {
+        'recordings': RecordingSet.from_recordings(recordings),
+        'supervisions': SupervisionSet.from_segments(supervisions)
+    }

--- a/lhotse/supervision.py
+++ b/lhotse/supervision.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence
 from lhotse.utils import JsonMixin, Seconds, YamlMixin, asdict_nonull, fastcopy, split_sequence
 
 
-@dataclass
+@dataclass(frozen=True, unsafe_hash=True)
 class SupervisionSegment:
     id: str
     recording_id: str

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ beautifulsoup4
 click>=7.1.1
 cytoolz>=0.10.1
 h5py>=2.10.0
+intervaltree>= 3.1.0
 lilcom>=1.1.0
 numpy>=1.18.1
 packaging

--- a/test/test_supervision_set.py
+++ b/test/test_supervision_set.py
@@ -4,6 +4,7 @@ import pytest
 
 from lhotse.supervision import SupervisionSegment, SupervisionSet
 from lhotse.testing.dummies import DummyManifest, remove_spaces_from_segment_text
+from lhotse.utils import fastcopy
 
 
 @pytest.fixture
@@ -213,6 +214,11 @@ def test_supervision_trim(supervision, trim_end, expected_end):
 
 @pytest.mark.parametrize('start', [0, 5])
 def test_supervision_trim_does_not_affect_nonnegative_start(supervision, start):
-    supervision.start = start
+    supervision = fastcopy(supervision, start=start)
     trimmed = supervision.trim(50)
     assert trimmed.start == start
+
+
+def test_supervision_is_hashable(supervision):
+    # Check that we can create a dict with the supervision object as the key.
+    d = {supervision: supervision.duration}


### PR DESCRIPTION
I'm adding a data prep script for National Speech Corpus (thousands of hours of Singaporean English), I actually want to build a Kaldi system for it so I am adding a utility to export RecordingSet + SupervisionSet into a Kaldi data dir (it is limited but maybe a good starting point to extend for anybody who needs more). Since the recordings in this corpus have 2h, there is a lot of SupervisionSegments and it revealed a quadratic complexity in some CutSet operations - I am optimizing them by building an IntervalTree of supervisions that can be used for efficient queries about overlaps and over-spanning segments.