### PR TITLE
WIP: Proposal for "universal" PyTorch speech dataset

### DIFF
--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -1644,10 +1644,12 @@ class CutSet(JsonMixin, YamlMixin, Sequence[AnyCut]):
             and returns a single cut instance.
         :return: a new ``CutSet`` with modified cuts.
         """
+
         def verified(mapped: Any) -> AnyCut:
             assert isinstance(mapped, (Cut, MixedCut, PaddingCut)), \
                 "The callable passed to CutSet.map() must return a Cut class instance."
             return mapped
+
         return CutSet.from_cuts(verified(transform_fn(c)) for c in self)
 
     def modify_ids(self, transform_fn: Callable[[str], str]) -> 'CutSet':

--- a/lhotse/dataset/__init__.py
+++ b/lhotse/dataset/__init__.py
@@ -1,3 +1,5 @@
+from .core import SpeechDataset
+from . import fields
 from .diarization import DiarizationDataset
 from .source_separation import (
     DynamicallyMixedSourceSeparationDataset,

--- a/lhotse/dataset/core.py
+++ b/lhotse/dataset/core.py
@@ -1,0 +1,444 @@
+from collections import defaultdict
+
+import math
+
+import random
+
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Union
+
+import torch
+from typing_extensions import Protocol, runtime_checkable
+
+from lhotse import CutSet, SupervisionSegment, warnings
+from lhotse.cut import AnyCut, MixedCut
+from lhotse.utils import Seconds, compute_num_frames
+
+
+class SupervisionField(Protocol):
+    def __call__(self, supervision: SupervisionSegment, cut: AnyCut) -> Dict[str, Any]: ...
+
+
+@runtime_checkable
+class RequiresCustomCollation(Protocol):
+    def collate(self, items: Sequence) -> Any:
+        pass
+
+
+class Text:
+    def __call__(self, supervision: SupervisionSegment, cut: AnyCut) -> Dict[str, Any]:
+        return {'text': supervision.text}
+
+
+class Characters:
+    def __init__(self, cuts):
+        self.pad = '<PAD>'
+        self.id2sym = sorted({char for cut in cuts for s in cut.supervisions for char in s.text}) + [self.pad]
+        self.sym2id = {v: k for k, v in enumerate(self.id2sym)}
+
+    def __call__(self, supervision, cut):
+        return {'chars': [self.sym2id[c] for c in supervision.text]}
+
+    def collate(self, items: List[int]):
+        items = sorted(items, key=len, reverse=True)
+        for idx in range(1, len(items)):
+            items[idx].extend([self.sym2id[self.pad]] * (len(items[0]) - len(items[idx])))
+        return torch.tensor(items, dtype=torch.int32)
+
+
+class Speaker:
+    def __init__(self, cuts: CutSet):
+        self.id2spk = sorted(cuts.speakers)
+        self.spk2id = {v: k for k, v in enumerate(self.id2spk)}
+
+    def __call__(self, supervision: SupervisionSegment, cut: AnyCut) -> Dict[str, Any]:
+        return {'speaker': self.spk2id[supervision.speaker]}
+
+
+class VoiceActivity:
+    def __init__(self, use_features: bool = True, use_audio: bool = False):
+        if not use_audio and not use_features:
+            raise ValueError("VoiceActivity requested but both use_audio and use_features set to False.")
+        self.use_features = use_features
+        self.use_audio = use_audio
+
+    def __call__(self, supervision: SupervisionSegment, cut: AnyCut) -> Dict[str, Any]:
+        output = {}
+        if self.use_audio:
+            output['audio_is_voiced'] = cut.supervisions_audio_mask()
+        if self.use_features:
+            output['frame_is_voiced'] = cut.supervisions_feature_mask()
+        return output
+
+
+class CutCollater:
+    def collate(self, cuts: Sequence[AnyCut]) -> Sequence[AnyCut]:
+        return cuts
+
+
+class SpeechDataset(torch.utils.data.IterableDataset):
+    """
+    The PyTorch Dataset for the speech recognition task using K2 library.
+
+    This dataset internally batches and collates the Cuts and should be used with
+    PyTorch DataLoader with argument batch_size=None to work properly.
+    The batch size is determined automatically to satisfy the constraints of ``max_frames``
+    and ``max_cuts``.
+
+    This dataset will automatically partition itself when used with a multiprocessing DataLoader
+    (i.e. the same cut will not appear twice in the same epoch).
+
+    By default, we "pack" the batches to minimize the amount of padding - we achieve that by
+    concatenating the cuts' feature matrices with a small amount of silence (padding) in between.
+
+    Each item in this dataset is a dict of:
+
+    .. code-block::
+
+        {
+            'features': float tensor of shape (B, T, F)
+            'supervisions': [
+                {
+                    'cut_id': List[str] of len S
+                    'sequence_idx': Tensor[int] of shape (S,)
+                    'text': List[str] of len S
+                    'start_frame': Tensor[int] of shape (S,)
+                    'num_frames': Tensor[int] of shape (S,)
+                }
+            ]
+        }
+
+    Dimension symbols legend:
+    * ``B`` - batch size (number of Cuts)
+    * ``S`` - number of supervision segments (greater or equal to B, as each Cut may have multiple supervisions)
+    * ``T`` - number of frames of the longest Cut
+    * ``F`` - number of features
+
+    The 'sequence_idx' field is the index of the Cut used to create the example in the Dataset.
+    """
+
+    def __init__(
+            self,
+            cuts: CutSet,
+            fields: Optional[Sequence[SupervisionField]] = None,
+            use_features: bool = True,
+            use_audio: bool = False,
+            multi_channel: bool = False,
+            return_cuts: bool = False,
+            max_frames: int = 26000,
+            max_cuts: Optional[int] = None,
+            shuffle: bool = False,
+            concat_cuts: bool = True,
+            concat_cuts_gap: Seconds = 1.0,
+            concat_cuts_duration_factor: float = 1
+    ):
+        """
+        K2 ASR IterableDataset constructor.
+
+        :param cuts: the ``CutSet`` to sample data from.
+        :param max_frames: The maximum number of feature frames that we're going to put in a single batch.
+            The padding frames do not contribute to that limit, since we pack the batch by default to minimze
+            the amount of padding.
+        :param max_cuts: The maximum number of cuts sampled to form a mini-batch.
+            By default, this constraint is off.
+        :param shuffle: When ``True``, the cuts will be shuffled at the start of iteration.
+            Convenient when mini-batch loop is inside an outer epoch-level loop, e.g.:
+            `for epoch in range(10): for batch in dataset: ...` as every epoch will see a
+            different cuts order.
+        :param concat_cuts: When ``True``, we will concatenate the cuts to minimize the total amount of padding;
+            e.g. instead of creating a batch with 40 examples, we will merge some of the examples together
+            adding some silence between them to avoid a large number of padding frames that waste the computation.
+            Enabled by default.
+        :param concat_cuts_gap: The duration of silence in seconds that is inserted between the cuts;
+            it's goal is to let the model "know" that there are separate utterances in a single example.
+        :param concat_cuts_duration_factor: Determines the maximum duration of the concatenated cuts;
+            by default it's 1, setting the limit at the duration of the longest cut in the batch.
+        """
+        super().__init__()
+        # Initialize the fields
+        self.cuts = cuts
+        self.shuffle = shuffle
+        self.max_frames = max_frames
+        self.max_cuts = max_cuts
+        self.concat_cuts = concat_cuts
+        self.concat_cuts_gap = concat_cuts_gap
+        self.concat_cuts_duration_factor = concat_cuts_duration_factor
+        # Representations / Supervisions configuration
+        self.fields = fields
+        self.use_features = use_features
+        self.use_audio = use_audio
+        self.multi_channel = multi_channel
+        self.return_cuts = return_cuts
+        # Set-up the mutable state for new epoch initialization in __iter__
+        self.cut_ids = list(self.cuts.ids)
+        self.current_idx = None
+        # Set-up the pseudo-immutable state for multiprocessing DataLoader compatibility
+        self.partition_start = 0
+        self.partition_end = len(self.cut_ids)
+        self._validate()
+
+    def __iter__(self):
+        """
+        Prepare the dataset for iterating over a new epoch. Will shuffle the data if requested.
+
+        This method takes care of partitioning for multiprocess data loading, so that the
+        dataset won't return data duplicates within a single epoch (for more details, see:
+        https://pytorch.org/docs/stable/data.html at "Multi-process data loading").
+        """
+        # noinspection PyUnresolvedReferences
+        worker_info = torch.utils.data.get_worker_info()
+        if worker_info is None:
+            # No multiprocessing involved - iterate full the CutSet.
+            self.partition_start = 0
+            self.partition_end = len(self.cut_ids)
+        else:
+            # We are in a worker process - need to select a partition to process.
+            start, end = 0, len(self.cut_ids)
+            per_worker = int(math.ceil((end - start) / float(worker_info.num_workers)))
+            worker_id = worker_info.id
+            self.partition_start = start + worker_id * per_worker
+            self.partition_end = min(self.partition_start + per_worker, end)
+
+        # Re-set the mutable state.
+        # Iterating over this dataset is equivalent to starting a new epoch.
+        if self.shuffle:
+            # If we're in multiprocessing mode, we should shuffle only the within the partition
+            # given to this worker, otherwise we might use data samples that are not intended
+            # for this worker.
+            partition_cut_ids = self.cut_ids[self.partition_start: self.partition_end]
+            random.shuffle(partition_cut_ids)
+            self.cut_ids[self.partition_start: self.partition_end] = partition_cut_ids
+        self.current_idx = self.partition_start
+        return self
+
+    def __next__(self) -> Dict[str, Union[torch.Tensor, List[str]]]:
+        """
+        Return a new batch, with the batch size automatically determined using the contraints
+        of max_frames and max_cuts.
+        """
+        from torch.utils.data._utils.collate import default_collate
+
+        # Collect the cuts that will form a batch, satisfying the criteria of max_cuts and max_frames.
+        # The returned object is a CutSet that we can keep on modifying (e.g. padding, mixing, etc.)
+        cuts: CutSet = self._collect_batch()
+
+        # For now, we'll just pad it with low energy values to match the longest Cut's
+        # duration in the batch. We might want to do something more interesting here
+        # later on - padding/mixing with noises, etc.
+        # TODO: multiple ways to pad the cuts
+        cuts = cuts.sort_by_duration().pad()
+
+        output = {}
+
+        if self.use_features:
+            if self.multi_channel:
+                output['features'] = _collate_multi_channel_features(cuts)
+            else:  # single channel
+                # Get a tensor with batched feature matrices, shape (B, T, F)
+                output['features'] = _collate_features(cuts)
+
+        if self.use_audio:
+            if self.multi_channel:
+                output['audio'] = _collate_multi_channel_audio(cuts)
+            else:  # single channel
+                output['audio'] = _collate_audio(cuts)
+
+        if self.fields:
+            supervisions = []
+            custom_collated = defaultdict(list)
+            collaters: Dict[str, RequiresCustomCollation] = {}
+            for sequence_idx, cut in enumerate(cuts):
+                for supervision in cut.supervisions:
+                    info = {
+                        'cut_id': cut.id,
+                        'sequence_idx': sequence_idx
+                    }
+                    if self.return_cuts:
+                        custom_collated['cut'].append(cut)
+                        collaters['cut'] = CutCollater()
+                    if self.use_features:
+                        info['start_frame'] = compute_num_frames(supervision.start, cut.frame_shift),
+                        info['num_frames'] = _asserted_num_frames(
+                            output['features'].shape[2 if self.multi_channel else 1],
+                            supervision.start,
+                            supervision.duration,
+                            cut.frame_shift
+                        )
+                    if self.use_audio:
+                        info['start_sample'] = round(supervision.start * cut.sampling_rate)
+                        info['num_samples'] = round(supervision.duration * cut.sampling_rate)
+                    for supervision_type in self.fields:
+                        entry = supervision_type(supervision, cut)
+                        if isinstance(supervision_type, RequiresCustomCollation):
+                            for key, value in entry.items():
+                                custom_collated[key].append(value)
+                                if key not in collaters:
+                                    collaters[key] = supervision_type
+                        else:
+                            info.update(entry)
+                    supervisions.append(info)
+            output['supervisions'] = default_collate(supervisions)
+            output['supervisions'].update(
+                {key: collaters[key].collate(values) for key, values in custom_collated.items()}
+            )
+
+        return output
+
+    def _collect_batch(self) -> CutSet:
+        """
+        Return a sub-CutSet that represents a full batch.
+        This is quick, as it does not perform any I/O in the process.
+        """
+        # Keep iterating the underlying CutSet as long as we hit or exceed the constraints
+        # provided by user (the max number of frames or max number of cuts).
+        # Note: no actual data is loaded into memory yet because the manifests contain all the metadata
+        # required to do this operation.
+        num_frames = 0
+        cuts = []
+        while True:
+            # Check that we have not reached the end of the dataset.
+            if self.current_idx < self.partition_end:
+                # We didn't - grab the next cut
+                next_cut_id = self.cut_ids[self.current_idx]
+            else:
+                if cuts:
+                    # We did and we have a partial batch - return it.
+                    return CutSet.from_cuts(cuts)
+                else:
+                    # We did and there is nothing more to return - signal the iteration code to stop.
+                    raise StopIteration()
+            next_cut = self.cuts[next_cut_id]
+            next_num_frames = num_frames + next_cut.num_frames
+            next_num_cuts = len(cuts) + 1
+            # Did we exceed the max_frames and max_cuts constraints?
+            if next_num_frames <= self.max_frames and (self.max_cuts is None or next_num_cuts <= self.max_cuts):
+                # No - add the next cut to the batch, and keep trying.
+                num_frames = next_num_frames
+                cuts.append(next_cut)
+                self.current_idx += 1
+            else:
+                # Yes. Do we have at least one cut in the batch?
+                if cuts:
+                    # Yes. Return it.
+                    break
+                else:
+                    # No. We'll warn the user that the constrains might be too tight,
+                    # and return the cut anyway.
+                    warnings.warn("The first cut drawn in batch collection violates the max_frames or max_cuts "
+                                  "constraints - we'll return it anyway. Consider increasing max_frames/max_cuts.")
+                    cuts.append(next_cut)
+                    self.current_idx += 1
+        if self.concat_cuts:
+            cuts = concat_cuts(
+                cuts,
+                gap=self.concat_cuts_gap,
+                max_duration=self.concat_cuts_duration_factor * cuts[0].duration
+            )
+        return CutSet.from_cuts(cuts)
+
+    def _validate(self) -> None:
+        for cut in self.cuts:
+            for supervision in cut.supervisions:
+                assert cut.start <= supervision.start <= supervision.end <= cut.end, \
+                    f"Cutting in the middle of a supervision is currently not supported for the ASR task. " \
+                    f"Cut ID violating the pre-condition: '{cut.id}'"
+        assert self.max_frames > 0
+        assert self.max_cuts is None or self.max_cuts > 0
+
+
+def _collate_features(cuts: CutSet) -> torch.Tensor:
+    assert all(cut.has_features for cut in cuts)
+    first_cut = next(iter(cuts))
+    features = torch.empty(len(cuts), first_cut.num_frames, first_cut.num_features)
+    for idx, cut in enumerate(cuts):
+        features[idx] = torch.from_numpy(cut.load_features())
+    return features
+
+
+def _collate_audio(cuts: CutSet) -> torch.Tensor:
+    assert all(cut.has_recording for cut in cuts)
+    first_cut = next(iter(cuts))
+    audio = torch.empty(len(cuts), first_cut.num_samples)
+    for idx, cut in enumerate(cuts):
+        audio[idx] = torch.from_numpy(cut.load_audio()[0])
+    return audio
+
+
+def _collate_multi_channel_features(cuts: CutSet) -> torch.Tensor:
+    assert all(cut.has_features for cut in cuts)
+    assert all(isinstance(cut, MixedCut) for cut in cuts)
+    # Output tensor shape: (B, C, T, F) -> (batch_size, num_channels, num_frames, num_features)
+    first_cut = next(iter(cuts))
+    # TODO: make MixedCut more friendly to use with multi channel audio;
+    #  discount PaddingCuts in "tracks" when specifying the number of channels
+    features = torch.empty(len(cuts), len(first_cut.tracks), first_cut.num_frames, first_cut.num_features)
+    for idx, cut in enumerate(cuts):
+        features[idx] = torch.from_numpy(cut.load_features(mixed=False))
+    return features
+
+
+def _collate_multi_channel_audio(cuts: CutSet) -> torch.Tensor:
+    assert all(cut.has_recording for cut in cuts)
+    assert all(isinstance(cut, MixedCut) for cut in cuts)
+    first_cut = next(iter(cuts))
+    audio = torch.empty(len(cuts), len(first_cut.tracks), first_cut.num_samples)
+    for idx, cut in enumerate(cuts):
+        audio[idx] = torch.from_numpy(cut.load_audio())
+    return audio
+
+
+def _asserted_num_frames(total_num_frames: int, start: Seconds, duration: Seconds, frame_shift: Seconds) -> int:
+    """
+    This closure with compute the num_frames, correct off-by-one errors in edge cases,
+    and assert that the supervision does not exceed the feature matrix temporal dimension.
+    """
+    offset = compute_num_frames(start, frame_shift=frame_shift)
+    num_frames = compute_num_frames(duration, frame_shift=frame_shift)
+    diff = total_num_frames - (offset + num_frames)
+    # Note: we tolerate off-by-ones because some mixed cuts could have one frame more
+    # than their duration suggests (we will try to change this eventually).
+    if diff == -1:
+        num_frames -= 1
+    assert offset + num_frames <= total_num_frames, \
+        f"Unexpected num_frames ({offset + num_frames}) exceeding features time dimension for a supervision " \
+        f"({total_num_frames}) when constructing a batch; please report this in Lhotse's GitHub issues, " \
+        "ideally providing the Cut data that triggered this."
+    return num_frames
+
+
+def concat_cuts(
+        cuts: List[AnyCut],
+        gap: Seconds = 1.0,
+        max_duration: Optional[Seconds] = None
+) -> List[AnyCut]:
+    """
+    We're going to concatenate the cuts to minimize the amount of total padding frames used.
+    This is actually solving a knapsack problem.
+    In this initial implementation we're using a greedy approach:
+    going from the back (i.e. the shortest cuts) we'll try to concat them to the longest cut
+    that still has some "space" at the end.
+
+    :param cuts: a list of cuts to pack.
+    :param gap: the duration of silence inserted between concatenated cuts.
+    :param max_duration: the maximum duration for the concatenated cuts
+        (by default set to the duration of the first cut).
+    :return a list of packed cuts.
+    """
+    if len(cuts) <= 1:
+        return cuts
+    cuts = sorted(cuts, key=lambda c: c.duration, reverse=True)
+    max_duration = cuts[0].duration if max_duration is None else max_duration
+    current_idx = 1
+    while True:
+        can_fit = False
+        shortest = cuts[-1]
+        for idx in range(current_idx, len(cuts) - 1):
+            cut = cuts[current_idx]
+            can_fit = cut.duration + gap + shortest.duration <= max_duration
+            if can_fit:
+                cuts[current_idx] = cut.pad(cut.duration + gap).append(shortest)
+                cuts = cuts[:-1]
+                break
+            current_idx += 1
+        if not can_fit:
+            break
+    return cuts

--- a/lhotse/dataset/fields.py
+++ b/lhotse/dataset/fields.py
@@ -1,4 +1,11 @@
-from decimal import ROUND_FLOOR, ROUND_HALF_DOWN
+"""
+The *fields* defined in this file conform to "Protocols" defined at the top.
+"Protocols" are like concepts in C++20, and you can think of them as an attempt
+to specify an expected interface without forcing the user to inherit from a common base class.
+It should make creating custom fields simpler for the user
+(they can in fact be implemented even as a simple method).
+"""
+from decimal import ROUND_FLOOR
 
 import torch
 from torch.utils.data.dataloader import default_collate
@@ -10,40 +17,118 @@ from lhotse.cut import AnyCut, MixedCut
 from lhotse.utils import compute_num_frames, compute_num_samples
 
 
+# Protocol (interface) definitions
+
+
 class SignalField(Protocol):
+    """
+    Represents a piece of information contained in ``Recording`` or ``Features`` manifests.
+    It could yield e.g. audio samples or feature matrices.
+    It consumes a ``CutSet`` and collates all the Cut data internally.
+    """
+
     def __call__(self, cuts: CutSet) -> Dict[str, torch.Tensor]: ...
 
 
-class Audio:
-    def __call__(self, cuts: CutSet) -> Dict[str, torch.Tensor]:
-        return {'audio': _collate_audio(cuts)}
-
-
-class MultiChannelAudio:
-    def __call__(self, cuts: CutSet) -> Dict[str, torch.Tensor]:
-        return {'multi_channel_audio': _collate_multi_channel_audio(cuts)}
-
-
-class Feats:
-    def __call__(self, cuts: CutSet) -> Dict[str, torch.Tensor]:
-        return {'features': _collate_features(cuts)}
-
-
-class MultiChannelFeats:
-    def __call__(self, cuts: CutSet) -> Dict[str, torch.Tensor]:
-        return {'multi_channel_features': _collate_multi_channel_features(cuts)}
-
-
 class SupervisionField(Protocol):
+    """
+    Represents a piece of information contained in ``SupervisionSegment`` manifests.
+    It could yield e.g. transcription text or speaker ID.
+    It consumes individual supervision + cut pairs, and the data is collated later.
+    """
+
     def __call__(self, supervision: SupervisionSegment, cut: AnyCut) -> Dict[str, Any]: ...
 
 
 @runtime_checkable
 class RequiresCustomCollation(Protocol):
+    """
+    A field that defines ``collate()`` will be treated differently during collation -
+    instead of using the default collation method in PyTorch, we will use the user-provided one.
+    """
+
     def collate(self, items: Sequence, key: str) -> Any: ...
 
 
+# Signal field implementations
+
+
+class Audio:
+    """
+    Returns a single-channel audio field (if the cut is a MixedCut, it will perform the mix).
+
+    Output:
+
+    .. code-block:
+
+        output = {'audio': <tensor, shape (B, T)>}
+    """
+
+    def __call__(self, cuts: CutSet) -> Dict[str, torch.Tensor]:
+        return {'audio': _collate_audio(cuts)}
+
+
+class MultiChannelAudio:
+    """
+    Returns a multi-channel audio field (the cut has to be a MixedCut, but we won't mix its tracks).
+
+    Output:
+
+    .. code-block:
+
+        output = {'multi_channel_audio': <tensor, shape (B, C, T)>}
+    """
+
+    def __call__(self, cuts: CutSet) -> Dict[str, torch.Tensor]:
+        assert all(isinstance(cut, MixedCut) for cut in cuts)
+        return {'multi_channel_audio': _collate_multi_channel_audio(cuts)}
+
+
+class Feats:
+    """
+    Returns a single-channel feature matrix field (if the cut is a MixedCut, it will perform the mix).
+
+    Output:
+
+    .. code-block:
+
+        output = {'features': <tensor, shape (B, T, F)>}
+    """
+
+    def __call__(self, cuts: CutSet) -> Dict[str, torch.Tensor]:
+        return {'features': _collate_features(cuts)}
+
+
+class MultiChannelFeats:
+    """
+    Returns a multi-channel feature matrix field (the cut has to be a MixedCut, but we won't mix its tracks).
+
+    Output:
+
+    .. code-block:
+
+        output = {'multi_channel_features': <tensor, shape (B, C, T, F)>}
+    """
+
+    def __call__(self, cuts: CutSet) -> Dict[str, torch.Tensor]:
+        assert all(isinstance(cut, MixedCut) for cut in cuts)
+        return {'multi_channel_features': _collate_multi_channel_features(cuts)}
+
+
+# Supervision field implementations
+
+
 class FeatureSpan:
+    """
+    Returns a field describing start frames and number of frames for the supervision.
+
+    Output:
+
+    .. code-block:
+
+        output = {'start_frame': int, 'num_frames': int}
+    """
+
     def __call__(self, supervision: SupervisionSegment, cut: AnyCut) -> Dict[str, Any]:
         return {
             'start_frame': compute_num_frames(
@@ -62,6 +147,16 @@ class FeatureSpan:
 
 
 class AudioSpan:
+    """
+    Returns a field describing start samples and number of samples for the supervision.
+
+    Output:
+
+    .. code-block:
+
+        output = {'start_sample': int, 'num_samples': int}
+    """
+
     def __call__(self, supervision: SupervisionSegment, cut: AnyCut) -> Dict[str, Any]:
         return {
             'start_sample': compute_num_samples(
@@ -77,11 +172,33 @@ class AudioSpan:
 
 
 class Text:
+    """
+    Returns a field with the transcription text (as string).
+
+    Output:
+
+    .. code-block:
+
+        output = {'text': str}
+    """
+
     def __call__(self, supervision: SupervisionSegment, cut: AnyCut) -> Dict[str, Any]:
         return {'text': supervision.text}
 
 
 class Characters:
+    """
+    Returns a field with the transcription text as a sequence of (string) characters.
+    During collation, it will add `<PAD>` symbols at the end to match the longest
+    sequence in the batch.
+
+    Output:
+
+    .. code-block:
+
+        output = {'chars': List[str], 'chars_len': int}
+    """
+
     def __init__(self):
         self.pad = '<PAD>'
 
@@ -100,6 +217,18 @@ class Characters:
 
 
 class CharacterIds:
+    """
+    Returns a field with the transcription text as a sequence of (int) character ids.
+    During collation, it will add `<PAD>` symbol ids at the end to match the longest
+    sequence in the batch.
+
+    Output:
+
+    .. code-block:
+
+        output = {'char_ids': List[int], 'char_ids_len': int}
+    """
+
     def __init__(self, cuts):
         self.pad = '<PAD>'
         self.id2sym = sorted({char for cut in cuts for s in cut.supervisions for char in s.text}) + [self.pad]
@@ -121,6 +250,17 @@ class CharacterIds:
 
 
 class Speaker:
+    """
+    Returns a field with the speaker ID index.
+    The indices are obtained by inspecting all speaker in the CutSet provided to ``__init__``.
+
+    Output:
+
+    .. code-block:
+
+        output = {'speaker': int}
+    """
+
     def __init__(self, cuts: CutSet):
         self.id2spk = sorted(cuts.speakers)
         self.spk2id = {v: k for k, v in enumerate(self.id2spk)}
@@ -130,6 +270,18 @@ class Speaker:
 
 
 class VoiceActivity:
+    """
+    Returns a field with a voice activity vector.
+    It is a binary vector that has values corresponding to each frame/sample.
+
+    Output:
+
+    .. code-block:
+
+        output = {'audio_is_voiced': <array, shape (T)>}
+        output = {'frame_is_voiced': <array, shape (T)>}
+    """
+
     def __init__(self, use_features: bool = True, use_audio: bool = False):
         if not use_audio and not use_features:
             raise ValueError("VoiceActivity requested but both use_audio and use_features set to False.")

--- a/lhotse/dataset/fields.py
+++ b/lhotse/dataset/fields.py
@@ -1,0 +1,195 @@
+import torch
+from torch.utils.data.dataloader import default_collate
+from typing import Any, Dict, List, Sequence
+from typing_extensions import Protocol, runtime_checkable
+
+from lhotse import CutSet, SupervisionSegment
+from lhotse.cut import AnyCut, MixedCut
+from lhotse.utils import Seconds, compute_num_frames
+
+
+class SignalField(Protocol):
+    def __call__(self, cuts: CutSet) -> Dict[str, torch.Tensor]: ...
+
+
+class Audio:
+    def __call__(self, cuts: CutSet) -> Dict[str, torch.Tensor]:
+        return {'audio': _collate_audio(cuts)}
+
+
+class MultiChannelAudio:
+    def __call__(self, cuts: CutSet) -> Dict[str, torch.Tensor]:
+        return {'multi_channel_audio': _collate_multi_channel_audio(cuts)}
+
+
+class Feats:
+    def __call__(self, cuts: CutSet) -> Dict[str, torch.Tensor]:
+        return {'features': _collate_features(cuts)}
+
+
+class MultiChannelFeats:
+    def __call__(self, cuts: CutSet) -> Dict[str, torch.Tensor]:
+        return {'multi_channel_features': _collate_multi_channel_features(cuts)}
+
+
+class SupervisionField(Protocol):
+    def __call__(self, supervision: SupervisionSegment, cut: AnyCut) -> Dict[str, Any]: ...
+
+
+@runtime_checkable
+class RequiresCustomCollation(Protocol):
+    def collate(self, items: Sequence, key: str) -> Any: ...
+
+
+class FeatureSpan:
+    def __call__(self, supervision: SupervisionSegment, cut: AnyCut) -> Dict[str, Any]:
+        return {
+            'start_frame': compute_num_frames(supervision.start, cut.frame_shift),
+            'num_frames': compute_num_frames(supervision.duration, frame_shift=cut.frame_shift)
+            # TODO: try this:
+            # 'num_frames': compute_num_frames(supervision.end, cut.frame_shift) - compute_num_frames(supervision.start, cut.frame_shift)
+            # Original version
+            # 'num_frames': _asserted_num_frames(
+            #     output['features'].shape[2 if self.multi_channel else 1],
+            #     supervision.start,
+            #     supervision.duration,
+            #     cut.frame_shift
+            # )
+        }
+
+
+class AudioSpan:
+    def __call__(self, supervision: SupervisionSegment, cut: AnyCut) -> Dict[str, Any]:
+        return {
+            'start_sample': round(supervision.start * cut.sampling_rate),
+            'num_samples': round(supervision.duration * cut.sampling_rate)
+        }
+
+
+class Text:
+    def __call__(self, supervision: SupervisionSegment, cut: AnyCut) -> Dict[str, Any]:
+        return {'text': supervision.text}
+
+
+class Characters:
+    def __init__(self):
+        self.pad = '<PAD>'
+
+    def __call__(self, supervision: SupervisionSegment, cut: AnyCut) -> Dict[str, Any]:
+        return {'chars': list(supervision.text), 'chars_len': len(supervision.text)}
+
+    def collate(self, items: List[str], key: str):
+        assert key in ('chars', 'chars_len')
+        if key == 'chars':
+            items = sorted(items, key=len, reverse=True)
+            for idx in range(1, len(items)):
+                items[idx].extend([self.pad] * (len(items[0]) - len(items[idx])))
+        elif key == 'chars_len':
+            items = default_collate(items)
+        return items
+
+
+class CharacterIds:
+    def __init__(self, cuts):
+        self.pad = '<PAD>'
+        self.id2sym = sorted({char for cut in cuts for s in cut.supervisions for char in s.text}) + [self.pad]
+        self.sym2id = {v: k for k, v in enumerate(self.id2sym)}
+
+    def __call__(self, supervision: SupervisionSegment, cut: AnyCut) -> Dict[str, Any]:
+        return {'char_ids': [self.sym2id[c] for c in supervision.text], 'char_ids_len': len(supervision.text)}
+
+    def collate(self, items: List[int], key: str):
+        assert key in ('char_ids', 'char_ids_len')
+        if key == 'char_ids':
+            items = sorted(items, key=len, reverse=True)
+            for idx in range(1, len(items)):
+                items[idx].extend([self.sym2id[self.pad]] * (len(items[0]) - len(items[idx])))
+            items = torch.tensor(items, dtype=torch.int32)
+        elif key == 'chars_ids_len':
+            items = default_collate(items)
+        return items
+
+
+class Speaker:
+    def __init__(self, cuts: CutSet):
+        self.id2spk = sorted(cuts.speakers)
+        self.spk2id = {v: k for k, v in enumerate(self.id2spk)}
+
+    def __call__(self, supervision: SupervisionSegment, cut: AnyCut) -> Dict[str, Any]:
+        return {'speaker': self.spk2id[supervision.speaker]}
+
+
+class VoiceActivity:
+    def __init__(self, use_features: bool = True, use_audio: bool = False):
+        if not use_audio and not use_features:
+            raise ValueError("VoiceActivity requested but both use_audio and use_features set to False.")
+        self.use_features = use_features
+        self.use_audio = use_audio
+
+    def __call__(self, supervision: SupervisionSegment, cut: AnyCut) -> Dict[str, Any]:
+        output = {}
+        if self.use_audio:
+            output['audio_is_voiced'] = cut.supervisions_audio_mask()
+        if self.use_features:
+            output['frame_is_voiced'] = cut.supervisions_feature_mask()
+        return output
+
+
+def _collate_features(cuts: CutSet) -> torch.Tensor:
+    assert all(cut.has_features for cut in cuts)
+    first_cut = next(iter(cuts))
+    features = torch.empty(len(cuts), first_cut.num_frames, first_cut.num_features)
+    for idx, cut in enumerate(cuts):
+        features[idx] = torch.from_numpy(cut.load_features())
+    return features
+
+
+def _collate_audio(cuts: CutSet) -> torch.Tensor:
+    assert all(cut.has_recording for cut in cuts)
+    first_cut = next(iter(cuts))
+    audio = torch.empty(len(cuts), first_cut.num_samples)
+    for idx, cut in enumerate(cuts):
+        audio[idx] = torch.from_numpy(cut.load_audio()[0])
+    return audio
+
+
+def _collate_multi_channel_features(cuts: CutSet) -> torch.Tensor:
+    assert all(cut.has_features for cut in cuts)
+    assert all(isinstance(cut, MixedCut) for cut in cuts)
+    # Output tensor shape: (B, C, T, F) -> (batch_size, num_channels, num_frames, num_features)
+    first_cut = next(iter(cuts))
+    # TODO: make MixedCut more friendly to use with multi channel audio;
+    #  discount PaddingCuts in "tracks" when specifying the number of channels
+    features = torch.empty(len(cuts), len(first_cut.tracks), first_cut.num_frames, first_cut.num_features)
+    for idx, cut in enumerate(cuts):
+        features[idx] = torch.from_numpy(cut.load_features(mixed=False))
+    return features
+
+
+def _collate_multi_channel_audio(cuts: CutSet) -> torch.Tensor:
+    assert all(cut.has_recording for cut in cuts)
+    assert all(isinstance(cut, MixedCut) for cut in cuts)
+    first_cut = next(iter(cuts))
+    audio = torch.empty(len(cuts), len(first_cut.tracks), first_cut.num_samples)
+    for idx, cut in enumerate(cuts):
+        audio[idx] = torch.from_numpy(cut.load_audio())
+    return audio
+
+
+def _asserted_num_frames(total_num_frames: int, start: Seconds, duration: Seconds, frame_shift: Seconds) -> int:
+    """
+    This closure with compute the num_frames, correct off-by-one errors in edge cases,
+    and assert that the supervision does not exceed the feature matrix temporal dimension.
+    """
+    offset = compute_num_frames(start, frame_shift=frame_shift)
+    num_frames = compute_num_frames(duration, frame_shift=frame_shift)
+    diff = total_num_frames - (offset + num_frames)
+    # Note: we tolerate off-by-ones because some mixed cuts could have one frame more
+    # than their duration suggests (we will try to change this eventually).
+    if diff == -1:
+        num_frames -= 1
+    assert offset + num_frames <= total_num_frames, \
+        f"Unexpected num_frames ({offset + num_frames}) exceeding features time dimension for a supervision " \
+        f"({total_num_frames}) when constructing a batch; please report this in Lhotse's GitHub issues, " \
+        "ideally providing the Cut data that triggered this."
+    return num_frames

--- a/lhotse/dataset/speech_recognition.py
+++ b/lhotse/dataset/speech_recognition.py
@@ -43,9 +43,7 @@ class K2SpeechRecognitionIterableDataset(SpeechDataset):
     The 'sequence_idx' field is the index of the Cut used to create the example in the Dataset.
     """
 
-    def __init__(
-            self, *args, concat_cuts=True, **kwargs
-    ):
+    def __init__(self, *args, concat_cuts=True, **kwargs):
         """
         K2 ASR IterableDataset constructor.
 
@@ -77,3 +75,10 @@ class K2SpeechRecognitionIterableDataset(SpeechDataset):
             concat_cuts=concat_cuts,
             **kwargs
         )
+
+    def _validate_hook(self) -> None:
+        for cut in self.cuts:
+            for supervision in cut.supervisions:
+                assert (cut.start - 1e-5) <= supervision.start <= supervision.end <= (cut.end + 1e-5), \
+                    f"Cutting in the middle of a supervision is currently not supported for the ASR task. " \
+                    f"Cut ID violating the pre-condition: '{cut.id}'"

--- a/lhotse/dataset/speech_recognition.py
+++ b/lhotse/dataset/speech_recognition.py
@@ -1,19 +1,8 @@
-from decimal import ROUND_FLOOR
-
-import math
-import random
-import warnings
-from typing import Dict, List, Optional, Union
-
-import torch
-from torch.utils.data.dataloader import DataLoader, default_collate
-
-from lhotse.cut import AnyCut, CutSet
-from lhotse.dataset.collation import collate_features
-from lhotse.utils import Seconds, compute_num_frames
+from lhotse.dataset.core import SpeechDataset
+from lhotse.dataset import fields
 
 
-class K2SpeechRecognitionIterableDataset(torch.utils.data.IterableDataset):
+class K2SpeechRecognitionIterableDataset(SpeechDataset):
     """
     The PyTorch Dataset for the speech recognition task using K2 library.
 
@@ -55,15 +44,7 @@ class K2SpeechRecognitionIterableDataset(torch.utils.data.IterableDataset):
     """
 
     def __init__(
-            self,
-            cuts: CutSet,
-            max_frames: int = 26000,
-            max_cuts: Optional[int] = None,
-            shuffle: bool = False,
-            return_cuts: bool = False,
-            concat_cuts: bool = True,
-            concat_cuts_gap: Seconds = 1.0,
-            concat_cuts_duration_factor: float = 1
+            self, concat_cuts=True, *args, **kwargs
     ):
         """
         K2 ASR IterableDataset constructor.
@@ -89,199 +70,10 @@ class K2SpeechRecognitionIterableDataset(torch.utils.data.IterableDataset):
         :param concat_cuts_duration_factor: Determines the maximum duration of the concatenated cuts;
             by default it's 1, setting the limit at the duration of the longest cut in the batch.
         """
-        super().__init__()
-        # Initialize the fields
-        self.cuts = cuts
-        self.shuffle = shuffle
-        self.max_frames = max_frames
-        self.max_cuts = max_cuts
-        self.return_cuts = return_cuts
-        self.concat_cuts = concat_cuts
-        self.concat_cuts_gap = concat_cuts_gap
-        self.concat_cuts_duration_factor = concat_cuts_duration_factor
-        # Set-up the mutable state for new epoch initialization in __iter__
-        self.cut_ids = list(self.cuts.ids)
-        self.current_idx = None
-        # Set-up the pseudo-immutable state for multiprocessing DataLoader compatibility
-        self.partition_start = 0
-        self.partition_end = len(self.cut_ids)
-        self._validate()
-
-    def __iter__(self):
-        """
-        Prepare the dataset for iterating over a new epoch. Will shuffle the data if requested.
-
-        This method takes care of partitioning for multiprocess data loading, so that the
-        dataset won't return data duplicates within a single epoch (for more details, see:
-        https://pytorch.org/docs/stable/data.html at "Multi-process data loading").
-        """
-        # noinspection PyUnresolvedReferences
-        worker_info = torch.utils.data.get_worker_info()
-        if worker_info is None:
-            # No multiprocessing involved - iterate full the CutSet.
-            self.partition_start = 0
-            self.partition_end = len(self.cut_ids)
-        else:
-            # We are in a worker process - need to select a partition to process.
-            start, end = 0, len(self.cut_ids)
-            per_worker = int(math.ceil((end - start) / float(worker_info.num_workers)))
-            worker_id = worker_info.id
-            self.partition_start = start + worker_id * per_worker
-            self.partition_end = min(self.partition_start + per_worker, end)
-
-        # Re-set the mutable state.
-        # Iterating over this dataset is equivalent to starting a new epoch.
-        if self.shuffle:
-            # If we're in multiprocessing mode, we should shuffle only the within the partition
-            # given to this worker, otherwise we might use data samples that are not intended
-            # for this worker.
-            partition_cut_ids = self.cut_ids[self.partition_start: self.partition_end]
-            random.shuffle(partition_cut_ids)
-            self.cut_ids[self.partition_start: self.partition_end] = partition_cut_ids
-        self.current_idx = self.partition_start
-        return self
-
-    def __next__(self) -> Dict[str, Union[torch.Tensor, List[str]]]:
-        """
-        Return a new batch, with the batch size automatically determined using the contraints
-        of max_frames and max_cuts.
-        """
-        # Collect the cuts that will form a batch, satisfying the criteria of max_cuts and max_frames.
-        # The returned object is a CutSet that we can keep on modifying (e.g. padding, mixing, etc.)
-        cuts: CutSet = self._collect_batch()
-
-        # For now, we'll just pad it with low energy values to match the longest Cut's
-        # duration in the batch. We might want to do something more interesting here
-        # later on - padding/mixing with noises, etc.
-        cuts = cuts.sort_by_duration().pad()
-
-        # Get a tensor with batched feature matrices, shape (B, T, F)
-        features = collate_features(cuts)
-
-        batch = {
-            'features': features,
-            'supervisions': default_collate([
-                {
-                    'sequence_idx': sequence_idx,
-                    'text': supervision.text,
-                    'start_frame': compute_num_frames(
-                        supervision.start,
-                        frame_shift=cut.frame_shift,
-                        # Note: Rounding "floor" can sometimes result in one extra frame being included
-                        # in the left context; but it guarantees that we will never go out-of-bounds when
-                        # summing start_frame + num_frames.
-                        rounding=ROUND_FLOOR
-                    ),
-                    'num_frames': compute_num_frames(
-                        supervision.duration,
-                        frame_shift=cut.frame_shift
-                    )
-                }
-                for sequence_idx, cut in enumerate(cuts)
-                for supervision in cut.supervisions
-            ])
-        }
-        if self.return_cuts:
-            batch['supervisions']['cut'] = [cut for cut in cuts for sup in cut.supervisions]
-
-        return batch
-
-    def _collect_batch(self) -> CutSet:
-        """
-        Return a sub-CutSet that represents a full batch.
-        This is quick, as it does not perform any I/O in the process.
-        """
-        # Keep iterating the underlying CutSet as long as we hit or exceed the constraints
-        # provided by user (the max number of frames or max number of cuts).
-        # Note: no actual data is loaded into memory yet because the manifests contain all the metadata
-        # required to do this operation.
-        num_frames = 0
-        cuts = []
-        while True:
-            # Check that we have not reached the end of the dataset.
-            if self.current_idx < self.partition_end:
-                # We didn't - grab the next cut
-                next_cut_id = self.cut_ids[self.current_idx]
-            else:
-                if cuts:
-                    # We did and we have a partial batch - return it.
-                    return CutSet.from_cuts(cuts)
-                else:
-                    # We did and there is nothing more to return - signal the iteration code to stop.
-                    raise StopIteration()
-            next_cut = self.cuts[next_cut_id]
-            next_num_frames = num_frames + next_cut.num_frames
-            next_num_cuts = len(cuts) + 1
-            # Did we exceed the max_frames and max_cuts constraints?
-            if next_num_frames <= self.max_frames and (self.max_cuts is None or next_num_cuts <= self.max_cuts):
-                # No - add the next cut to the batch, and keep trying.
-                num_frames = next_num_frames
-                cuts.append(next_cut)
-                self.current_idx += 1
-            else:
-                # Yes. Do we have at least one cut in the batch?
-                if cuts:
-                    # Yes. Return it.
-                    break
-                else:
-                    # No. We'll warn the user that the constrains might be too tight,
-                    # and return the cut anyway.
-                    warnings.warn("The first cut drawn in batch collection violates the max_frames or max_cuts "
-                                  "constraints - we'll return it anyway. Consider increasing max_frames/max_cuts.")
-                    cuts.append(next_cut)
-                    self.current_idx += 1
-        if self.concat_cuts:
-            cuts = concat_cuts(
-                cuts,
-                gap=self.concat_cuts_gap,
-                max_duration=self.concat_cuts_duration_factor * cuts[0].duration
-            )
-        return CutSet.from_cuts(cuts)
-
-    def _validate(self) -> None:
-        for cut in self.cuts:
-            for supervision in cut.supervisions:
-                assert (cut.start - 1e-5) <= supervision.start <= supervision.end <= (cut.end + 1e-5), \
-                    f"Cutting in the middle of a supervision is currently not supported for the ASR task. " \
-                    f"Cut ID violating the pre-condition: '{cut.id}'"
-        assert self.max_frames > 0
-        assert self.max_cuts is None or self.max_cuts > 0
-
-
-def concat_cuts(
-        cuts: List[AnyCut],
-        gap: Seconds = 1.0,
-        max_duration: Optional[Seconds] = None
-) -> List[AnyCut]:
-    """
-    We're going to concatenate the cuts to minimize the amount of total padding frames used.
-    This is actually solving a knapsack problem.
-    In this initial implementation we're using a greedy approach:
-    going from the back (i.e. the shortest cuts) we'll try to concat them to the longest cut
-    that still has some "space" at the end.
-
-    :param cuts: a list of cuts to pack.
-    :param gap: the duration of silence inserted between concatenated cuts.
-    :param max_duration: the maximum duration for the concatenated cuts
-        (by default set to the duration of the first cut).
-    :return a list of packed cuts.
-    """
-    if len(cuts) <= 1:
-        return cuts
-    cuts = sorted(cuts, key=lambda c: c.duration, reverse=True)
-    max_duration = cuts[0].duration if max_duration is None else max_duration
-    current_idx = 1
-    while True:
-        can_fit = False
-        shortest = cuts[-1]
-        for idx in range(current_idx, len(cuts) - 1):
-            cut = cuts[current_idx]
-            can_fit = cut.duration + gap + shortest.duration <= max_duration
-            if can_fit:
-                cuts[current_idx] = cut.pad(cut.duration + gap).append(shortest)
-                cuts = cuts[:-1]
-                break
-            current_idx += 1
-        if not can_fit:
-            break
-    return cuts
+        super().__init__(
+            *args,
+            signal_fields=[fields.Feats()],
+            supervision_fields=[fields.Text(), fields.FeatureSpan()],
+            concat_cuts=concat_cuts,
+            **kwargs
+        )

--- a/lhotse/dataset/speech_recognition.py
+++ b/lhotse/dataset/speech_recognition.py
@@ -44,7 +44,7 @@ class K2SpeechRecognitionIterableDataset(SpeechDataset):
     """
 
     def __init__(
-            self, concat_cuts=True, *args, **kwargs
+            self, *args, concat_cuts=True, **kwargs
     ):
         """
         K2 ASR IterableDataset constructor.

--- a/lhotse/dataset/speech_synthesis.py
+++ b/lhotse/dataset/speech_synthesis.py
@@ -1,65 +1,14 @@
-from pathlib import Path
-from typing import Dict, List, Optional
-
-import torch
-from torch.utils.data import Dataset
-
 from lhotse.cut import CutSet
-from lhotse.utils import Pathlike
+from lhotse.dataset.core import SpeechDataset
+from lhotse.dataset import fields
 
-EPS = 1e-8
 
-
-class SpeechSynthesisDataset(Dataset):
-    """
-    The PyTorch Dataset for the speech synthesis task.
-    Each item in this dataset is a dict of:
-
-    .. code-block::
-
-        {
-            'audio': (1 x NumSamples) tensor
-            'features': (NumFrames x NumFeatures) tensor
-            'tokens': list of characters
-        }
-    """
-
-    def __init__(
-            self,
-            cuts: CutSet,
-            root_dir: Optional[Pathlike] = None
-    ):
-        super().__init__()
-        self.cuts = cuts
-        self.root_dir = Path(root_dir) if root_dir else None
-        self.cut_ids = list(self.cuts.ids)
-
-        # generate tokens from text
-        self.id_to_token = {}
-        self.token_set = set()
-        for cut in cuts:
-            assert len(cut.supervisions) == 1, 'Only the Cuts with single supervision are supported.'
-            characters = list(cut.supervisions[0].text)
-            self.token_set.update(set(characters))
-            self.id_to_token[cut.id] = characters
-        self.token_set = sorted(list(self.tokens))
-
-    def __getitem__(self, idx: int) -> Dict[str, torch.Tensor]:
-        cut_id = self.cut_ids[idx]
-        cut = self.cuts[cut_id]
-
-        features = torch.from_numpy(cut.load_features())
-        audio = torch.from_numpy(cut.load_audio())
-        assert cut.id in self.id_to_token
-        return {
-            'audio': audio,
-            'features': features,
-            'tokens': self.id_to_token[cut.id]
-        }
-
-    def __len__(self) -> int:
-        return len(self.cut_ids)
-
-    @property
-    def tokens(self) -> List[str]:
-        return self.token_set
+class SpeechSynthesisDataset(SpeechDataset):
+    def __init__(self, cuts: CutSet, *args, **kwargs):
+        super().__init__(
+            cuts,
+            *args,
+            signal_fields=[fields.Audio(), fields.Feats()],
+            supervision_fields=[fields.CharacterIds(cuts)],
+            **kwargs
+        )

--- a/lhotse/dataset/vad.py
+++ b/lhotse/dataset/vad.py
@@ -1,49 +1,11 @@
-from math import isclose
-from typing import Dict
-
-import torch
-from torch.utils.data import Dataset
-
-from lhotse.cut import CutSet
-
-EPS = 1e-8
+from lhotse.dataset import SpeechDataset, fields
 
 
-class VadDataset(Dataset):
-    """
-    The PyTorch Dataset for the voice activity detection task.
-    Each item in this dataset is a dict of:
-
-    .. code-block::
-
-        {
-            'features': (T x F) tensor
-            'is_voice': (T x 1) tensor
-        }
-    """
-
-    def __init__(
-            self,
-            cuts: CutSet,
-    ):
-        super().__init__()
-        self.cuts = cuts
-        self.cut_ids = list(cuts.ids)
-
-    def __getitem__(self, idx: int) -> Dict[str, torch.Tensor]:
-        cut_id = self.cut_ids[idx]
-        cut = self.cuts[cut_id]
-
-        features = torch.from_numpy(cut.load_features())
-        assert features.shape[0] == cut.num_frames
-        assert isclose(cut.num_frames * cut.frame_shift, cut.duration)
-
-        is_voice = torch.from_numpy(cut.supervisions_feature_mask())
-
-        return {
-            'features': features,
-            'is_voice': is_voice
-        }
-
-    def __len__(self) -> int:
-        return len(self.cut_ids)
+class VadDataset(SpeechDataset):
+    def __init__(self, *args, **kwargs):
+        super().__init__(
+            *args,
+            signal_fields=[fields.Feats()],
+            supervision_fields=[fields.VoiceActivity()],
+            **kwargs
+        )

--- a/lhotse/features/mixer.py
+++ b/lhotse/features/mixer.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Sequence, Tuple
 
 import numpy as np
 

--- a/test/cut/test_invariants_randomized.py
+++ b/test/cut/test_invariants_randomized.py
@@ -1,4 +1,4 @@
-from hypothesis import given, settings
+from hypothesis import given, reproduce_failure, settings
 from hypothesis import strategies as st
 
 from lhotse.testing.fixtures import RandomCutTestCase

--- a/test/dataset/test_speech_dataset_randomized.py
+++ b/test/dataset/test_speech_dataset_randomized.py
@@ -1,0 +1,72 @@
+from hypothesis import given, reproduce_failure, settings
+from hypothesis import strategies as st
+
+from lhotse import CutSet
+from lhotse.dataset import SpeechDataset, fields
+from lhotse.testing.fixtures import RandomCutTestCase
+
+
+class TestMixedCutNumFramesNumSamplesRandomized(RandomCutTestCase):
+    @settings(deadline=None, print_blob=True)
+    @given(
+        st.one_of(st.just(8000), st.just(16000), st.just(44100)),
+        st.data(),
+    )
+    def test_no_off_by_one_errors_in_dataset_batch_collation(
+            self,
+            sampling_rate: int,
+            data
+    ):
+        ### Test data preparation ###
+        # Generate 10 - 20 cut durations in numbers of samples
+        nums_samples = data.draw(
+            st.lists(
+                st.integers(
+                    round(sampling_rate * 0.1),
+                    round(sampling_rate * 5.0)
+                ),
+                min_size=10,
+                max_size=20
+            ),
+            label='Cuts numbers of samples'
+        )
+        # Generate random cuts
+        cuts = [
+            self.with_cut(sampling_rate=sampling_rate, num_samples=num_samples, supervision=True)
+            for num_samples in nums_samples
+        ]
+        # Mix them with random offsets
+        mixed_cuts = CutSet.from_cuts(
+            lhs.mix(
+                rhs,
+                # Sample the offset in terms of number of samples, and then divide by the sampling rate
+                # to obtain "realistic" offsets
+                offset_other_by=data.draw(
+                    st.integers(min_value=int(0.1 * sampling_rate), max_value=int(lhs.duration * sampling_rate)),
+                    label=f'Offset for pair {idx + 1}'
+                ) / sampling_rate
+            ) for idx, (lhs, rhs) in enumerate(zip(cuts, cuts[1:]))
+        )
+        # Create a "SpeechDataset"
+        dataset = SpeechDataset(
+            mixed_cuts,
+            signal_fields=[fields.Audio(), fields.Feats()],
+            supervision_fields=[fields.AudioSpan(), fields.FeatureSpan()],
+            # Cuts will be needed to read the num frames/samples from them, as they are created randomly
+            return_cuts=True,
+            # Enabling cut concatenation (efficient batching mechanism) increases the "risk" of
+            # off-by-one errors as num_frames may be wrongly computed with randomized offsets.
+            concat_cuts=True,
+            concat_cuts_duration_factor=3.0
+        )
+        ### End of test data preparation ###
+        # Test the invariants
+        for batch in dataset:
+            spvns = batch['supervisions']
+            cuts = spvns['cut']
+            for idx, cut in enumerate(cuts):
+                assert spvns['start_frame'][idx] + spvns['num_frames'][idx] <= cut.num_frames, f"Error at index {idx}"
+                assert spvns['start_sample'][idx] + spvns['num_samples'][
+                    idx] <= cut.num_samples, f"Error at index {idx}"
+        # Need to call cleanup manually to free the file handles, otherwise the test may crash
+        self.cleanup()

--- a/test/dataset/test_speech_recognition_dataset.py
+++ b/test/dataset/test_speech_recognition_dataset.py
@@ -3,7 +3,8 @@ import torch
 from torch.utils.data import DataLoader
 
 from lhotse.cut import CutSet
-from lhotse.dataset.speech_recognition import K2SpeechRecognitionIterableDataset, concat_cuts
+from lhotse.dataset.core import concat_cuts
+from lhotse.dataset.speech_recognition import K2SpeechRecognitionIterableDataset
 from lhotse.testing.dummies import DummyManifest, dummy_cut
 
 

--- a/test/dataset/test_speech_synthesis_dataset.py
+++ b/test/dataset/test_speech_synthesis_dataset.py
@@ -11,7 +11,8 @@ def cut_set():
 
 def test_speech_synthesis_dataset(cut_set):
     dataset = SpeechSynthesisDataset(cut_set)
-    example = dataset[0]
+    example = next(iter(dataset))
     assert example['audio'].shape[1] > 0
     assert example['features'].shape[0] > 0
-    assert len(example['tokens']) > 0
+    assert len(example['supervisions']['char_ids']) > 0
+    assert len(example['supervisions']['char_ids_len']) > 0

--- a/test/dataset/test_vad_dataset.py
+++ b/test/dataset/test_vad_dataset.py
@@ -28,15 +28,17 @@ def test_vad_dataset(cut_set):
     end = time_diff_to_num_frames(duration, frame_length=0, frame_shift=0.01)
 
     dataset = VadDataset(cut_set.cut_into_windows(duration=duration))
-    example = dataset[0]
-    assert isclose(float(torch.mean(example['is_voice'][0:v1_start])), 0)
-    assert isclose(float(torch.mean(example['is_voice'][v1_start:v1_end])), 1)
-    assert isclose(float(torch.mean(example['is_voice'][v1_end:v2_start])), 0)
-    assert isclose(float(torch.mean(example['is_voice'][v2_start:v2_end])), 1)
-    assert isclose(float(torch.mean(example['is_voice'][v2_end:end])), 0)
+    example = next(iter(dataset))
+    is_voiced = example['supervisions']['frame_is_voiced'][0]
+    assert isclose(float(torch.mean(is_voiced[0:v1_start])), 0)
+    assert isclose(float(torch.mean(is_voiced[v1_start:v1_end])), 1)
+    assert isclose(float(torch.mean(is_voiced[v1_end:v2_start])), 0)
+    assert isclose(float(torch.mean(is_voiced[v2_start:v2_end])), 1)
+    assert isclose(float(torch.mean(is_voiced[v2_end:end])), 0)
 
-    assert float(torch.mean(example['features'][0:v1_start])) < feature_threhold
-    assert float(torch.mean(example['features'][v1_start:v1_end])) > feature_threhold
-    assert float(torch.mean(example['features'][v1_end:v2_start])) < feature_threhold
-    assert float(torch.mean(example['features'][v2_start:v2_end])) > feature_threhold
-    assert float(torch.mean(example['features'][v2_end:end])) < feature_threhold
+    feats = example['features'][0]
+    assert float(torch.mean(feats[0:v1_start])) < feature_threhold
+    assert float(torch.mean(feats[v1_start:v1_end])) > feature_threhold
+    assert float(torch.mean(feats[v1_end:v2_start])) < feature_threhold
+    assert float(torch.mean(feats[v2_start:v2_end])) > feature_threhold
+    assert float(torch.mean(feats[v2_end:end])) < feature_threhold


### PR DESCRIPTION
# Request for comments

I've been thinking how to leverage the batching efficiency improvements we made in K2 IterableDataset in other dataset classes, and if it's possible to avoid the major code overlap between the most Dataset classes in Lhotse. I came up with some ideas how to create a highly-customizable dataset class that you only need to implement the relevant bits for to adapt it to a new task.

The core idea is that there's one class that does the auto-batching stuff (`SpeechDataset`), and we give a list of "fields" that we want to see in the batches. There's "signal fields" (e.g. audio/features, single/multi channel) and "supervision fields" (e.g. text/chars/phones/fsas/supervision start frames and number of frames/speaker id/etc.). See the implementations of `SpeechDataset` in `lhotse/dataset/core.py` and the fields in `lhotse/dataset/fields.py`. To illustrate the benefits, I changed the K2, VAD and TTS dataset implementations to use this class.

As a teaser this is how a TTS dataset is implemented:

```python
class SpeechSynthesisDataset(SpeechDataset):
    def __init__(self, cuts: CutSet, *args, **kwargs):
        super().__init__(
            cuts,
            *args,
            signal_fields=[fields.Audio(), fields.Feats()],
            supervision_fields=[fields.CharacterIds(cuts)],
            **kwargs
        )
```

Note that this becomes a very declarative way to define a task (minus some args/kwargs noise; I'll try to figure out if that can be improved upon).

Things that still need to be worked out in this approach:
- handling tasks when we might need more than a single cut set in the input (e.g. for speech enhancement, speech separation, speech translation, voice conversion, and some implementations of self-supervised learning)
- more flexible auto-batching criteria (currently we support max_frames and max_cuts, but we might want max_samples or something we will come up with later, etc.)

As a proof of concept I'm going to modify the K2 dataset to output FsaVec alongside the text (so that the graph construction is performed in dataloader processes rather than the main training processes; BTW the graphs can still be cached like we do it in snowfall).

I think this might be the right way to go but I'm not 100% sure. One alternative is just writing each Dataset separately, like we did so far. Some very specific tasks might actually still require that, but I think we can be flexible enough to cover a lot of use cases with this proposal. 

@danpovey WDYT