### PR TITLE
Refactor Standardize to GlobalMVN

### DIFF
--- a/lhotse/dataset/feature_transforms.py
+++ b/lhotse/dataset/feature_transforms.py
@@ -1,6 +1,6 @@
 import torch
 
-from typing import Union
+from typing import Union, Optional
 
 from lhotse import CutSet
 from lhotse.utils import Pathlike
@@ -11,12 +11,13 @@ class GlobalMVN(torch.nn.Module):
 
     def __init__(self, feature_dim: int):
         super().__init__()
+        self.feature_dim = feature_dim
         self.register_buffer("norm_means", torch.zeros(feature_dim))
         self.register_buffer("norm_stds", torch.ones(feature_dim))
 
     @classmethod
-    def from_cuts(cls, cuts: CutSet) -> "GlobalMVN":
-        stats = cuts.compute_global_feature_stats()
+    def from_cuts(cls, cuts: CutSet, max_cuts: Optional[int] = None) -> "GlobalMVN":
+        stats = cuts.compute_global_feature_stats(max_cuts)
         stats = {name: torch.as_tensor(value) for name, value in stats.items()}
         feature_dim, = stats["norm_means"].shape
         global_mvn = cls(feature_dim)

--- a/lhotse/dataset/feature_transforms.py
+++ b/lhotse/dataset/feature_transforms.py
@@ -1,15 +1,30 @@
 import torch
 
+from typing import Union
+
 from lhotse import CutSet
+from lhotse.utils import Pathlike
 
 
-class Standardize:
-    def __init__(self, cuts: CutSet):
+class GlobalMVN(torch.nn.Module):
+    """Apply global mean and variance normalization"""
+
+    def __init__(self, norm_means, norm_stds):
+        super().__init__()
+        self.register_buffer("norm_means", torch.as_tensor(norm_means))
+        self.register_buffer("norm_stds", torch.as_tensor(norm_stds))
+
+    @classmethod
+    def from_cuts(cls, cuts: CutSet) -> "GlobalMVN":
         stats = cuts.compute_global_feature_stats()
-        self.norm_means = stats["norm_means"]
-        self.norm_stds = stats["norm_stds"]
+        return cls(stats["norm_means"], stats["norm_stds"])
 
-    def __call__(self, features: torch.Tensor) -> torch.Tensor:
+    @classmethod
+    def from_file(cls, stats_file: Pathlike) -> "GlobalMVN":
+        stats = torch.load(stats_file)
+        return cls(stats["norm_means"], stats["norm_stds"])
+
+    def forward(self, features: torch.Tensor) -> torch.Tensor:
         return (features - self.norm_means) / self.norm_stds
 
     def inverse(self, features: torch.Tensor) -> torch.Tensor:

--- a/lhotse/dataset/feature_transforms.py
+++ b/lhotse/dataset/feature_transforms.py
@@ -9,20 +9,30 @@ from lhotse.utils import Pathlike
 class GlobalMVN(torch.nn.Module):
     """Apply global mean and variance normalization"""
 
-    def __init__(self, norm_means, norm_stds):
+    def __init__(self, feature_dim: int):
         super().__init__()
-        self.register_buffer("norm_means", torch.as_tensor(norm_means))
-        self.register_buffer("norm_stds", torch.as_tensor(norm_stds))
+        self.register_buffer("norm_means", torch.zeros(feature_dim))
+        self.register_buffer("norm_stds", torch.ones(feature_dim))
 
     @classmethod
     def from_cuts(cls, cuts: CutSet) -> "GlobalMVN":
         stats = cuts.compute_global_feature_stats()
-        return cls(stats["norm_means"], stats["norm_stds"])
+        stats = {name: torch.as_tensor(value) for name, value in stats.items()}
+        feature_dim, = stats["norm_means"].shape
+        global_mvn = cls(feature_dim)
+        global_mvn.load_state_dict(stats)
+        return global_mvn
 
     @classmethod
     def from_file(cls, stats_file: Pathlike) -> "GlobalMVN":
         stats = torch.load(stats_file)
-        return cls(stats["norm_means"], stats["norm_stds"])
+        feature_dim, = stats["norm_means"].shape
+        global_mvn = cls(feature_dim)
+        global_mvn.load_state_dict(stats)
+        return global_mvn
+
+    def to_file(self, stats_file: Pathlike):
+        torch.save(self.state_dict(), stats_file)
 
     def forward(self, features: torch.Tensor) -> torch.Tensor:
         return (features - self.norm_means) / self.norm_stds

--- a/test/dataset/test_feature_transforms.py
+++ b/test/dataset/test_feature_transforms.py
@@ -1,0 +1,20 @@
+import tempfile
+import torch
+
+from lhotse import CutSet
+from lhotse.dataset.feature_transforms import GlobalMVN
+
+
+def test_global_mvn_initialization_and_stats_saving():
+    cuts = CutSet.from_json('test/fixtures/ljspeech/cuts.json')
+    tf = tempfile.NamedTemporaryFile()
+
+    global_mvn = GlobalMVN.from_cuts(cuts)
+    global_mvn.to_file(tf.name)
+    global_mvn2 = GlobalMVN.from_file(tf.name)
+    tf.close()
+
+    for key_item_1, key_item_2 in zip(global_mvn.state_dict().items(), global_mvn2.state_dict().items()):
+        assert torch.equal(key_item_1[1], key_item_2[1])
+
+

--- a/test/dataset/test_feature_transforms.py
+++ b/test/dataset/test_feature_transforms.py
@@ -1,20 +1,42 @@
 import tempfile
+import pytest
 import torch
 
 from lhotse import CutSet
 from lhotse.dataset.feature_transforms import GlobalMVN
 
 
-def test_global_mvn_initialization_and_stats_saving():
+@pytest.fixture
+def global_mvn():
     cuts = CutSet.from_json('test/fixtures/ljspeech/cuts.json')
-    tf = tempfile.NamedTemporaryFile()
+    return GlobalMVN.from_cuts(cuts)
 
-    global_mvn = GlobalMVN.from_cuts(cuts)
-    global_mvn.to_file(tf.name)
-    global_mvn2 = GlobalMVN.from_file(tf.name)
-    tf.close()
 
-    for key_item_1, key_item_2 in zip(global_mvn.state_dict().items(), global_mvn2.state_dict().items()):
+def test_global_mvn_initialization_and_stats_saving(global_mvn):
+
+    with tempfile.NamedTemporaryFile() as tf:
+        global_mvn.to_file(tf.name)
+        global_mvn2 = GlobalMVN.from_file(tf.name)
+
+    for key_item_1, key_item_2 in zip(
+            global_mvn.state_dict().items(),
+            global_mvn2.state_dict().items()
+    ):
         assert torch.equal(key_item_1[1], key_item_2[1])
 
+
+@pytest.mark.parametrize(
+    "in_tensor", [torch.ones(10, 40), torch.ones(2, 10, 40)]
+)
+def test_global_mvn_shapes(global_mvn, in_tensor):
+    assert global_mvn(in_tensor).shape == in_tensor.shape
+    assert global_mvn.inverse(in_tensor).shape == in_tensor.shape
+
+
+@pytest.mark.parametrize(
+    "in_tensor", [torch.ones(10, 40), torch.ones(2, 10, 40)]
+)
+def test_global_mvn_inverse(global_mvn, in_tensor):
+    out_tensor = global_mvn(in_tensor)
+    assert torch.allclose(in_tensor, global_mvn.inverse(out_tensor))
 

--- a/test/dataset/test_speech_synthesis_dataset.py
+++ b/test/dataset/test_speech_synthesis_dataset.py
@@ -2,7 +2,7 @@ import pytest
 import torch
 
 from lhotse.cut import CutSet
-from lhotse.dataset.feature_transforms import Standardize
+from lhotse.dataset.feature_transforms import GlobalMVN
 from lhotse.dataset.speech_synthesis import SpeechSynthesisDataset
 
 
@@ -11,13 +11,13 @@ def cut_set():
     return CutSet.from_json('test/fixtures/ljspeech/cuts.json')
 
 
-@pytest.mark.parametrize('transform', [None, Standardize, [Standardize]])
+@pytest.mark.parametrize('transform', [None, GlobalMVN, [GlobalMVN]])
 def test_speech_synthesis_dataset(cut_set, transform):
     ids = cut_set.ids
 
     if isinstance(transform, list):
-        transform = [transform[0](cut_set)]
-    elif isinstance(transform, Standardize):
+        transform = [transform[0].from_cuts(cut_set)]
+    elif isinstance(transform, GlobalMVN):
         transform = transform(cut_set)
     else:
         transform = None


### PR DESCRIPTION
Compute stats from CutSet, or load stats from file.
Save stats to disk with `torch.save(global_mvn.state_dict())`.

Standardize is refactored into `GlobalMVN`. It is a torch Module now, so it should be easier to use it as the first layer in neural nets.
It can be initialized `from_cuts` or `from_file` and it internally uses `torch.state_dict` and `torch.load`. Since it accepts mean and std as arguments to init, `Module.load_state_dict` cannot be easily used right now, but it would be nice so any suggestions how to handle this are welcome. It would make the module fully compatible with standard neural layers in pytorch.