### PR TITLE
ASR batch visualisation (features only)

### DIFF
--- a/lhotse/dataset/__init__.py
+++ b/lhotse/dataset/__init__.py
@@ -15,3 +15,4 @@ from .unsupervised import (
     UnsupervisedWaveformDataset
 )
 from .vad import VadDataset
+from .vis import plot_batch

--- a/lhotse/dataset/vis.py
+++ b/lhotse/dataset/vis.py
@@ -1,7 +1,7 @@
 from typing import Any, Mapping
 
 
-def plot_batch(batch: Mapping[str, Any], supervisions: bool = True):
+def plot_batch(batch: Mapping[str, Any], supervisions: bool = True, text=True):
     import matplotlib.pyplot as plt
 
     batch_size = _get_one_of(batch, 'features', 'audio', 'inputs').shape[0]
@@ -12,7 +12,8 @@ def plot_batch(batch: Mapping[str, Any], supervisions: bool = True):
         feat_actors = []
         for idx in range(batch_size):
             feat_actors.append(axes[idx].imshow(feats[idx].numpy().transpose()))
-    fig.colorbar(feat_actors[-1], ax=axes)
+        fig.tight_layout(h_pad=2)
+        fig.colorbar(feat_actors[-1], ax=axes)
 
     if supervisions and 'supervisions' in batch:
         sups = batch['supervisions']
@@ -27,6 +28,8 @@ def plot_batch(batch: Mapping[str, Any], supervisions: bool = True):
                     "Cannot plot supervisions: missing 'start_frame/sample' and 'num_frames/samples' fields."
                 )
             axes[seq_idx].axvspan(start, end, fill=False, edgecolor='red', linestyle='--', linewidth=4)
+            if text and 'text' in sups:
+                axes[seq_idx].text(start, -3, sups['text'][idx])
 
 
 def _get_one_of(d, *keys):

--- a/lhotse/dataset/vis.py
+++ b/lhotse/dataset/vis.py
@@ -1,0 +1,35 @@
+from typing import Any, Mapping
+
+
+def plot_batch(batch: Mapping[str, Any], supervisions: bool = True):
+    import matplotlib.pyplot as plt
+
+    batch_size = _get_one_of(batch, 'features', 'audio', 'inputs').shape[0]
+    fig, axes = plt.subplots(batch_size, figsize=(16, batch_size), sharex=True)
+
+    if 'features' in batch:
+        feats = batch['features']
+        feat_actors = []
+        for idx in range(batch_size):
+            feat_actors.append(axes[idx].imshow(feats[idx].numpy().transpose()))
+    fig.colorbar(feat_actors[-1], ax=axes)
+
+    if supervisions and 'supervisions' in batch:
+        sups = batch['supervisions']
+        for idx in range(len(sups['sequence_idx'])):
+            seq_idx = sups['sequence_idx'][idx]
+            if all(k in sups for k in ('start_frame', 'num_frames')):
+                start, end = sups['start_frame'][idx], sups['start_frame'][idx] + sups['num_frames'][idx]
+            elif all(k in sups for k in ('start_sample', 'num_samples')):
+                start, end = sups['start_sample'][idx], sups['start_sample'][idx] + sups['num_samples'][idx]
+            else:
+                raise ValueError(
+                    "Cannot plot supervisions: missing 'start_frame/sample' and 'num_frames/samples' fields."
+                )
+            axes[seq_idx].axvspan(start, end, fill=False, edgecolor='red', linestyle='--', linewidth=4)
+
+
+def _get_one_of(d, *keys):
+    for k in keys:
+        if k in d:
+            return d[k]


### PR DESCRIPTION
Screenshot time! I already love this.

# Vanilla ASR dataset
<img width="875" alt="image" src="https://user-images.githubusercontent.com/15930688/111402881-614a1100-86a2-11eb-9974-5d4f084a4a82.png">

# Cut concatenation (duration_factor=2)
<img width="1034" alt="image" src="https://user-images.githubusercontent.com/15930688/111402957-83dc2a00-86a2-11eb-8373-247098311c78.png">

# Cut concatenation (duration_factor=3)
<img width="1034" alt="image" src="https://user-images.githubusercontent.com/15930688/111402987-948ca000-86a2-11eb-84a2-374849593d83.png">

# BucketingSampler
<img width="830" alt="image" src="https://user-images.githubusercontent.com/15930688/111403076-bb4ad680-86a2-11eb-8d58-3ae2d26ae679.png">

# BucketingSampler + cut concatenation (duration_factor=2.5)
<img width="964" alt="image" src="https://user-images.githubusercontent.com/15930688/111403106-cdc51000-86a2-11eb-8d15-94caf184ece0.png">

(BTW I clearly have a bug that prevents concatenating to the first sample...)