### PR TITLE
Refactoring - modularizing K2 ASR dataset

### DIFF
--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -1338,7 +1338,9 @@ class CutSet(JsonMixin, YamlMixin, Sequence[AnyCut]):
 
     def subset(
             self,
+            *,  # only keyword arguments allowed
             supervision_ids: Optional[Iterable[str]] = None,
+            cut_ids: Optional[Iterable[str]] = None,
             first: Optional[int] = None,
             last: Optional[int] = None
     ) -> 'CutSet':
@@ -1351,12 +1353,13 @@ class CutSet(JsonMixin, YamlMixin, Sequence[AnyCut]):
             >>> train_set = cuts.subset(supervision_ids=train_ids)
             >>> test_set = cuts.subset(supervision_ids=test_ids)
 
-        :param supervision_ids: List of ``supervision_ids`` to keep.
+        :param supervision_ids: List of supervision IDs to keep.
+        :param cut_ids: List of cut IDs to keep.
         :param first: int, the number of first cuts to keep.
         :param last: int, the number of last cuts to keep.
         :return: a new ``CutSet`` with the subset results.
         """
-        assert exactly_one_not_null(supervision_ids, first, last), "subset() can handle only one non-None arg."
+        assert exactly_one_not_null(supervision_ids, cut_ids, first, last), "subset() can handle only one non-None arg."
 
         if first is not None:
             assert first > 0
@@ -1380,6 +1383,10 @@ class CutSet(JsonMixin, YamlMixin, Sequence[AnyCut]):
                 cut.filter_supervisions(lambda s: s.id in supervision_ids) for cut in self
                 if any(s.id in supervision_ids for s in cut.supervisions)
             )
+
+        if cut_ids is not None:
+            cut_ids = set(cut_ids)
+            return CutSet.from_cuts(self[cid] for cid in cut_ids)
 
     def filter_supervisions(self, predicate: Callable[[SupervisionSegment], bool]) -> 'CutSet':
         """

--- a/lhotse/dataset/__init__.py
+++ b/lhotse/dataset/__init__.py
@@ -1,4 +1,5 @@
 from .diarization import DiarizationDataset
+from .sampling import CutPairsSampler, SingleCutSampler
 from .source_separation import (
     DynamicallyMixedSourceSeparationDataset,
     PreMixedSourceSeparationDataset,
@@ -6,6 +7,7 @@ from .source_separation import (
 )
 from .speech_recognition import K2SpeechRecognitionDataset
 from .speech_synthesis import SpeechSynthesisDataset
+from .transforms import *
 from .unsupervised import (
     DynamicUnsupervisedDataset,
     UnsupervisedDataset,

--- a/lhotse/dataset/__init__.py
+++ b/lhotse/dataset/__init__.py
@@ -4,7 +4,7 @@ from .source_separation import (
     PreMixedSourceSeparationDataset,
     SourceSeparationDataset
 )
-from .speech_recognition import K2SpeechRecognitionIterableDataset
+from .speech_recognition import K2SpeechRecognitionDataset
 from .speech_synthesis import SpeechSynthesisDataset
 from .unsupervised import (
     DynamicUnsupervisedDataset,

--- a/lhotse/dataset/sampling.py
+++ b/lhotse/dataset/sampling.py
@@ -3,7 +3,7 @@ import math
 import random
 import warnings
 from abc import ABC, abstractmethod
-from typing import Iterable, List, Optional, Tuple
+from typing import Any, Iterable, List, Optional, Tuple
 
 import torch
 
@@ -65,7 +65,8 @@ class CutSampler(ABC):
         return self
 
     @abstractmethod
-    def __next__(self): ...
+    def __next__(self) -> Any:
+        pass
 
 
 class SingleCutSampler(CutSampler):
@@ -147,6 +148,7 @@ class SingleCutSampler(CutSampler):
 class CutPairsSampler(CutSampler):
     """
     Samples pairs of cuts from a "source" and "target" CutSet.
+    It expects that both CutSet's strictly consist of Cuts with corresponding IDs.
     It will try to satisfy the criteria of max_source_frames, max_target_frames, and max_cuts.
     Use as an iterable that yields pairs of ``CutSet`` objects (individual batches).
     """
@@ -163,7 +165,8 @@ class CutPairsSampler(CutSampler):
         """
         CutPairsSampler's constructor.
 
-        :param cuts: the ``CutSet`` to sample data from.
+        :param source_cuts: the first ``CutSet`` to sample data from.
+        :param target_cuts: the second ``CutSet`` to sample data from.
         :param max_frames: The maximum number of feature frames that we're going to put in a single batch.
             The padding frames do not contribute to that limit, since we pack the batch by default to minimze
             the amount of padding.

--- a/lhotse/dataset/sampling.py
+++ b/lhotse/dataset/sampling.py
@@ -1,0 +1,288 @@
+import logging
+import math
+import random
+import warnings
+from abc import ABC, abstractmethod
+from typing import Iterable, List, Optional, Tuple
+
+import torch
+
+from lhotse import CutSet
+
+
+class CutSampler(ABC):
+    """
+    CutSampler is responsible for collecting batches of cuts, given specified criteria.
+    It implements correct handling of multiprocessing in DataLoader,
+    as well as distributed training, so that the cuts are not duplicated across workers.
+
+    Sampling in a CutSampler is intended to be very quick - it only uses the metadata in
+    ``CutSet`` manifest to select the cuts, and is not intended to perform any I/O.
+
+    .. note:
+
+        For implementers of new samplers:
+        Subclasses of CutSampler are expected to implement ``__next__()`` to introduce specific
+        sampling logic (e.g. based on filters such as max number of frames/tokens/etc.).
+        CutSampler defines ``__iter__()`` which optionally shuffles the cut IDs, and resets
+        ``self.current_idx`` to zero (to be used and incremented inside of ``__next__()``.
+    """
+
+    def __init__(
+            self,
+            cut_ids: Iterable[str],
+            shuffle: bool = False,
+            world_size: int = 1,
+            local_rank: int = 0,
+    ) -> None:
+        """
+
+        :param cut_ids: An iterable of cut IDs for the full dataset.
+            CutSampler will take care of partitioning that into parallel/distributed workers.
+        :param shuffle: When ``True``, the cuts will be shuffled at the start of iteration.
+            Convenient when mini-batch loop is inside an outer epoch-level loop, e.g.:
+            `for epoch in range(10): for batch in dataset: ...` as every epoch will see a
+            different cuts order.
+        :param world_size: Total number of distributed nodes. Set only when using ``DistributedDataParallel``.
+        :param local_rank: Index of distributed node. Set only when using ``DistributedDataParallel``.
+        """
+        self.all_cut_ids = list(cut_ids)
+        self.shuffle = shuffle
+        self.world_size = world_size
+        self.local_rank = local_rank
+
+    def __iter__(self) -> 'CutSampler':
+        """
+        Prepare the dataset for iterating over a new epoch. Will shuffle the data if requested.
+        """
+        # We can only retrieve the cut ids once iter is called, not before!
+        # Iter is called inside a dataloader process, whereas init is called when
+        # instantiating this class (typically before dataloader).
+        self.cut_ids = partition_cut_ids(self.all_cut_ids, world_size=self.world_size, local_rank=self.local_rank)
+        if self.shuffle:
+            random.shuffle(self.cut_ids)
+        self.current_idx = 0
+        return self
+
+    @abstractmethod
+    def __next__(self): ...
+
+
+class SingleCutSampler(CutSampler):
+    """
+    Samples cuts from a CutSet to satisfy the criteria of max_frames and max_cuts.
+    Use as an iterable that yields ``CutSet`` objects (individual batches).
+    """
+
+    def __init__(
+            self,
+            cuts: CutSet,
+            max_frames: int = 26000,
+            max_cuts: Optional[int] = None,
+            **kwargs
+    ):
+        """
+        SingleCutSampler's constructor.
+
+        :param cuts: the ``CutSet`` to sample data from.
+        :param max_frames: The maximum number of feature frames that we're going to put in a single batch.
+            The padding frames do not contribute to that limit, since we pack the batch by default to minimze
+            the amount of padding.
+        :param max_cuts: The maximum number of cuts sampled to form a mini-batch.
+            By default, this constraint is off.
+        :param kwargs: Arguments to be passed into ``CutSampler``.
+        """
+        super().__init__(cuts.ids, **kwargs)
+        self.cuts = cuts
+        # Constraints
+        self.max_frames = max_frames
+        self.max_cuts = max_cuts
+        assert self.max_frames > 0
+        assert self.max_cuts is None or self.max_cuts > 0
+
+    def __next__(self) -> CutSet:
+        # Keep iterating the underlying CutSet as long as we hit or exceed the constraints
+        # provided by user (the max number of frames or max number of cuts).
+        # Note: no actual data is loaded into memory yet because the manifests contain all the metadata
+        # required to do this operation.
+        num_frames = 0
+        cuts = []
+        while True:
+            # Check that we have not reached the end of the dataset.
+            if self.current_idx < len(self.cut_ids):
+                # We didn't - grab the next cut
+                next_cut_id = self.cut_ids[self.current_idx]
+            else:
+                if cuts:
+                    # We did and we have a partial batch - return it.
+                    return CutSet.from_cuts(cuts)
+                else:
+                    # We did and there is nothing more to return - signal the iteration code to stop.
+                    raise StopIteration()
+            next_cut = self.cuts[next_cut_id]
+            next_num_frames = num_frames + next_cut.num_frames
+            next_num_cuts = len(cuts) + 1
+            # Did we exceed the max_frames and max_cuts constraints?
+            if next_num_frames <= self.max_frames and (self.max_cuts is None or next_num_cuts <= self.max_cuts):
+                # No - add the next cut to the batch, and keep trying.
+                num_frames = next_num_frames
+                cuts.append(next_cut)
+                self.current_idx += 1
+            else:
+                # Yes. Do we have at least one cut in the batch?
+                if cuts:
+                    # Yes. Return it.
+                    break
+                else:
+                    # No. We'll warn the user that the constrains might be too tight,
+                    # and return the cut anyway.
+                    warnings.warn("The first cut drawn in batch collection violates the max_frames or max_cuts "
+                                  "constraints - we'll return it anyway. Consider increasing max_frames/max_cuts.")
+                    cuts.append(next_cut)
+                    self.current_idx += 1
+        batch = CutSet.from_cuts(cuts)
+        return batch
+
+
+class CutPairsSampler(CutSampler):
+    """
+    Samples pairs of cuts from a "source" and "target" CutSet.
+    It will try to satisfy the criteria of max_source_frames, max_target_frames, and max_cuts.
+    Use as an iterable that yields pairs of ``CutSet`` objects (individual batches).
+    """
+
+    def __init__(
+            self,
+            source_cuts: CutSet,
+            target_cuts: CutSet,
+            max_source_frames: int = 26000,
+            max_target_frames: int = 26000,
+            max_cuts: Optional[int] = None,
+            **kwargs
+    ):
+        """
+        CutPairsSampler's constructor.
+
+        :param cuts: the ``CutSet`` to sample data from.
+        :param max_frames: The maximum number of feature frames that we're going to put in a single batch.
+            The padding frames do not contribute to that limit, since we pack the batch by default to minimze
+            the amount of padding.
+        :param max_cuts: The maximum number of cuts sampled to form a mini-batch.
+            By default, this constraint is off.
+        :param shuffle: When ``True``, the cuts will be shuffled at the start of iteration.
+            Convenient when mini-batch loop is inside an outer epoch-level loop, e.g.:
+            `for epoch in range(10): for batch in dataset: ...` as every epoch will see a
+            different cuts order.
+        """
+        super().__init__(self.source_cuts.ids, **kwargs)
+        self.source_cuts = source_cuts
+        self.target_cuts = target_cuts
+        assert set(self.source_cuts.ids) == set(self.target_cuts.ids), \
+            "Expected source and target cuts to have the same set of IDs."
+        # Constraints
+        self.max_source_frames = max_source_frames
+        self.max_target_frames = max_target_frames
+        self.max_cuts = max_cuts
+
+    def __next__(self) -> Tuple[CutSet, CutSet]:
+        # Keep iterating the underlying CutSet as long as we hit or exceed the constraints
+        # provided by user (the max number of source_feats or max number of cuts).
+        # Note: no actual data is loaded into memory yet because the manifests contain all the metadata
+        # required to do this operation.
+        num_source_frames = 0
+        num_target_frames = 0
+        source_cuts = []
+        while True:
+            # Check that we have not reached the end of the dataset.
+            if self.current_idx < len(self.cut_ids):
+                # We didn't - grab the next cut
+                next_cut_id = self.cut_ids[self.current_idx]
+            else:
+                if source_cuts:
+                    # We did and we have a partial batch - return it.
+                    return (
+                        CutSet.from_cuts(source_cuts),
+                        CutSet.from_cuts(self.target_cuts[c.id] for c in source_cuts)
+                    )
+                else:
+                    # We did and there is nothing more to return - signal the iteration code to stop.
+                    raise StopIteration()
+            next_source_cut = self.source_cuts[next_cut_id]
+            next_target_cut = self.target_cuts[next_cut_id]
+            next_num_source_frames = num_source_frames + next_source_cut.num_frames
+            next_num_target_frames = num_target_frames + next_target_cut.num_frames
+            next_num_cuts = len(source_cuts) + 1
+            # Did we exceed the max_source_frames and max_cuts constraints?
+            if next_num_source_frames <= self.max_source_frames \
+                    and (next_num_target_frames <= self.max_target_frames) \
+                    and (self.max_cuts is None or next_num_cuts <= self.max_cuts):
+                # No - add the next cut to the batch, and keep trying.
+                num_source_frames = next_num_source_frames
+                num_target_frames = next_num_target_frames
+                source_cuts.append(next_source_cut)
+                self.current_idx += 1
+            else:
+                # Yes. Do we have at least one cut in the batch?
+                if source_cuts:
+                    # Yes. Return it.
+                    break
+                else:
+                    # No. We'll warn the user that the constrains might be too tight,
+                    # and return the cut anyway.
+                    warnings.warn("The first cut drawn in batch collection violates one of the max_... constraints"
+                                  "we'll return it anyway. Consider increasing max_source_frames/max_cuts/etc.")
+                    source_cuts.append(next_source_cut)
+                    self.current_idx += 1
+        return (
+            CutSet.from_cuts(source_cuts),
+            CutSet.from_cuts(self.target_cuts[c.id] for c in source_cuts)
+        )
+
+
+def partition_cut_ids(
+        cut_ids: List[str],
+        world_size: int = 1,
+        local_rank: int = 0
+) -> List[str]:
+    """
+    Returns a list of cut IDs to be used by a single dataloading process.
+    For multiple dataloader workers or ``DistributedDataParallel`` training,
+    that list will be smaller than ``self.cut_ids``.
+
+    This method takes care of partitioning for multiprocess data loading, so that the
+    dataset won't return data duplicates within a single epoch (for more details, see:
+    https://pytorch.org/docs/stable/data.html at "Multi-process data loading").
+
+    :param cut_ids: a list of Cut IDs, representing the full dataset.
+    :param world_size: Total number of distributed nodes. Set only when using ``DistributedDataParallel``.
+    :param local_rank: Index of distributed node. Set only when using ``DistributedDataParallel``.
+    """
+
+    # First, split depending on the world_size and local_rank.
+    if world_size == 1:
+        logging.info('No distributed training - not partitioning here.')
+        partition_start = 0
+        partition_end = len(cut_ids)
+    else:
+        logging.info(f'Distributed training with world size of {world_size} detected '
+                     f'(node\'s local rank is {local_rank}. '
+                     f'Splitting cuts into {world_size} partitions.')
+        # Distributed training is active - split full dataset into a subset.
+        total = len(cut_ids)
+        per_partition = int(math.ceil(total / float(world_size)))
+        partition_start = local_rank * per_partition
+        partition_end = min(partition_start + per_partition, total)
+
+    # Ask PyTorch about multiprocessing in the DataLoader.
+    # If there is no multiprocessing involved, we'll iterate full partition for this node.
+    worker_info = torch.utils.data.get_worker_info()
+    if worker_info is not None:
+        logging.info(f'Multiprocessing dataloader detected with num workers of {worker_info.num_workers}. '
+                     f'Creating per-worker partitions (the effect stacks with distributed training, if used).')
+        # We are in a worker process - need to select a partition to process.
+        per_worker = int(math.ceil((partition_end - partition_start) / float(worker_info.num_workers)))
+        worker_id = worker_info.id
+        partition_start += worker_id * per_worker
+        partition_end = min(partition_start + per_worker, partition_end)
+
+    return cut_ids[partition_start: partition_end]

--- a/lhotse/dataset/speech_recognition.py
+++ b/lhotse/dataset/speech_recognition.py
@@ -1,15 +1,13 @@
-import math
-import random
-import warnings
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Callable, Dict, List, Optional, Union
 
 import torch
 from torch.utils.data.dataloader import DataLoader, default_collate
 
 from lhotse import validate
-from lhotse.cut import AnyCut, CutSet
+from lhotse.cut import CutSet
 from lhotse.dataset.collation import collate_features
-from lhotse.utils import Decibels, Seconds, supervision_to_frames
+from lhotse.dataset.sampling import SingleCutSampler
+from lhotse.utils import supervision_to_frames
 
 
 class K2SpeechRecognitionIterableDataset(torch.utils.data.IterableDataset):
@@ -19,13 +17,10 @@ class K2SpeechRecognitionIterableDataset(torch.utils.data.IterableDataset):
     This dataset internally batches and collates the Cuts and should be used with
     PyTorch DataLoader with argument batch_size=None to work properly.
     The batch size is determined automatically to satisfy the constraints of ``max_frames``
-    and ``max_cuts``.
+    and ``max_cuts``, specified by the sampler.
 
     This dataset will automatically partition itself when used with a multiprocessing DataLoader
     (i.e. the same cut will not appear twice in the same epoch).
-
-    By default, we "pack" the batches to minimize the amount of padding - we achieve that by
-    concatenating the cuts' feature matrices with a small amount of silence (padding) in between.
 
     Each item in this dataset is a dict of:
 
@@ -35,11 +30,12 @@ class K2SpeechRecognitionIterableDataset(torch.utils.data.IterableDataset):
             'features': float tensor of shape (B, T, F)
             'supervisions': [
                 {
-                    'cut_id': List[str] of len S
                     'sequence_idx': Tensor[int] of shape (S,)
                     'text': List[str] of len S
                     'start_frame': Tensor[int] of shape (S,)
                     'num_frames': Tensor[int] of shape (S,)
+                    # Optionally, when return_cuts=True
+                    'cut': List[AnyCut] of len S
                 }
             ]
         }
@@ -56,102 +52,32 @@ class K2SpeechRecognitionIterableDataset(torch.utils.data.IterableDataset):
     def __init__(
             self,
             cuts: CutSet,
-            max_frames: int = 26000,
-            max_cuts: Optional[int] = None,
-            shuffle: bool = False,
+            sampler: Optional[SingleCutSampler] = None,
             return_cuts: bool = False,
-            concat_cuts: bool = True,
-            concat_cuts_gap: Seconds = 1.0,
-            concat_cuts_duration_factor: float = 1,
-            aug_cuts: Optional[CutSet] = None,
-            aug_snr: Optional[Union[Decibels, Tuple[Decibels, Decibels]]] = (10, 20),
-            aug_prob: float = 0.5
+            cut_transforms: List[Callable[[CutSet], CutSet]] = None
     ):
         """
         K2 ASR IterableDataset constructor.
 
         :param cuts: the ``CutSet`` to sample data from.
-        :param max_frames: The maximum number of feature frames that we're going to put in a single batch.
-            The padding frames do not contribute to that limit, since we pack the batch by default to minimze
-            the amount of padding.
-        :param max_cuts: The maximum number of cuts sampled to form a mini-batch.
-            By default, this constraint is off.
-        :param shuffle: When ``True``, the cuts will be shuffled at the start of iteration.
-            Convenient when mini-batch loop is inside an outer epoch-level loop, e.g.:
-            `for epoch in range(10): for batch in dataset: ...` as every epoch will see a
-            different cuts order.
+        :param sampler: a ``SingleCutSampler`` objects that draws Cuts from the ``CutSet`` to form batches.
+            When not provided, we will create one with default settings.
         :param return_cuts: When ``True``, will additionally return a "cut" field in each batch with the Cut
             objects used to create that batch.
-        :param concat_cuts: When ``True``, we will concatenate the cuts to minimize the total amount of padding;
-            e.g. instead of creating a batch with 40 examples, we will merge some of the examples together
-            adding some silence between them to avoid a large number of padding frames that waste the computation.
-            Enabled by default.
-        :param concat_cuts_gap: The duration of silence in seconds that is inserted between the cuts;
-            it's goal is to let the model "know" that there are separate utterances in a single example.
-        :param concat_cuts_duration_factor: Determines the maximum duration of the concatenated cuts;
-            by default it's 1, setting the limit at the duration of the longest cut in the batch.
-        :param aug_cuts: an optional ``CutSet`` containing augmentation data, e.g. noise, music, babble.
-        :param aug_snr: either a float, a pair (range) of floats, or ``None``.
-            It determines the SNR of the speech signal vs the noise signal that's mixed into it.
-            When a range is specified, we will uniformly sample SNR in that range.
-            When it's ``None``, the noise will be mixed as-is -- i.e. without any level adjustment.
-            Note that it's different from ``aug_snr=0``, which will adjust the noise level so that the SNR is 0.
-        :param aug_prob: a float probability in range [0, 1].
-            Specifies the probability with which we will mix augment the cuts.
+        :param cut_transforms: A list of transforms to be applied on each sampled batch
+            (e.g. cut concatenation, noise cuts mixing, etc.).
         """
         super().__init__()
         # Initialize the fields
         self.cuts = cuts
-        self.shuffle = shuffle
-        self.max_frames = max_frames
-        self.max_cuts = max_cuts
+        self.sampler = sampler if sampler is not None else SingleCutSampler(cuts)
         self.return_cuts = return_cuts
-        self.concat_cuts = concat_cuts
-        self.concat_cuts_gap = concat_cuts_gap
-        self.concat_cuts_duration_factor = concat_cuts_duration_factor
-        self.aug_cuts = aug_cuts
-        self.aug_snr = aug_snr
-        self.aug_prob = aug_prob
-        # Set-up the mutable state for new epoch initialization in __iter__
-        self.cut_ids = list(self.cuts.ids)
-        self.current_idx = None
-        # Set-up the pseudo-immutable state for multiprocessing DataLoader compatibility
-        self.partition_start = 0
-        self.partition_end = len(self.cut_ids)
+        self.cut_transforms = cut_transforms if cut_transforms is not None else ()
         self._validate()
 
     def __iter__(self):
-        """
-        Prepare the dataset for iterating over a new epoch. Will shuffle the data if requested.
-
-        This method takes care of partitioning for multiprocess data loading, so that the
-        dataset won't return data duplicates within a single epoch (for more details, see:
-        https://pytorch.org/docs/stable/data.html at "Multi-process data loading").
-        """
-        # noinspection PyUnresolvedReferences
-        worker_info = torch.utils.data.get_worker_info()
-        if worker_info is None:
-            # No multiprocessing involved - iterate full the CutSet.
-            self.partition_start = 0
-            self.partition_end = len(self.cut_ids)
-        else:
-            # We are in a worker process - need to select a partition to process.
-            start, end = 0, len(self.cut_ids)
-            per_worker = int(math.ceil((end - start) / float(worker_info.num_workers)))
-            worker_id = worker_info.id
-            self.partition_start = start + worker_id * per_worker
-            self.partition_end = min(self.partition_start + per_worker, end)
-
-        # Re-set the mutable state.
-        # Iterating over this dataset is equivalent to starting a new epoch.
-        if self.shuffle:
-            # If we're in multiprocessing mode, we should shuffle only the within the partition
-            # given to this worker, otherwise we might use data samples that are not intended
-            # for this worker.
-            partition_cut_ids = self.cut_ids[self.partition_start: self.partition_end]
-            random.shuffle(partition_cut_ids)
-            self.cut_ids[self.partition_start: self.partition_end] = partition_cut_ids
-        self.current_idx = self.partition_start
+        """Prepare the dataset for iterating over a new epoch."""
+        self.sampler = iter(self.sampler)
         return self
 
     def __next__(self) -> Dict[str, Union[torch.Tensor, List[str]]]:
@@ -161,20 +87,17 @@ class K2SpeechRecognitionIterableDataset(torch.utils.data.IterableDataset):
         """
         # Collect the cuts that will form a batch, satisfying the criteria of max_cuts and max_frames.
         # The returned object is a CutSet that we can keep on modifying (e.g. padding, mixing, etc.)
-        cuts: CutSet = self._collect_batch()
+        cuts = next(self.sampler)
 
         # Sort the cuts by duration so that the first one determines the batch time dimensions.
         cuts = cuts.sort_by_duration(ascending=False)
 
-        # Perform the padding (and possibly augmentation at the same time).
-        if self.aug_cuts is not None:
-            # Mix in the signal from the augmentation CutSet; use them as padding at the same time.
-            cuts = cuts.mix(self.aug_cuts, duration=cuts[0].duration, snr=self.aug_snr, mix_prob=self.aug_prob)
-        else:
-            # We'll just pad it with low energy values to match the longest Cut's duration in the batch.
-            cuts = cuts.pad()
+        # Optional transforms.
+        for tnfm in self.cut_transforms:
+            cuts = tnfm(cuts)
 
         # Get a tensor with batched feature matrices, shape (B, T, F)
+        # Collation performs auto-padding, if necessary.
         features = collate_features(cuts)
 
         batch = {
@@ -201,58 +124,6 @@ class K2SpeechRecognitionIterableDataset(torch.utils.data.IterableDataset):
 
         return batch
 
-    def _collect_batch(self) -> CutSet:
-        """
-        Return a sub-CutSet that represents a full batch.
-        This is quick, as it does not perform any I/O in the process.
-        """
-        # Keep iterating the underlying CutSet as long as we hit or exceed the constraints
-        # provided by user (the max number of frames or max number of cuts).
-        # Note: no actual data is loaded into memory yet because the manifests contain all the metadata
-        # required to do this operation.
-        num_frames = 0
-        cuts = []
-        while True:
-            # Check that we have not reached the end of the dataset.
-            if self.current_idx < self.partition_end:
-                # We didn't - grab the next cut
-                next_cut_id = self.cut_ids[self.current_idx]
-            else:
-                if cuts:
-                    # We did and we have a partial batch - return it.
-                    return CutSet.from_cuts(cuts)
-                else:
-                    # We did and there is nothing more to return - signal the iteration code to stop.
-                    raise StopIteration()
-            next_cut = self.cuts[next_cut_id]
-            next_num_frames = num_frames + next_cut.num_frames
-            next_num_cuts = len(cuts) + 1
-            # Did we exceed the max_frames and max_cuts constraints?
-            if next_num_frames <= self.max_frames and (self.max_cuts is None or next_num_cuts <= self.max_cuts):
-                # No - add the next cut to the batch, and keep trying.
-                num_frames = next_num_frames
-                cuts.append(next_cut)
-                self.current_idx += 1
-            else:
-                # Yes. Do we have at least one cut in the batch?
-                if cuts:
-                    # Yes. Return it.
-                    break
-                else:
-                    # No. We'll warn the user that the constrains might be too tight,
-                    # and return the cut anyway.
-                    warnings.warn("The first cut drawn in batch collection violates the max_frames or max_cuts "
-                                  "constraints - we'll return it anyway. Consider increasing max_frames/max_cuts.")
-                    cuts.append(next_cut)
-                    self.current_idx += 1
-        if self.concat_cuts:
-            cuts = concat_cuts(
-                cuts,
-                gap=self.concat_cuts_gap,
-                max_duration=self.concat_cuts_duration_factor * cuts[0].duration
-            )
-        return CutSet.from_cuts(cuts)
-
     def _validate(self) -> None:
         validate(self.cuts)
         for cut in self.cuts:
@@ -260,44 +131,3 @@ class K2SpeechRecognitionIterableDataset(torch.utils.data.IterableDataset):
                 assert (cut.start - 1e-5) <= supervision.start <= supervision.end <= (cut.end + 1e-5), \
                     f"Cutting in the middle of a supervision is currently not supported for the ASR task. " \
                     f"Cut ID violating the pre-condition: '{cut.id}'"
-        assert self.max_frames > 0
-        assert self.max_cuts is None or self.max_cuts > 0
-
-
-def concat_cuts(
-        cuts: List[AnyCut],
-        gap: Seconds = 1.0,
-        max_duration: Optional[Seconds] = None
-) -> List[AnyCut]:
-    """
-    We're going to concatenate the cuts to minimize the amount of total padding frames used.
-    This is actually solving a knapsack problem.
-    In this initial implementation we're using a greedy approach:
-    going from the back (i.e. the shortest cuts) we'll try to concat them to the longest cut
-    that still has some "space" at the end.
-
-    :param cuts: a list of cuts to pack.
-    :param gap: the duration of silence inserted between concatenated cuts.
-    :param max_duration: the maximum duration for the concatenated cuts
-        (by default set to the duration of the first cut).
-    :return a list of packed cuts.
-    """
-    if len(cuts) <= 1:
-        return cuts
-    cuts = sorted(cuts, key=lambda c: c.duration, reverse=True)
-    max_duration = cuts[0].duration if max_duration is None else max_duration
-    current_idx = 1
-    while True:
-        can_fit = False
-        shortest = cuts[-1]
-        for idx in range(current_idx, len(cuts) - 1):
-            cut = cuts[current_idx]
-            can_fit = cut.duration + gap + shortest.duration <= max_duration
-            if can_fit:
-                cuts[current_idx] = cut.pad(cut.duration + gap).append(shortest)
-                cuts = cuts[:-1]
-                break
-            current_idx += 1
-        if not can_fit:
-            break
-    return cuts

--- a/lhotse/dataset/speech_recognition.py
+++ b/lhotse/dataset/speech_recognition.py
@@ -13,13 +13,11 @@ class K2SpeechRecognitionDataset(torch.utils.data.Dataset):
     """
     The PyTorch Dataset for the speech recognition task using K2 library.
 
-    This dataset internally batches and collates the Cuts and should be used with
-    PyTorch DataLoader with argument batch_size=None to work properly.
-    The batch size is determined automatically to satisfy the constraints of ``max_frames``
-    and ``max_cuts``, specified by the sampler.
+    This dataset expects to be queried with lists of cut IDs,
+    for which it loads features and automatically collates/batches them.
 
-    This dataset will automatically partition itself when used with a multiprocessing DataLoader
-    (i.e. the same cut will not appear twice in the same epoch).
+    To use it with a PyTorch DataLoader, set ``batch_size=None``
+    and provide a :class:`SingleCutSampler` sampler.
 
     Each item in this dataset is a dict of:
 

--- a/lhotse/dataset/transforms/__init__.py
+++ b/lhotse/dataset/transforms/__init__.py
@@ -1,2 +1,2 @@
-from .cat import CutCat, concat_cuts
+from .concatenate import CutConcatenate, concat_cuts
 from .mix import CutMix

--- a/lhotse/dataset/transforms/__init__.py
+++ b/lhotse/dataset/transforms/__init__.py
@@ -1,0 +1,2 @@
+from .cat import CutCat, concat_cuts
+from .mix import CutMix

--- a/lhotse/dataset/transforms/cat.py
+++ b/lhotse/dataset/transforms/cat.py
@@ -1,0 +1,79 @@
+from typing import Optional, Sequence
+
+from lhotse import CutSet
+from lhotse.cut import AnyCut
+from lhotse.utils import Seconds
+
+
+class CutCat:
+    """
+    A transform on batch of cuts (``CutSet``) that concatenates the cuts to minimize the total amount of padding;
+    e.g. instead of creating a batch with 40 examples, we will merge some of the examples together
+    adding some silence between them to avoid a large number of padding frames that waste the computation.
+    """
+
+    def __init__(
+            self,
+            gap: Seconds = 1.0,
+            duration_factor: float = 1.0
+    ) -> None:
+        """
+        CutCat's constructor.
+
+        :param gap: The duration of silence in seconds that is inserted between the cuts;
+            it's goal is to let the model "know" that there are separate utterances in a single example.
+        :param duration_factor: Determines the maximum duration of the concatenated cuts;
+            by default it's 1, setting the limit at the duration of the longest cut in the batch.
+        """
+        self.gap = gap
+        self.duration_factor = duration_factor
+
+    def __call__(self, cuts: CutSet) -> CutSet:
+        cuts = cuts.sort_by_duration(ascending=False)
+        return concat_cuts(
+            cuts,
+            gap=self.gap,
+            max_duration=cuts[0].duration * self.duration_factor
+        )
+
+
+def concat_cuts(
+        cuts: Sequence[AnyCut],
+        gap: Seconds = 1.0,
+        max_duration: Optional[Seconds] = None
+) -> CutSet:
+    """
+    We're going to concatenate the cuts to minimize the amount of total padding frames used.
+    This means that some samples in the batch will be merged together into one sample,
+    separated by an interval of silence.
+    This is actually solving a knapsack problem.
+    In this initial implementation we're using a greedy approach:
+    going from the back (i.e. the shortest cuts) we'll try to concat them to the longest cut
+    that still has some "space" at the end.
+
+    :param cuts: a list of cuts to pack.
+    :param gap: the duration of silence inserted between concatenated cuts.
+    :param max_duration: the maximum duration for the concatenated cuts
+        (by default set to the duration of the first cut).
+    :return a list of packed cuts.
+    """
+    if len(cuts) <= 1:
+        # Nothing to do.
+        return CutSet.from_cuts(cuts)
+    cuts = sorted(cuts, key=lambda c: c.duration, reverse=True)
+    max_duration = cuts[0].duration if max_duration is None else max_duration
+    current_idx = 1
+    while True:
+        can_fit = False
+        shortest = cuts[-1]
+        for idx in range(current_idx, len(cuts) - 1):
+            cut = cuts[current_idx]
+            can_fit = cut.duration + gap + shortest.duration <= max_duration
+            if can_fit:
+                cuts[current_idx] = cut.pad(cut.duration + gap).append(shortest)
+                cuts = cuts[:-1]
+                break
+            current_idx += 1
+        if not can_fit:
+            break
+    return CutSet.from_cuts(cuts)

--- a/lhotse/dataset/transforms/concatenate.py
+++ b/lhotse/dataset/transforms/concatenate.py
@@ -5,7 +5,7 @@ from lhotse.cut import AnyCut
 from lhotse.utils import Seconds
 
 
-class CutCat:
+class CutConcatenate:
     """
     A transform on batch of cuts (``CutSet``) that concatenates the cuts to minimize the total amount of padding;
     e.g. instead of creating a batch with 40 examples, we will merge some of the examples together
@@ -18,7 +18,7 @@ class CutCat:
             duration_factor: float = 1.0
     ) -> None:
         """
-        CutCat's constructor.
+        CutConcatenate's constructor.
 
         :param gap: The duration of silence in seconds that is inserted between the cuts;
             it's goal is to let the model "know" that there are separate utterances in a single example.

--- a/lhotse/dataset/transforms/mix.py
+++ b/lhotse/dataset/transforms/mix.py
@@ -1,0 +1,40 @@
+from typing import Optional, Tuple, Union
+
+from lhotse import CutSet
+from lhotse.utils import Decibels
+
+
+class CutMix:
+    """
+    A transform for batches of cuts (CutSet's) that stochastically performs n
+    oise augmentation with a constant or varying SNR.
+    """
+
+    def __init__(
+            self,
+            cuts: Optional[CutSet] = None,
+            snr: Optional[Union[Decibels, Tuple[Decibels, Decibels]]] = (10, 20),
+            prob: float = 0.5
+    ) -> None:
+        """
+        CutMix's constructor.
+
+        :param cuts: a ``CutSet`` containing augmentation data, e.g. noise, music, babble.
+        :param snr: either a float, a pair (range) of floats, or ``None``.
+            It determines the SNR of the speech signal vs the noise signal that's mixed into it.
+            When a range is specified, we will uniformly sample SNR in that range.
+            When it's ``None``, the noise will be mixed as-is -- i.e. without any level adjustment.
+            Note that it's different from ``aug_snr=0``, which will adjust the noise level so that the SNR is 0.
+        :param prob: a float probability in range [0, 1].
+            Specifies the probability with which we will mix augment the cuts.
+        """
+        self.cuts = cuts
+        self.snr = snr
+        self.prob = prob
+
+    def __call__(self, cuts: CutSet) -> CutSet:
+        return (
+            cuts
+                .sort_by_duration(ascending=False)
+                .mix(self.cuts, duration=cuts[0].duration, snr=self.snr, mix_prob=self.prob)
+        )

--- a/lhotse/dataset/transforms/mix.py
+++ b/lhotse/dataset/transforms/mix.py
@@ -6,8 +6,8 @@ from lhotse.utils import Decibels
 
 class CutMix:
     """
-    A transform for batches of cuts (CutSet's) that stochastically performs n
-    oise augmentation with a constant or varying SNR.
+    A transform for batches of cuts (CutSet's) that stochastically performs
+    noise augmentation with a constant or varying SNR.
     """
 
     def __init__(
@@ -24,7 +24,7 @@ class CutMix:
             It determines the SNR of the speech signal vs the noise signal that's mixed into it.
             When a range is specified, we will uniformly sample SNR in that range.
             When it's ``None``, the noise will be mixed as-is -- i.e. without any level adjustment.
-            Note that it's different from ``aug_snr=0``, which will adjust the noise level so that the SNR is 0.
+            Note that it's different from ``snr=0``, which will adjust the noise level so that the SNR is 0.
         :param prob: a float probability in range [0, 1].
             Specifies the probability with which we will mix augment the cuts.
         """

--- a/test/dataset/test_sampling.py
+++ b/test/dataset/test_sampling.py
@@ -1,0 +1,69 @@
+import pytest
+
+from lhotse import CutSet
+from lhotse.dataset.sampling import SingleCutSampler
+from lhotse.dataset.transforms import concat_cuts
+from lhotse.testing.dummies import DummyManifest, dummy_cut
+
+
+@pytest.fixture
+def libri_cut_set():
+    cs = CutSet.from_json('test/fixtures/libri/cuts.json')
+    return CutSet.from_cuts([
+        cs[0],
+        cs[0].with_id('copy-1'),
+        cs[0].with_id('copy-2'),
+        cs[0].append(cs[0])
+    ])
+
+
+def test_single_cut_sampler_shuffling():
+    # The dummy cuts have a duration of 1 second each
+    cut_set = DummyManifest(CutSet, begin_id=0, end_id=100)
+
+    sampler = SingleCutSampler(
+        cut_set,
+        shuffle=True,
+        # Set an effective batch size of 10 cuts, as all have 1s duration == 100 frames
+        # This way we're testing that it works okay when returning multiple batches in
+        # a full epoch.
+        max_frames=1000
+    )
+    sampler_cut_ids = []
+    batches = []
+    for batch in sampler:
+        batches.append(batch)
+        sampler_cut_ids.extend(c.id for c in batch)
+
+    # Invariant 1: we receive the same amount of items in a dataloader epoch as there we in the CutSet
+    assert len(sampler_cut_ids) == len(cut_set)
+    # Invariant 2: the items are not duplicated
+    assert len(set(sampler_cut_ids)) == len(sampler_cut_ids)
+    # Invariant 3: the items are shuffled, i.e. the order is different than that in the CutSet
+    assert sampler_cut_ids != [c.id for c in cut_set]
+
+
+def test_single_cut_sampler_low_max_frames(libri_cut_set):
+    sampler = SingleCutSampler(libri_cut_set, shuffle=False, max_frames=2)
+    # Check that it does not crash
+    for batch in sampler:
+        # There will be only a single item in each batch as we're exceeding the limit each time.
+        assert len(batch) == 1
+
+
+def test_concat_cuts():
+    cuts = [
+        dummy_cut(0, duration=30.0),
+        dummy_cut(1, duration=20.0),
+        dummy_cut(2, duration=10.0),
+        dummy_cut(3, duration=5.0),
+        dummy_cut(4, duration=4.0),
+        dummy_cut(5, duration=3.0),
+        dummy_cut(6, duration=2.0),
+    ]
+    concat = concat_cuts(cuts, gap=1.0)
+    assert [c.duration for c in concat] == [
+        30.0,
+        20.0 + 1.0 + 2.0 + 1.0 + 3.0,  # == 27.0
+        10.0 + 1.0 + 4.0 + 1.0 + 5.0,  # == 21.0
+    ]

--- a/test/dataset/test_speech_recognition_dataset.py
+++ b/test/dataset/test_speech_recognition_dataset.py
@@ -5,7 +5,7 @@ from torch.utils.data import DataLoader
 from lhotse.cut import CutSet
 from lhotse.dataset.sampling import SingleCutSampler
 from lhotse.dataset.speech_recognition import K2SpeechRecognitionIterableDataset
-from lhotse.dataset.transforms import CutCat, CutMix
+from lhotse.dataset.transforms import CutConcatenate, CutMix
 from lhotse.testing.dummies import DummyManifest
 
 
@@ -31,7 +31,7 @@ def test_k2_speech_recognition_iterable_dataset(k2_cut_set, num_workers):
     dataset = K2SpeechRecognitionIterableDataset(
         k2_cut_set,
         sampler=SingleCutSampler(k2_cut_set, shuffle=False),
-        cut_transforms=[CutCat()]
+        cut_transforms=[CutConcatenate()]
     )
     # Note: "batch_size=None" disables the automatic batching mechanism,
     #       which is required when Dataset takes care of the collation itself.
@@ -53,7 +53,7 @@ def test_k2_speech_recognition_iterable_dataset_multiple_workers(k2_cut_set, num
     dataset = K2SpeechRecognitionIterableDataset(
         k2_cut_set,
         sampler=SingleCutSampler(k2_cut_set, shuffle=False),
-        cut_transforms=[CutCat()]
+        cut_transforms=[CutConcatenate()]
     )
     dloader = DataLoader(dataset, batch_size=None, num_workers=num_workers)
 
@@ -87,7 +87,7 @@ def test_k2_speech_recognition_iterable_dataset_shuffling():
             max_frames=1000
         ),
         cut_transforms=[
-            CutCat(),
+            CutConcatenate(),
         ]
     )
     dloader = DataLoader(dataset, batch_size=None, num_workers=2)
@@ -131,7 +131,7 @@ def test_k2_speech_recognition_augmentation(k2_cut_set, k2_noise_cut_set):
         k2_cut_set,
         sampler=SingleCutSampler(k2_cut_set, shuffle=False),
         cut_transforms=[
-            CutCat(),
+            CutConcatenate(),
             CutMix(k2_noise_cut_set)
         ]
     )

--- a/test/dataset/test_speech_recognition_dataset.py
+++ b/test/dataset/test_speech_recognition_dataset.py
@@ -4,7 +4,7 @@ from torch.utils.data import DataLoader
 
 from lhotse.cut import CutSet
 from lhotse.dataset.sampling import SingleCutSampler
-from lhotse.dataset.speech_recognition import K2SpeechRecognitionIterableDataset
+from lhotse.dataset.speech_recognition import K2SpeechRecognitionDataset
 from lhotse.dataset.transforms import CutConcatenate, CutMix
 from lhotse.testing.dummies import DummyManifest
 
@@ -28,14 +28,14 @@ def k2_cut_set(libri_cut_set):
 @pytest.mark.parametrize('num_workers', [0, 1])
 def test_k2_speech_recognition_iterable_dataset(k2_cut_set, num_workers):
     from torch import tensor
-    dataset = K2SpeechRecognitionIterableDataset(
+    dataset = K2SpeechRecognitionDataset(
         k2_cut_set,
-        sampler=SingleCutSampler(k2_cut_set, shuffle=False),
         cut_transforms=[CutConcatenate()]
     )
+    sampler = SingleCutSampler(k2_cut_set, shuffle=False)
     # Note: "batch_size=None" disables the automatic batching mechanism,
     #       which is required when Dataset takes care of the collation itself.
-    dloader = DataLoader(dataset, batch_size=None, num_workers=num_workers)
+    dloader = DataLoader(dataset, batch_size=None, sampler=sampler, num_workers=num_workers)
     batch = next(iter(dloader))
     assert batch['features'].shape == (4, 2000, 40)
     # Each list has 5 items, to account for:
@@ -48,14 +48,13 @@ def test_k2_speech_recognition_iterable_dataset(k2_cut_set, num_workers):
 
 @pytest.mark.parametrize('num_workers', [2, 3, 4])
 def test_k2_speech_recognition_iterable_dataset_multiple_workers(k2_cut_set, num_workers):
-    from torch import tensor
     k2_cut_set = k2_cut_set.pad()
-    dataset = K2SpeechRecognitionIterableDataset(
+    dataset = K2SpeechRecognitionDataset(
         k2_cut_set,
-        sampler=SingleCutSampler(k2_cut_set, shuffle=False),
         cut_transforms=[CutConcatenate()]
     )
-    dloader = DataLoader(dataset, batch_size=None, num_workers=num_workers)
+    sampler = SingleCutSampler(k2_cut_set, shuffle=False)
+    dloader = DataLoader(dataset, batch_size=None, sampler=sampler, num_workers=num_workers)
 
     # We expect a variable number of batches for each parametrized num_workers value,
     # because the dataset is small with 4 cuts that are partitioned across the workers.
@@ -65,32 +64,36 @@ def test_k2_speech_recognition_iterable_dataset_multiple_workers(k2_cut_set, num
     assert features.shape == (4, 2000, 40)
     text = [t for b in batches for t in b['supervisions']['text']]
     assert text == ['EXAMPLE OF TEXT'] * 5  # a list, not tensor
-    start_frame = torch.cat([b['supervisions']['start_frame'] for b in batches])
-    assert (start_frame == tensor([0] * 4 + [1000])).all()
-    num_frames = torch.cat([b['supervisions']['num_frames'] for b in batches])
-    assert (num_frames == tensor([1000] * 5)).all()
+    start_frame = torch.cat([b['supervisions']['start_frame'] for b in batches]).tolist()
+    # The multi-worker dataloader might not preserve order, because the workers
+    # might finish processing in different order. To compare ground truth
+    # start times with actual start times, we need to sort.
+    start_frame = sorted(start_frame)
+    assert start_frame == [0] * 4 + [1000]
+    num_frames = torch.cat([b['supervisions']['num_frames'] for b in batches]).tolist()
+    assert num_frames == [1000] * 5
 
 
 def test_k2_speech_recognition_iterable_dataset_shuffling():
     # The dummy cuts have a duration of 1 second each
     cut_set = DummyManifest(CutSet, begin_id=0, end_id=100)
 
-    dataset = K2SpeechRecognitionIterableDataset(
+    dataset = K2SpeechRecognitionDataset(
         cuts=cut_set,
         return_cuts=True,
-        sampler=SingleCutSampler(
-            cut_set,
-            shuffle=True,
-            # Set an effective batch size of 10 cuts, as all have 1s duration == 100 frames
-            # This way we're testing that it works okay when returning multiple batches in
-            # a full epoch.
-            max_frames=1000
-        ),
         cut_transforms=[
             CutConcatenate(),
         ]
     )
-    dloader = DataLoader(dataset, batch_size=None, num_workers=2)
+    sampler = SingleCutSampler(
+        cut_set,
+        shuffle=True,
+        # Set an effective batch size of 10 cuts, as all have 1s duration == 100 frames
+        # This way we're testing that it works okay when returning multiple batches in
+        # a full epoch.
+        max_frames=1000
+    )
+    dloader = DataLoader(dataset, batch_size=None, sampler=sampler, num_workers=2)
     dloader_cut_ids = []
     batches = []
     for batch in dloader:
@@ -106,11 +109,9 @@ def test_k2_speech_recognition_iterable_dataset_shuffling():
 
 
 def test_k2_speech_recognition_iterable_dataset_low_max_frames(k2_cut_set):
-    dataset = K2SpeechRecognitionIterableDataset(
-        k2_cut_set,
-        sampler=SingleCutSampler(k2_cut_set, shuffle=False, max_frames=2)
-    )
-    dloader = DataLoader(dataset, batch_size=None)
+    dataset = K2SpeechRecognitionDataset(k2_cut_set)
+    sampler = SingleCutSampler(k2_cut_set, shuffle=False, max_frames=2)
+    dloader = DataLoader(dataset, sampler=sampler, batch_size=None)
     # Check that it does not crash
     for batch in dloader:
         # There will be only a single item in each batch as we're exceeding the limit each time.
@@ -127,15 +128,15 @@ def k2_noise_cut_set(libri_cut_set):
 
 
 def test_k2_speech_recognition_augmentation(k2_cut_set, k2_noise_cut_set):
-    dataset = K2SpeechRecognitionIterableDataset(
+    dataset = K2SpeechRecognitionDataset(
         k2_cut_set,
-        sampler=SingleCutSampler(k2_cut_set, shuffle=False),
         cut_transforms=[
             CutConcatenate(),
             CutMix(k2_noise_cut_set)
         ]
     )
-    dloader = DataLoader(dataset, batch_size=None)
+    sampler = SingleCutSampler(k2_cut_set, shuffle=False)
+    dloader = DataLoader(dataset, sampler=sampler, batch_size=None)
     # Check that it does not crash by just running all dataloader iterations
     batches = list(dloader)
     assert len(batches) > 0

--- a/test/dataset/test_speech_recognition_dataset_randomized.py
+++ b/test/dataset/test_speech_recognition_dataset_randomized.py
@@ -3,6 +3,7 @@ from hypothesis import strategies as st
 
 from lhotse import CutSet
 from lhotse.dataset import K2SpeechRecognitionIterableDataset
+from lhotse.dataset.sampling import SingleCutSampler
 from lhotse.testing.fixtures import RandomCutTestCase
 
 
@@ -51,8 +52,12 @@ class TestCollationRandomized(RandomCutTestCase):
         dataset = K2SpeechRecognitionIterableDataset(
             mixed_cuts,
             return_cuts=True,
-            concat_cuts=True,
-            concat_cuts_duration_factor=3.0
+            sampler=SingleCutSampler(
+                mixed_cuts,
+                shuffle=False,
+                concat_cuts=True,
+                concat_cuts_duration_factor=3.0
+            )
         )
         ### End of test data preparation ###
         # Test the invariants

--- a/test/dataset/test_speech_recognition_dataset_randomized.py
+++ b/test/dataset/test_speech_recognition_dataset_randomized.py
@@ -4,7 +4,7 @@ from hypothesis import strategies as st
 from lhotse import CutSet
 from lhotse.dataset import K2SpeechRecognitionIterableDataset
 from lhotse.dataset.sampling import SingleCutSampler
-from lhotse.dataset.transforms import CutCat
+from lhotse.dataset.transforms import CutConcatenate
 from lhotse.testing.fixtures import RandomCutTestCase
 
 
@@ -58,7 +58,7 @@ class TestCollationRandomized(RandomCutTestCase):
                 shuffle=False,
             ),
             cut_transforms=[
-                CutCat(duration_factor=3.0)
+                CutConcatenate(duration_factor=3.0)
             ],
         )
         ### End of test data preparation ###

--- a/test/dataset/test_speech_recognition_dataset_randomized.py
+++ b/test/dataset/test_speech_recognition_dataset_randomized.py
@@ -1,8 +1,9 @@
 from hypothesis import given, settings
 from hypothesis import strategies as st
+from torch.utils.data import DataLoader
 
 from lhotse import CutSet
-from lhotse.dataset import K2SpeechRecognitionIterableDataset
+from lhotse.dataset import K2SpeechRecognitionDataset
 from lhotse.dataset.sampling import SingleCutSampler
 from lhotse.dataset.transforms import CutConcatenate
 from lhotse.testing.fixtures import RandomCutTestCase
@@ -50,20 +51,21 @@ class TestCollationRandomized(RandomCutTestCase):
             ) for idx, (lhs, rhs) in enumerate(zip(cuts, cuts[1:]))
         )
         # Create an ASR dataset
-        dataset = K2SpeechRecognitionIterableDataset(
+        dataset = K2SpeechRecognitionDataset(
             mixed_cuts,
             return_cuts=True,
-            sampler=SingleCutSampler(
-                mixed_cuts,
-                shuffle=False,
-            ),
             cut_transforms=[
                 CutConcatenate(duration_factor=3.0)
             ],
         )
+        sampler = SingleCutSampler(
+            mixed_cuts,
+            shuffle=False,
+        )
+        dloader = DataLoader(dataset, batch_size=None, sampler=sampler)
         ### End of test data preparation ###
         # Test the invariants
-        for batch in dataset:
+        for batch in dloader:
             sups = batch['supervisions']
             cuts = sups['cut']
             for idx, cut in enumerate(cuts):

--- a/test/dataset/test_speech_recognition_dataset_randomized.py
+++ b/test/dataset/test_speech_recognition_dataset_randomized.py
@@ -4,6 +4,7 @@ from hypothesis import strategies as st
 from lhotse import CutSet
 from lhotse.dataset import K2SpeechRecognitionIterableDataset
 from lhotse.dataset.sampling import SingleCutSampler
+from lhotse.dataset.transforms import CutCat
 from lhotse.testing.fixtures import RandomCutTestCase
 
 
@@ -55,9 +56,10 @@ class TestCollationRandomized(RandomCutTestCase):
             sampler=SingleCutSampler(
                 mixed_cuts,
                 shuffle=False,
-                concat_cuts=True,
-                concat_cuts_duration_factor=3.0
-            )
+            ),
+            cut_transforms=[
+                CutCat(duration_factor=3.0)
+            ],
         )
         ### End of test data preparation ###
         # Test the invariants


### PR DESCRIPTION
This is mostly a refactoring PR, that splits the K2SpeechRecognitionIterableDataset into multiple modules with separation of concerns. It's an inverse approach to the "universal dataset" in #172 - instead of one big blob with a lot of hooks, I'm just going to provide multiple components for building "the perfect dataset".

The dataset itself now only takes care of converting a batch CutSet into an actual batch. There is a `CutSampler` abstraction that takes care of multi/distributed processing. Other classes can inherit to specify the filtering behaviour (e.g. what we had so far is now called `SingleCutSampler`, as an example that I'm using in another project I introduced `CutPairSampler` as well). Maybe there is an even cleaner way (no inheritance) to separate the "partitioning" from the "filtering" but I don't have an idea atm.

Finally, the cut concatenation and noise mixing are separate transforms performed on batch CutSets, optionally provided to the dataset's constructor (nobody else is going to be surprised that batch_size of features and supervisions is not the same thing...).

I yet have to test whether the distributed behaviour is correct (needed for multi-GPU training), and create some examples (maybe a notebook) that illustrate this stuff. Preliminary examples of usage can be seen in the tests.