### PR TITLE
Fix trim_to_supervisions and CLI

### DIFF
--- a/lhotse/bin/modes/features.py
+++ b/lhotse/bin/modes/features.py
@@ -4,7 +4,6 @@ from typing import Optional
 import click
 
 from lhotse.audio import RecordingSet
-from lhotse.augmentation import WavAugmenter, available_wav_augmentations
 from lhotse.bin.modes.cli_base import cli
 from lhotse.features import Fbank, FeatureExtractor, FeatureSetBuilder, create_default_feature_extractor
 from lhotse.features.io import available_storage_backends, get_writer
@@ -29,8 +28,6 @@ def write_default_config(output_config: Pathlike, feature_type: str):
 @feat.command(context_settings=dict(show_default=True))
 @click.argument('recording_manifest', type=click.Path(exists=True, dir_okay=False))
 @click.argument('output_dir', type=click.Path())
-@click.option('-a', '--augmentation', type=click.Choice(available_wav_augmentations()),
-              default=None, help='Optional time-domain data augmentation effect chain to apply.')
 @click.option('-f', '--feature-manifest', type=click.Path(exists=True, dir_okay=False),
               help='Optional manifest specifying feature extractor configuration.')
 @click.option('--storage-type', type=click.Choice(available_storage_backends()),
@@ -45,7 +42,6 @@ def write_default_config(output_config: Pathlike, feature_type: str):
 def extract(
         recording_manifest: Pathlike,
         output_dir: Pathlike,
-        augmentation: str,
         feature_manifest: Optional[Pathlike],
         storage_type: str,
         lilcom_tick_power: int,
@@ -67,18 +63,10 @@ def extract(
     output_dir.mkdir(exist_ok=True, parents=True)
     storage_path = output_dir / 'feats.h5' if 'hdf5' in storage_type else output_dir / 'storage'
 
-    augment_fn = None
-    if augmentation is not None:
-        sampling_rate = next(iter(recordings)).sampling_rate
-        assert all(rec.sampling_rate == sampling_rate for rec in recordings), \
-            "Wav augmentation effect chains expect all the recordings to have the same sampling rate at this time."
-        augment_fn = WavAugmenter.create_predefined(name=augmentation, sampling_rate=sampling_rate)
-
     with get_writer(storage_type)(storage_path, tick_power=lilcom_tick_power) as storage:
         feature_set_builder = FeatureSetBuilder(
             feature_extractor=feature_extractor,
             storage=storage,
-            augment_fn=augment_fn
         )
         feature_set_builder.process_and_store_recordings(
             recordings=recordings,

--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -406,9 +406,11 @@ class Cut(CutUtilsMixin):
             # of Intervals that contain the SupervisionSegments matching our criterion.
             # We call "interval.data" to obtain the underlying SupervisionSegment.
             match_supervisions = tree.overlap if keep_excessive_supervisions else tree.envelop
+            from lhotse.utils import TimeSpan, measure_overlap
             supervisions = [
                 interval.data.with_offset(-offset)
                 for interval in match_supervisions(begin=offset, end=offset + new_duration)
+                if measure_overlap(interval.data, TimeSpan(new_start, new_start + new_duration)) > 0.01
             ]
 
         return Cut(

--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -24,7 +24,7 @@ from lhotse.features.mixer import NonPositiveEnergyError
 from lhotse.supervision import SupervisionSegment, SupervisionSet
 from lhotse.utils import (Decibels, JsonMixin, LOG_EPSILON, Pathlike, Seconds, TimeSpan, YamlMixin, asdict_nonull,
                           compute_num_frames, compute_num_samples, exactly_one_not_null, fastcopy,
-                          index_by_id_and_check, overlaps,
+                          index_by_id_and_check, measure_overlap, overlaps,
                           overspans, perturb_num_samples, split_sequence, uuid4)
 
 # One of the design principles for Cuts is a maximally "lazy" implementation, e.g. when mixing Cuts,
@@ -406,7 +406,6 @@ class Cut(CutUtilsMixin):
             # of Intervals that contain the SupervisionSegments matching our criterion.
             # We call "interval.data" to obtain the underlying SupervisionSegment.
             match_supervisions = tree.overlap if keep_excessive_supervisions else tree.envelop
-            from lhotse.utils import TimeSpan, measure_overlap
             supervisions = []
             for interval in match_supervisions(begin=offset, end=offset + new_duration):
                 # We are going to measure the overlap ratio of the supervision with the "truncated" cut

--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -411,9 +411,9 @@ class Cut(CutUtilsMixin):
             for interval in match_supervisions(begin=offset, end=offset + new_duration):
                 # We are going to measure the overlap ratio of the supervision with the "truncated" cut
                 # and reject segments that overlap less than 1%. This way we can avoid quirks and errors
-                # of limited floaat precision.
+                # of limited float precision.
                 olap_ratio = measure_overlap(interval.data, TimeSpan(new_start, new_start + new_duration))
-                if olap_ratio == 0 or olap_ratio > 0.01:
+                if olap_ratio > 0.01:
                     supervisions.append(interval.data.with_offset(-offset))
 
         return Cut(

--- a/lhotse/supervision.py
+++ b/lhotse/supervision.py
@@ -216,7 +216,7 @@ class SupervisionSet(JsonMixin, YamlMixin, Sequence[SupervisionSegment]):
             # We only modify the offset - the duration remains the same, as we're only shifting the segment
             # relative to the Cut's start, and not truncating anything.
             segment.with_offset(-start_after) if adjust_offset else segment
-            for segment in segment_by_recording_id[recording_id]
+            for segment in segment_by_recording_id.get(recording_id, [])
             if (channel is None or segment.channel == channel)
                and segment.start >= start_after
                and (end_before is None or segment.end <= end_before)

--- a/lhotse/utils.py
+++ b/lhotse/utils.py
@@ -447,3 +447,17 @@ def is_module_available(*modules: str) -> bool:
     """
     import importlib
     return all(importlib.util.find_spec(m) is not None for m in modules)
+
+
+def measure_overlap(lhs: Any, rhs: Any) -> float:
+    """
+    Given two objects with "start" and "end" attributes, return the % of their overlapped time
+    with regard to the shorter of the two spans.
+    ."""
+    lhs, rhs = sorted([lhs, rhs], key=lambda item: item.start)
+    overlapped_area = lhs.end - rhs.start
+    if overlapped_area <= 0:
+        return 0.
+    dur = min(lhs.end - lhs.start, rhs.end - rhs.start)
+    return overlapped_area / dur
+


### PR DESCRIPTION
This addresses an issue where `cut_set.trim_to_supervisions()` would produce cuts that contain non-overlapping supervisions due to float precision errors when adding offsets and durations. 