### PR TITLE
Proof of concept for creating K2 FSAs inside the DataLoader processes

### DIFF
--- a/lhotse/dataset/speech_recognition.py
+++ b/lhotse/dataset/speech_recognition.py
@@ -71,7 +71,7 @@ class K2SpeechRecognitionDataset(torch.utils.data.Dataset):
         self.cuts = cuts
         self.return_cuts = return_cuts
         self.cut_transforms = cut_transforms if cut_transforms is not None else ()
-        self.extra_supervision_fn = extra_supervision_fn if extra_supervision_fn is not None else ()
+        self.extra_supervision_fn = extra_supervision_fn
         self._validate()
 
     def __len__(self) -> int:


### PR DESCRIPTION
I'll test it in snowfall when I have more time (if it's needed sooner feel free to take it, just LMK). I think we should disable caching when doing it this way to avoid problems with increasing memory, as each dataloader process will keep its own cache (and I think by default pytorch re-starts the dataloader processes in each epoch, making caching super wasteful in such case).

@danpovey @csukuangfj 