### PR TITLE
LibriSpeech recipe API lifting and major preparation speedup

### DIFF
--- a/lhotse/bin/modes/recipes/mini_librispeech.py
+++ b/lhotse/bin/modes/recipes/mini_librispeech.py
@@ -1,7 +1,7 @@
 import click
 
 from lhotse.bin.modes import obtain, prepare
-from lhotse.recipes.librispeech import download_and_untar, prepare_librispeech
+from lhotse.recipes.librispeech import download_librispeech, prepare_librispeech
 from lhotse.utils import Pathlike
 
 __all__ = ['mini_librispeech']
@@ -24,4 +24,4 @@ def mini_librispeech(
         target_dir: Pathlike
 ):
     """Mini Librispeech download."""
-    download_and_untar(target_dir)
+    download_librispeech(target_dir)

--- a/lhotse/recipes/__init__.py
+++ b/lhotse/recipes/__init__.py
@@ -3,7 +3,7 @@ from .babel import prepare_single_babel_language
 from .broadcast_news import prepare_broadcast_news
 from .heroico import prepare_heroico
 from .librimix import prepare_librimix
-from .librispeech import prepare_librispeech
+from .librispeech import download_librispeech, prepare_librispeech
 from .ljspeech import prepare_ljspeech
 from .mobvoihotwords import prepare_mobvoihotwords
 from .switchboard import prepare_switchboard

--- a/lhotse/recipes/librispeech.py
+++ b/lhotse/recipes/librispeech.py
@@ -96,8 +96,7 @@ def prepare_librispeech(
         recordings = []
         supervisions = []
         part_path = corpus_dir / part
-        transcript_files = list(part_path.rglob('*.txt'))
-        for trans_path in tqdm(transcript_files, desc='Utterances', leave=False):
+        for trans_path in tqdm(part_path.rglob('*.txt'), desc='Utterances', leave=False):
             # "trans_path" file contains lines like:
             #
             #   121-121726-0000 ALSO A POPULAR CONTRIVANCE

--- a/lhotse/recipes/librispeech.py
+++ b/lhotse/recipes/librispeech.py
@@ -134,7 +134,7 @@ def prepare_librispeech(
                 'supervisions': supervision_set
             }
 
-    return manifests
+    return dict(manifests)  # Convert to normal dict
 
 
 def parse_utterance(

--- a/lhotse/recipes/librispeech.py
+++ b/lhotse/recipes/librispeech.py
@@ -99,7 +99,7 @@ def prepare_librispeech(
             supervisions = []
             part_path = corpus_dir / part
             futures = []
-            for trans_path in tqdm(part_path.rglob('*.txt'), desc='Utterances', leave=False):
+            for trans_path in part_path.rglob('*.txt'):
                 # "trans_path" file contains lines like:
                 #
                 #   121-121726-0000 ALSO A POPULAR CONTRIVANCE
@@ -111,7 +111,7 @@ def prepare_librispeech(
                     for line in f:
                         futures.append(ex.submit(parse_utterance, part_path, line))
 
-            for future in futures:
+            for future in tqdm(futures, desc='Utterances', leave=False):
                 result = future.result()
                 if result is None:
                     continue

--- a/lhotse/recipes/librispeech.py
+++ b/lhotse/recipes/librispeech.py
@@ -133,7 +133,7 @@ def parse_utterance(
         dataset_split_path: Path,
         line: str,
 ) -> Optional[Tuple[Recording, SupervisionSegment]]:
-    recording_id, text = line.strip().split()
+    recording_id, text = line.strip().split(maxsplit=1)
     # Create the Recording first
     audio_path = dataset_split_path / Path(recording_id.replace('-', '/')).parent / f'{recording_id}.flac'
     if not audio_path.is_file():

--- a/lhotse/recipes/librispeech.py
+++ b/lhotse/recipes/librispeech.py
@@ -109,7 +109,7 @@ def prepare_librispeech(
                 # We will create a separate Recording and SupervisionSegment for those.
 
                 with open(trans_path) as f:
-                    results = ex.map(parse_utterance, repeat(trans_path), f)
+                    results = ex.map(parse_utterance, repeat(part_path), f)
                     for recording, segment in results:
                         recordings.append(recording)
                         supervisions.append(segment)

--- a/lhotse/recipes/librispeech.py
+++ b/lhotse/recipes/librispeech.py
@@ -19,9 +19,9 @@ LIBRISPEECH = ('dev-clean', 'dev-other', 'test-clean', 'test-other',
 MINI_LIBRISPEECH = ('dev-clean-2', 'train-clean-5')
 
 
-def download_and_untar(
+def download_librispeech(
         target_dir: Pathlike = '.',
-        dataset_parts: Optional[Tuple[str]] = MINI_LIBRISPEECH,
+        dataset_parts: Optional[Union[str, Sequence[str]]] = "mini_librispeech",
         force_download: Optional[bool] = False,
         base_url: Optional[str] = 'http://www.openslr.org/resources'
 ) -> None:
@@ -29,13 +29,19 @@ def download_and_untar(
     Downdload and untar the dataset, supporting both LibriSpeech and MiniLibrispeech
 
     :param target_dir: Pathlike, the path of the dir to storage the dataset.
-    :param dataset_parts: dataset part name, e.g. 'train-clean-100', 'train-clean-5', 'dev-clean'
+    :param dataset_parts: "librispeech", "mini_librispeech",
+        or a list of splits (e.g. "dev-clean") to download.
     :param force_download: Bool, if True, download the tars no matter if the tars exist.
     :param base_url: str, the url of the OpenSLR resources.
     """
-
     target_dir = Path(target_dir)
     target_dir.mkdir(parents=True, exist_ok=True)
+
+    if dataset_parts == "librispeech":
+        dataset_parts = LIBRISPEECH
+    elif dataset_parts == "mini_librispeech":
+        dataset_parts = MINI_LIBRISPEECH
+
     for part in tqdm(dataset_parts, desc='Downloading LibriSpeech parts'):
         if part in LIBRISPEECH:
             url = f'{base_url}/12'

--- a/lhotse/recipes/librispeech.py
+++ b/lhotse/recipes/librispeech.py
@@ -91,12 +91,13 @@ def prepare_librispeech(
             return maybe_manifests
 
     manifests = defaultdict(dict)
-    for part in dataset_parts:
+    for part in tqdm(dataset_parts, desc='Dataset parts'):
 
         recordings = []
         supervisions = []
         part_path = corpus_dir / part
-        for trans_path in part_path.rglob('*.txt'):
+        transcript_files = list(part_path.rglob('*.txt'))
+        for trans_path in tqdm(transcript_files, desc='Utterances', leave=False):
             # "trans_path" file contains lines like:
             #
             #   121-121726-0000 ALSO A POPULAR CONTRIVANCE

--- a/lhotse/recipes/librispeech.py
+++ b/lhotse/recipes/librispeech.py
@@ -102,7 +102,7 @@ def prepare_librispeech(
             supervisions = []
             part_path = corpus_dir / part
             futures = []
-            for trans_path in tqdm(part_path.rglob('*.txt'), desc='Preparing parallel processing', leave=False):
+            for trans_path in tqdm(part_path.rglob('*.txt'), desc='Distributing tasks', leave=False):
                 # "trans_path" file contains lines like:
                 #
                 #   121-121726-0000 ALSO A POPULAR CONTRIVANCE
@@ -114,7 +114,7 @@ def prepare_librispeech(
                     for line in f:
                         futures.append(ex.submit(parse_utterance, part_path, line))
 
-            for future in tqdm(futures, desc='Utterances', leave=False):
+            for future in tqdm(futures, desc='Processing', leave=False):
                 result = future.result()
                 if result is None:
                     continue


### PR DESCRIPTION
Changes:
- The API is more human-friendly (e.g. "auto" detection of dataset parts to prepare)
- `Recording.from_file` can auto-create `Recording` from common audio file formats
- significant speedup of LibriSpeech data prep with multi-threading (especially when I/O is the bottleneck)
- got rid of `torchaudio.info` (partially addresses #79, will propagate this change throughout other recipes later)