### PR TITLE
Return lengths from feature and token collations

### DIFF
--- a/lhotse/dataset/diarization.py
+++ b/lhotse/dataset/diarization.py
@@ -28,6 +28,7 @@ class DiarizationDataset(Dataset):
 
         {
             'features': (B x T x F) tensor
+            'features_lens': (B, ) tensor
             'speaker_activity': (B x num_speaker x T) tensor
         }
 
@@ -60,8 +61,10 @@ class DiarizationDataset(Dataset):
 
     def __getitem__(self, cut_ids: Iterable[str]) -> Dict[str, torch.Tensor]:
         cuts = self.cuts.subset(cut_ids=cut_ids)
+        features, features_lens = collate_features(cuts)
         return {
-            'features': collate_features(cuts),
+            'features': features,
+            'features_lens': features_lens,
             'speaker_activity': collate_matrices(
                 (cut.speakers_feature_mask(
                     min_speaker_dim=self.min_speaker_dim,

--- a/lhotse/dataset/feature_transforms.py
+++ b/lhotse/dataset/feature_transforms.py
@@ -1,0 +1,16 @@
+import torch
+
+from lhotse import CutSet
+
+
+class Standardize:
+    def __init__(self, cuts: CutSet):
+        stats = cuts.compute_global_feature_stats()
+        self.norm_means = stats["norm_means"]
+        self.norm_stds = stats["norm_stds"]
+
+    def __call__(self, features: torch.Tensor) -> torch.Tensor:
+        return (features - self.norm_means) / self.norm_stds
+
+    def inverse(self, features: torch.Tensor) -> torch.Tensor:
+        return features * self.norm_stds + self.norm_means

--- a/lhotse/dataset/speech_recognition.py
+++ b/lhotse/dataset/speech_recognition.py
@@ -89,7 +89,7 @@ class K2SpeechRecognitionDataset(torch.utils.data.Dataset):
 
         # Get a tensor with batched feature matrices, shape (B, T, F)
         # Collation performs auto-padding, if necessary.
-        features = collate_features(cuts)
+        features, _ = collate_features(cuts)
 
         batch = {
             'features': features,

--- a/lhotse/dataset/speech_synthesis.py
+++ b/lhotse/dataset/speech_synthesis.py
@@ -1,10 +1,10 @@
-from typing import Dict, Iterable
+from typing import Dict, Iterable, Callable, Union, Sequence
 
 import torch
 
 from lhotse import validate
 from lhotse.cut import CutSet
-from lhotse.dataset.collation import collate_audio, collate_features
+from lhotse.dataset.collation import TokenCollater, collate_features, collate_audio
 
 
 class SpeechSynthesisDataset(torch.utils.data.Dataset):
@@ -15,38 +15,61 @@ class SpeechSynthesisDataset(torch.utils.data.Dataset):
     .. code-block::
 
         {
-            'audio': (B x NumSamples) tensor
-            'features': (B x NumFrames x NumFeatures) tensor
-            'tokens': list of lists of characters (str)
+            'audio': (B x NumSamples) float tensor
+            'features': (B x NumFrames x NumFeatures) float tensor
+            'tokens': (B x NumTokens) int tensor
+            'audio_lens': (B, ) int tensor
+            'features_lens': (B, ) int tensor
+            'tokens_lens': (B, ) int tensor
         }
     """
 
-    def __init__(self, cuts: CutSet) -> None:
+    def __init__(
+        self,
+        cuts: CutSet,
+        feature_transforms: Union[Sequence[Callable], Callable] = None,
+        add_eos: bool = True,
+        add_bos: bool = True,
+    ) -> None:
         super().__init__()
-        validate(cuts)
-        self.cuts = cuts
 
-        # generate tokens from text
-        self.cut_id_to_token = {}
-        self.tokens = set()
+        validate(cuts)
         for cut in cuts:
-            assert len(cut.supervisions) == 1, 'Only the Cuts with single supervision are supported.'
-            characters = list(cut.supervisions[0].text)
-            self.tokens.update(set(characters))
-            self.cut_id_to_token[cut.id] = characters
-        self.tokens = sorted(list(self.tokens))
+            assert (
+                len(cut.supervisions) == 1
+            ), "Only the Cuts with single supervision are supported."
+
+        self.cuts = cuts
+        self.token_collater = TokenCollater(cuts, add_eos=add_eos, add_bos=add_bos)
+
+        if feature_transforms is None:
+            feature_transforms = []
+        elif not isinstance(feature_transforms, Sequence):
+            feature_transforms = [feature_transforms]
+
+        assert all(isinstance(transform, Callable) for transform in feature_transforms), \
+            "Feature transforms must be Callable"
+        self.feature_transforms = feature_transforms
 
     def __getitem__(self, cut_ids: Iterable[str]) -> Dict[str, torch.Tensor]:
         cuts = self.cuts.subset(cut_ids=cut_ids)
 
-        features = collate_features(cuts)
-        audio = collate_audio(cuts)
+        audio, audio_lens = collate_audio(cuts)
+        features, features_lens = collate_features(cuts)
+
+        for transform in self.feature_transforms:
+            features = transform(features)
+
+        tokens, tokens_lens = self.token_collater(cuts)
+
         return {
-            'audio': audio,
-            'features': features,
-            # TODO: consider extending the dataset to create a collated tensor of integer token IDs
-            'tokens': [self.cut_id_to_token[cut.id] for cut in cuts]
+            "audio": audio,
+            "features": features,
+            "tokens": tokens,
+            "audio_lens": audio_lens,
+            "features_lens": features_lens,
+            "tokens_lens": tokens_lens,
         }
 
     def __len__(self) -> int:
-        return len(self.cut_ids)
+        return len(self.cuts)

--- a/lhotse/dataset/vad.py
+++ b/lhotse/dataset/vad.py
@@ -15,7 +15,8 @@ class VadDataset(torch.utils.data.Dataset):
     .. code-block::
 
         {
-            'features': (T x F) tensor
+            'features': (B x T x F) tensor
+            'features_lens': (B,) tensor
             'is_voice': (T x 1) tensor
             'cut': List[Cut]
         }
@@ -28,8 +29,10 @@ class VadDataset(torch.utils.data.Dataset):
 
     def __getitem__(self, cut_ids: Iterable[str]) -> Dict[str, torch.Tensor]:
         cuts = self.cuts.subset(cut_ids=cut_ids).sort_by_duration()
+        features, features_lens = collate_features(cuts)
         return {
-            'features': collate_features(cuts),
+            'features': features,
+            'features_lens': features_lens,
             'is_voice': collate_vectors(c.supervisions_feature_mask() for c in cuts),
             'cut': cuts
         }

--- a/lhotse/testing/dummies.py
+++ b/lhotse/testing/dummies.py
@@ -34,13 +34,13 @@ def dummy_recording(unique_id: int) -> Recording:
     )
 
 
-def dummy_supervision(unique_id: int, start: float = 0.0, duration: float = 1.0) -> SupervisionSegment:
+def dummy_supervision(unique_id: int, start: float = 0.0, duration: float = 1.0, text: str = "irrelevant") -> SupervisionSegment:
     return SupervisionSegment(
         id=f'dummy-segment-{unique_id:04d}',
         recording_id=f'dummy-recording-{unique_id:04d}',
         start=start,
         duration=duration,
-        text='irrelevant'
+        text=text
     )
 
 

--- a/test/dataset/test_collation.py
+++ b/test/dataset/test_collation.py
@@ -1,0 +1,42 @@
+import pytest
+
+import torch
+
+from lhotse.dataset.collation import TokenCollater
+from lhotse import CutSet
+from lhotse.testing.dummies import dummy_cut, dummy_supervision
+
+
+@pytest.mark.parametrize('add_bos', [True, False])
+@pytest.mark.parametrize('add_eos', [True, False])
+def test_token_collater(add_bos, add_eos):
+    test_sentences = [
+        "Testing the first sentence.",
+        "Let's add some more punctuation, shall we?",
+        "How about number 42!"
+    ]
+
+    cuts = CutSet.from_cuts(
+        dummy_cut(
+            idx,
+            idx,
+            supervisions=[dummy_supervision(
+                idx, idx, text=sentence
+            )]
+        ) for idx, sentence in enumerate(test_sentences)
+    )
+
+    token_collater = TokenCollater(cuts, add_bos=add_bos, add_eos=add_eos)
+    tokens_batch, tokens_lens = token_collater(cuts)
+
+    assert isinstance(tokens_batch, torch.IntTensor)
+    assert isinstance(tokens_lens, torch.IntTensor)
+
+    extend = int(add_bos) + int(add_eos)
+    expected_len = len(max(test_sentences, key=len)) + extend
+    assert tokens_batch.shape == (len(test_sentences), expected_len)
+    assert torch.all(tokens_lens == torch.IntTensor([len(sentence) + extend for sentence in test_sentences]))
+
+    reconstructed = token_collater.inverse(tokens_batch, tokens_lens)
+    assert reconstructed == test_sentences
+

--- a/test/dataset/test_speech_synthesis_dataset.py
+++ b/test/dataset/test_speech_synthesis_dataset.py
@@ -1,6 +1,8 @@
 import pytest
+import torch
 
 from lhotse.cut import CutSet
+from lhotse.dataset.feature_transforms import Standardize
 from lhotse.dataset.speech_synthesis import SpeechSynthesisDataset
 
 
@@ -9,10 +11,32 @@ def cut_set():
     return CutSet.from_json('test/fixtures/ljspeech/cuts.json')
 
 
-def test_speech_synthesis_dataset(cut_set):
+@pytest.mark.parametrize('transform', [None, Standardize, [Standardize]])
+def test_speech_synthesis_dataset(cut_set, transform):
     ids = cut_set.ids
-    dataset = SpeechSynthesisDataset(cut_set)
+
+    if isinstance(transform, list):
+        transform = [transform[0](cut_set)]
+    elif isinstance(transform, Standardize):
+        transform = transform(cut_set)
+    else:
+        transform = None
+
+    dataset = SpeechSynthesisDataset(cut_set, feature_transforms=transform)
     example = dataset[ids]
     assert example['audio'].shape[1] > 0
     assert example['features'].shape[1] > 0
-    assert len(example['tokens'][0]) > 0
+    assert example['tokens'].shape[1] > 0
+
+    assert example['audio'].ndim == 2
+    assert example['features'].ndim == 3
+    assert example['tokens'].ndim == 2
+
+    assert isinstance(example['audio_lens'], torch.IntTensor)
+    assert isinstance(example['features_lens'], torch.IntTensor)
+    assert isinstance(example['tokens_lens'], torch.IntTensor)
+
+    assert example['audio_lens'].ndim == 1
+    assert example['features_lens'].ndim == 1
+    assert example['tokens_lens'].ndim == 1
+

--- a/test/dataset/test_unsupervised_dataset.py
+++ b/test/dataset/test_unsupervised_dataset.py
@@ -1,3 +1,4 @@
+import torch
 import numpy as np
 import pytest
 
@@ -17,16 +18,17 @@ def test_unsupervised_dataset(libri_cut_set):
     ids = list(libri_cut_set.ids)
     dataset = UnsupervisedDataset(libri_cut_set)
     assert len(dataset) == 1
-    feats = dataset[ids]
-    assert feats.shape == (1, 1000, 40)
+    out = dataset[ids]
+    assert out["features"].shape == (1, 1000, 40)
 
 
 def test_unsupervised_waveform_dataset(libri_cut_set):
     ids = list(libri_cut_set.ids)
     dataset = UnsupervisedWaveformDataset(libri_cut_set)
     assert len(dataset) == 1
-    audio = dataset[ids]
-    assert audio.shape == (1, 10 * 16000)
+    out = dataset[ids]
+    assert out["audio"].shape == (1, 10 * 16000)
+    assert isinstance(out["audio_lens"], torch.IntTensor)
 
 
 def test_on_the_fly_feature_extraction_unsupervised_dataset(libri_cut_set):
@@ -36,7 +38,8 @@ def test_on_the_fly_feature_extraction_unsupervised_dataset(libri_cut_set):
         feature_extractor=Fbank(),
         cuts=libri_cut_set
     )
-    ref_feats = ref_dataset[ids]
+    out = ref_dataset[ids]
+    ref_feats = out["features"]
     tested_feats = tested_dataset[ids]
     # Note: comparison to 1 decimal fails.
     #       I'm assuming this is due to lilcom's compression.


### PR DESCRIPTION
Summary:

* Return feature lengths from collate_features
* Add TokenCollater and corresponding test
* Add Standardize feature transform
* SpeechSynthesisDataset returns lengths for tokens and features
* SpeechSynthesisDataset applies feature transforms after collation
----

Problem: Where to pad features, normalize features, tokenize etc?

Proposal: Use stateful Collate functions that can be passed by user, but are pre-set with reasonable defaults.

Example:
```
collate_features = CollateFeatures(
    pad_mode="reflect",
    normalize_features=StandardizeFeatures(**cuts.compute_global_feature_stats())
)
dataset = SpeechSynthesisDataset(cuts, collate_features=collate_features)
```
Benefits:

1. Stateful collations allow user to pre-configure eg. normalization with pre-computed mean and std without using `partial`
2. More control over padding schemes, tokenization, normalization etc. 
3. Does not bloat already heavy CutSet with additional functionality
4. Allows user to create custom collations
5. Simple enough - can work with simple collation function without any state, can be completely be avoided by user if she is satisfied with the defaults.

More Ideas/Questions:
1. Should collation and online feature augmentation be treated on the same level? (eg they would be passed in a list of callables)I think maybe not, because collation returns also feature lengths
2. Should the normalization be considered online augmentation instead of part of Collation? (probably yes)

More generic suggestion:
```
collate_features = CollateFeatures(
    pad_mode="reflect",
)
transform_features = Transforms(
    StandardizeFeatures(**cuts.compute_global_feature_stats()),
    SpecAugment(some_other_args),
)

dataset = SpeechSynthesisDataset(cuts, collate_features=collate_features, transform_features=transform_features)
```

The tests may fail now, but I will fix that based on reactions to the proposal :)
