### PR TITLE
Quality-of-life improvements for padding

### DIFF
--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -1469,21 +1469,23 @@ class CutSet(JsonMixin, YamlMixin, Sequence[AnyCut]):
                             Interval(s.start, s.end, s) for s in track.cut.supervisions)
         return indexed
 
-    def pad(
-            self,
-            duration: Seconds = None,
-    ) -> 'CutSet':
+    def pad(self, duration: Seconds = None, pad_feat_value: float = LOG_EPSILON) -> 'CutSet':
         """
         Return a new CutSet with Cuts padded to ``duration`` in seconds.
         Cuts longer than ``duration`` will not be affected.
         Cuts will be padded to the right (i.e. after the signal).
+
         :param duration: The cuts minimal duration after padding.
-        When not specified, we'll choose the duration of the longest cut in the CutSet.
+            When not specified, we'll choose the duration of the longest cut in the CutSet.
+        :param pad_feat_value: A float value that's used for padding the features.
+            By default we assume a log-energy floor of approx. -23 (1e-10 after exp).
         :return: A padded CutSet.
         """
         if duration is None:
             duration = max(cut.duration for cut in self)
-        return CutSet.from_cuts(cut.pad(duration=duration) for cut in self)
+        return CutSet.from_cuts(
+            cut.pad(duration=duration, pad_feat_value=pad_feat_value) for cut in self
+        )
 
     def truncate(
             self,

--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -967,7 +967,7 @@ class MixedCut(CutUtilsMixin):
         # because we are not performing any actual mixing.
         # That makes life simpler for the users who have a custom feature extractor,
         # but don't actually care about feature-domain mixing; just want to pad.
-        if mixed and all(isinstance(t, PaddingCut) for t in self.tracks[1:]):
+        if mixed and all(isinstance(t.cut, PaddingCut) for t in self.tracks[1:]):
             padding_val = self.tracks[1].cut.feat_value
             feats = np.ones((self.num_frames, self.num_features)) * padding_val
             feats[:first_cut.num_frames, :] = first_cut.load_features()

--- a/lhotse/features/fbank.py
+++ b/lhotse/features/fbank.py
@@ -4,7 +4,7 @@ import numpy as np
 import torchaudio
 
 from lhotse.features.base import TorchaudioFeatureExtractor, register_extractor
-from lhotse.utils import Seconds, EPSILON
+from lhotse.utils import EPSILON, Seconds
 
 
 @dataclass
@@ -17,7 +17,7 @@ class FbankConfig:
     frame_shift: Seconds = 0.01
     remove_dc_offset: bool = True
     round_to_power_of_two: bool = True
-    energy_floor: float = 1e-10
+    energy_floor: float = EPSILON
     min_duration: float = 0.0
     preemphasis_coefficient: float = 0.97
     raw_energy: bool = True

--- a/lhotse/features/mfcc.py
+++ b/lhotse/features/mfcc.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 import torchaudio
 
 from lhotse.features.base import TorchaudioFeatureExtractor, register_extractor
-from lhotse.utils import Seconds
+from lhotse.utils import EPSILON, Seconds
 
 
 @dataclass
@@ -16,7 +16,7 @@ class MfccConfig:
     frame_shift: Seconds = 0.01
     remove_dc_offset: bool = True
     round_to_power_of_two: bool = True
-    energy_floor: float = 1e-10
+    energy_floor: float = EPSILON
     min_duration: float = 0.0
     preemphasis_coefficient: float = 0.97
     raw_energy: bool = True

--- a/lhotse/features/spectrogram.py
+++ b/lhotse/features/spectrogram.py
@@ -3,8 +3,8 @@ from dataclasses import dataclass
 import numpy as np
 import torchaudio
 
-from lhotse.features.base import register_extractor, TorchaudioFeatureExtractor
-from lhotse.utils import Seconds, EPSILON
+from lhotse.features.base import TorchaudioFeatureExtractor, register_extractor
+from lhotse.utils import EPSILON, Seconds
 
 
 @dataclass
@@ -18,7 +18,7 @@ class SpectrogramConfig:
     frame_shift: Seconds = 0.01
     remove_dc_offset: bool = True
     round_to_power_of_two: bool = True
-    energy_floor: float = 1e-10
+    energy_floor: float = EPSILON
     min_duration: float = 0.0
     preemphasis_coefficient: float = 0.97
     raw_energy: bool = True

--- a/lhotse/utils.py
+++ b/lhotse/utils.py
@@ -22,8 +22,8 @@ Seconds = float
 Decibels = float
 
 INT16MAX = 32768
-LOG_EPSILON = -100.0
-EPSILON = math.exp(LOG_EPSILON)
+EPSILON = 1e-10
+LOG_EPSILON = math.log(EPSILON)
 
 # This is a utility that generates uuid4's and is set when the user calls
 # the ``fix_random_seed`` function.

--- a/test/cut/test_cut_perturb.py
+++ b/test/cut/test_cut_perturb.py
@@ -168,7 +168,7 @@ def test_mixed_cut_start01_perturb(cut_with_supervision_start01):
 
 
 def test_padding_cut_perturb():
-    cut = PaddingCut(id='cut', duration=5.75, sampling_rate=16000, use_log_energy=True, num_samples=92000)
+    cut = PaddingCut(id='cut', duration=5.75, sampling_rate=16000, feat_value=1e-10, num_samples=92000)
     cut_sp = cut.perturb_speed(1.1)
     assert cut_sp.num_samples == 83636
     assert cut_sp.duration == 5.22725

--- a/test/cut/test_cut_set.py
+++ b/test/cut/test_cut_set.py
@@ -167,22 +167,28 @@ def test_trim_to_supervisions_mixed_cuts():
             ])
         )
     ])
+    assert isinstance(cut_set[0], MixedCut)
     cuts = cut_set.trim_to_supervisions()
     assert len(cuts) == 4
-    assert all(isinstance(cut, MixedCut) for cut in cuts)
-    assert all(cut.start == 0 for cut in cuts)
+    # After "trimming", the MixedCut "decayed" into simple, unmixed cuts, as they did not overlap
+    assert all(isinstance(cut, Cut) for cut in cuts)
     assert all(len(cut.supervisions) == 1 for cut in cuts)
     assert all(cut.supervisions[0].start == 0 for cut in cuts)
     cut = cuts[0]
+    # Check that the cuts preserved their start/duration/supervisions after trimming
+    assert cut.start == 1.5
     assert cut.duration == 8.5
     assert cut.supervisions[0].id == 'sup1'
     cut = cuts[1]
+    assert cut.start == 10
     assert cut.duration == 5
     assert cut.supervisions[0].id == 'sup2'
     cut = cuts[2]
+    assert cut.start == 20
     assert cut.duration == 8
     assert cut.supervisions[0].id == 'sup3'
     cut = cuts[3]
+    assert cut.start == 0
     assert cut.duration == 30
     assert cut.supervisions[0].id == 'sup4'
 

--- a/test/cut/test_cut_truncate.py
+++ b/test/cut/test_cut_truncate.py
@@ -125,15 +125,10 @@ def test_truncate_mixed_cut_with_small_offset(simple_mixed_cut):
 
 def test_truncate_mixed_cut_with_offset_exceeding_first_track(simple_mixed_cut):
     truncated_cut = simple_mixed_cut.truncate(offset=11.0)
-
-    assert len(truncated_cut.tracks) == 1
-
-    assert truncated_cut.tracks[0].offset == 0.0
-    assert truncated_cut.tracks[0].cut.start == 6.0
-    assert truncated_cut.tracks[0].cut.duration == 4.0
-    assert truncated_cut.tracks[0].cut.end == 10.0
-
+    assert isinstance(truncated_cut, Cut)
+    assert truncated_cut.start == 6.0
     assert truncated_cut.duration == 4.0
+    assert truncated_cut.end == 10.0
 
 
 def test_truncate_mixed_cut_decreased_duration(simple_mixed_cut):
@@ -156,15 +151,10 @@ def test_truncate_mixed_cut_decreased_duration(simple_mixed_cut):
 
 def test_truncate_mixed_cut_decreased_duration_removing_last_cut(simple_mixed_cut):
     truncated_cut = simple_mixed_cut.truncate(duration=4.0)
-
-    assert len(truncated_cut.tracks) == 1
-
-    assert truncated_cut.tracks[0].offset == 0.0
-    assert truncated_cut.tracks[0].cut.start == 0.0
-    assert truncated_cut.tracks[0].cut.duration == 4.0
-    assert truncated_cut.tracks[0].cut.end == 4.0
-
+    assert isinstance(truncated_cut, Cut)
+    assert truncated_cut.start == 0.0
     assert truncated_cut.duration == 4.0
+    assert truncated_cut.end == 4.0
 
 
 def test_truncate_mixed_cut_with_small_offset_and_duration(simple_mixed_cut):

--- a/test/cut/test_masks.py
+++ b/test/cut/test_masks.py
@@ -4,6 +4,7 @@ import pytest
 
 from lhotse import Cut, SupervisionSegment
 from lhotse.cut import PaddingCut
+from lhotse.utils import LOG_EPSILON
 
 
 class TestMasksWithoutSupervisions:
@@ -19,12 +20,13 @@ class TestMasksWithoutSupervisions:
         assert mask.sum() == 0
 
     def test_padding_cut_audio_mask(self):
-        cut = PaddingCut('cut', duration=2, sampling_rate=16000, use_log_energy=True, num_samples=32000)
+        cut = PaddingCut('cut', duration=2, sampling_rate=16000, feat_value=LOG_EPSILON, num_samples=32000)
         mask = cut.supervisions_audio_mask()
         assert mask.sum() == 0
 
     def test_padding_cut_features_mask(self):
-        cut = PaddingCut('cut', duration=2, sampling_rate=16000, use_log_energy=True, num_frames=2000, num_features=13)
+        cut = PaddingCut('cut', duration=2, sampling_rate=16000, feat_value=LOG_EPSILON, num_frames=2000,
+                         num_features=13)
         mask = cut.supervisions_feature_mask()
         assert mask.sum() == 0
 

--- a/test/cut/test_padding_cut.py
+++ b/test/cut/test_padding_cut.py
@@ -274,3 +274,9 @@ def test_serialize_padded_cut_set(cut_set):
         padded_cut_set.to_json(f.name)
         restored = CutSet.from_json(f.name)
     assert padded_cut_set == restored
+
+
+def test_pad_without_mixing(libri_cut):
+    cut = libri_cut.pad(20)
+    cut.tracks[0].cut.features.type = 'undefined'  # make Lhotse think that a custom feat extractor is used
+    cut.load_features()  # does not throw

--- a/test/cut/test_padding_cut.py
+++ b/test/cut/test_padding_cut.py
@@ -21,19 +21,13 @@ def padding_cut():
         num_features=40,
         sampling_rate=16000,
         num_samples=160000,
-        use_log_energy=True
+        feat_value=PADDING_LOG_ENERGY
     )
 
 
-@pytest.mark.parametrize(
-    ['use_log_energy', 'expected_value'],
-    [
-        (True, PADDING_LOG_ENERGY),
-        (False, PADDING_ENERGY)
-    ]
-)
-def test_load_features_log(padding_cut, use_log_energy, expected_value):
-    padding_cut.use_log_energy = use_log_energy
+@pytest.mark.parametrize('expected_value', [PADDING_LOG_ENERGY, PADDING_ENERGY])
+def test_load_features_log(padding_cut, expected_value):
+    padding_cut.feat_value = expected_value
     feats = padding_cut.load_features()
     assert feats.shape[0] == 1000
     assert feats.shape[1] == 40
@@ -67,7 +61,7 @@ def test_truncate(padding_cut, offset, duration, expected_duration, expected_num
     assert cut.frame_shift == padding_cut.frame_shift
     assert cut.num_features == padding_cut.num_features
     assert cut.sampling_rate == padding_cut.sampling_rate
-    assert cut.use_log_energy == padding_cut.use_log_energy
+    assert cut.feat_value == padding_cut.feat_value
     assert cut.id == padding_cut.id
     # Variants
     assert cut.duration == expected_duration


### PR DESCRIPTION
Highlights:
- Cut/CutSet padding is now possible with a user-specified value instead of a hard-coded one.
- Mixing a `Cut` with a `PaddingCut` is simpler for user-defined feature extractors (i.e. they need not be registered in Lhotse), as we don't need to perform any mixing anymore - just put the padding values in the array. It also makes it possible to pad features in spaces that do not have a defined feature-space mixing operator (e.g. learned features).