### PR TITLE
Make CutSet.from_manifest() create deterministic Cut IDs by default

### DIFF
--- a/lhotse/bin/modes/manipulation.py
+++ b/lhotse/bin/modes/manipulation.py
@@ -17,29 +17,26 @@ from lhotse.utils import Pathlike
 __all__ = ['split', 'combine']
 
 
-@cli.group()
-def manifest():
-    """Generic commands working with all or most manifest types."""
-    pass
-
-
-@manifest.command()
+@cli.command()
 @click.argument('num_splits', type=int)
 @click.argument('manifest', type=click.Path(exists=True, dir_okay=False))
 @click.argument('output_dir', type=click.Path())
 @click.option('-s', '--shuffle', is_flag=True, help='Optionally shuffle the sequence before splitting.')
 def split(num_splits: int, manifest: Pathlike, output_dir: Pathlike, shuffle: bool):
-    """Load MANIFEST, split it into NUM_SPLITS equal parts and save as separate manifests in OUTPUT_DIR. """
+    """
+    Load MANIFEST, split it into NUM_SPLITS equal parts and save as separate manifests in OUTPUT_DIR.
+    """
     output_dir = Path(output_dir)
     manifest = Path(manifest)
+    suffix = ''.join(manifest.suffixes)
     any_set = load_manifest(manifest)
     parts = any_set.split(num_splits=num_splits, shuffle=shuffle)
     output_dir.mkdir(parents=True, exist_ok=True)
     for idx, part in enumerate(parts):
-        part.to_json(output_dir / f'{manifest.stem}.{idx + 1}.json')
+        part.to_json((output_dir / manifest).with_suffix(f'.{idx + 1}.{suffix}'))
 
 
-@manifest.command()
+@cli.command()
 @click.argument('manifests', nargs=-1, type=click.Path(exists=True, dir_okay=False))
 @click.argument('output_manifest', type=click.Path())
 def combine(manifests: Pathlike, output_manifest: Pathlike):
@@ -48,7 +45,7 @@ def combine(manifests: Pathlike, output_manifest: Pathlike):
     data_set.to_json(output_manifest)
 
 
-@manifest.command()
+@cli.command()
 @click.argument('predicate')
 @click.argument('manifest', type=click.Path(exists=True, dir_okay=False))
 @click.argument('output_manifest', type=click.Path())
@@ -59,10 +56,10 @@ def filter(predicate: str, manifest: Pathlike, output_manifest: Pathlike):
 
     \b
     The PREDICATE specifies which attribute is used for item selection. Some examples:
-    lhotse manifest filter 'duration>4.5' supervision.json output.json
-    lhotse manifest filter 'num_frames<600' cuts.json output.json
-    lhotse manifest filter 'start=0' cuts.json output.json
-    lhotse manifest filter 'channel!=0' audio.json output.json
+    lhotse filter 'duration>4.5' supervision.json output.json
+    lhotse filter 'num_frames<600' cuts.json output.json
+    lhotse filter 'start=0' cuts.json output.json
+    lhotse filter 'channel!=0' audio.json output.json
 
     It currently only supports comparison of numerical manifest item attributes, such as:
     start, duration, end, channel, num_frames, num_features, etc.

--- a/test/cut/test_cut.py
+++ b/test/cut/test_cut.py
@@ -1,9 +1,9 @@
 import pytest
 
-from lhotse.audio import RecordingSet, Recording, AudioSource
+from lhotse.audio import AudioSource, Recording, RecordingSet
 from lhotse.cut import Cut, CutSet
 from lhotse.features import FeatureSet, Features
-from lhotse.supervision import SupervisionSet, SupervisionSegment
+from lhotse.supervision import SupervisionSegment, SupervisionSet
 from lhotse.testing.dummies import dummy_cut, dummy_supervision
 
 
@@ -179,6 +179,30 @@ def test_make_cuts_from_features_recordings(dummy_recording_set, dummy_feature_s
     assert cut1.num_frames == 1000
     assert cut1.num_features == 23
     assert cut1.features_type == 'fbank'
+
+
+def test_make_cuts_from_recordings_with_deterministic_ids(dummy_recording_set):
+    cut_set = CutSet.from_manifests(recordings=dummy_recording_set, random_ids=False)
+    for idx, cut in enumerate(cut_set):
+        assert cut.id == f'{cut.recording_id}-{idx}-{cut.channel}'
+
+
+def test_make_cuts_from_recordings_with_random_ids(dummy_recording_set):
+    cut_set = CutSet.from_manifests(recordings=dummy_recording_set, random_ids=True)
+    for idx, cut in enumerate(cut_set):
+        assert cut.id != f'{cut.recording_id}-{idx}-{cut.channel}'
+
+
+def test_make_cuts_from_features_with_deterministic_ids(dummy_feature_set):
+    cut_set = CutSet.from_manifests(features=dummy_feature_set, random_ids=False)
+    for idx, cut in enumerate(cut_set):
+        assert cut.id == f'{cut.recording_id}-{idx}-{cut.channel}'
+
+
+def test_make_cuts_from_features_with_random_ids(dummy_feature_set):
+    cut_set = CutSet.from_manifests(features=dummy_feature_set, random_ids=True)
+    for idx, cut in enumerate(cut_set):
+        assert cut.id != f'{cut.recording_id}-{idx}-{cut.channel}'
 
 
 class TestCutOnSupervisions:


### PR DESCRIPTION
This will be helpful for scenarios when we create two or more CutSet's which share one of (recordings, supervisions) and we want to match the corresponding cuts easily. I am probably going to revise other methods that use randomized IDs to make Cut creation fully deterministic in the future.