### PR TITLE
Support for auto-magically determined serializers (CLI + Python API)

### DIFF
--- a/lhotse/__init__.py
+++ b/lhotse/__init__.py
@@ -12,7 +12,7 @@ from .cut import Cut, CutSet
 from .features import *
 from .kaldi import load_kaldi_data_dir
 from .manipulation import combine, to_manifest
-from .serialization import load_manifest
+from .serialization import load_manifest, store_manifest
 from .supervision import SupervisionSegment, SupervisionSet
 from .qa import validate, validate_recordings_and_supervisions
 

--- a/lhotse/bin/modes/cut.py
+++ b/lhotse/bin/modes/cut.py
@@ -30,7 +30,7 @@ def cut():
               help='Optional recording manifest - will be used to attach the recordings to the cuts.')
 @click.option('-f', '--feature-manifest', type=click.Path(exists=True, dir_okay=False),
               help='Optional feature manifest - will be used to attach the features to the cuts.')
-@click.option('-s', '--supervision_manifest', type=click.Path(exists=True, dir_okay=False),
+@click.option('-s', '--supervision-manifest', type=click.Path(exists=True, dir_okay=False),
               help='Optional supervision manifest - will be used to attach the supervisions to the cuts.')
 def simple(
         output_cut_manifest: Pathlike,
@@ -50,7 +50,7 @@ def simple(
         for p in (supervision_manifest, feature_manifest, recording_manifest)
     ]
     cut_set = CutSet.from_manifests(recordings=recording_set, supervisions=supervision_set, features=feature_set)
-    cut_set.to_json(output_cut_manifest)
+    cut_set.to_file(output_cut_manifest)
 
 
 @cut.command()
@@ -80,7 +80,7 @@ def windowed(
         cut_shift=cut_shift,
         keep_shorter_windows=keep_shorter_windows
     )
-    cut_set.to_json(output_cut_manifest)
+    cut_set.to_file(output_cut_manifest)
 
 
 @cut.command()
@@ -122,7 +122,7 @@ def random_mixed(
         )
         for left_cut, right_cut, snr, relative_offset in zip(left_cuts, right_cuts, snrs, relative_offsets)
     )
-    mixed_cut_set.to_json(output_cut_manifest)
+    mixed_cut_set.to_file(output_cut_manifest)
 
 
 @cut.command()
@@ -140,7 +140,7 @@ def mix_sequential(
     """
     cut_manifests = [CutSet.from_json(path) for path in cut_manifests]
     mixed_cut_set = CutSet.from_cuts(mix_cuts(cuts) for cuts in zip(*cut_manifests))
-    mixed_cut_set.to_json(output_cut_manifest)
+    mixed_cut_set.to_file(output_cut_manifest)
 
 
 @cut.command()
@@ -157,7 +157,7 @@ def mix_by_recording_id(
     all_cuts = combine(*[CutSet.from_json(path) for path in cut_manifests])
     recording_id_to_cuts = groupby(lambda cut: cut.recording_id, all_cuts)
     mixed_cut_set = CutSet.from_cuts(mix_cuts(cuts) for recording_id, cuts in recording_id_to_cuts.items())
-    mixed_cut_set.to_json(output_cut_manifest)
+    mixed_cut_set.to_file(output_cut_manifest)
 
 
 @cut.command(context_settings=dict(show_default=True))
@@ -185,14 +185,14 @@ def truncate(
     Truncate the cuts in the CUT_MANIFEST and write them to OUTPUT_CUT_MANIFEST.
     Cuts shorter than MAX_DURATION will not be modified.
     """
-    cut_set = CutSet.from_json(cut_manifest)
+    cut_set = CutSet.from_file(cut_manifest)
     truncated_cut_set = cut_set.truncate(
         max_duration=max_duration,
         offset_type=offset_type,
         keep_excessive_supervisions=keep_overflowing_supervisions,
         preserve_id=preserve_id
     )
-    truncated_cut_set.to_json(output_cut_manifest)
+    truncated_cut_set.to_file(output_cut_manifest)
 
 
 @cut.command()
@@ -209,9 +209,9 @@ def append(
     input argument list.
     If CUT_MANIFESTS have different lengths, the script stops once the shortest CutSet is depleted.
     """
-    cut_sets = [CutSet.from_json(path) for path in cut_manifests]
+    cut_sets = [CutSet.from_file(path) for path in cut_manifests]
     appended_cut_set = CutSet.from_cuts(append_cuts(cuts) for cuts in zip(*cut_sets))
-    appended_cut_set.to_json(output_cut_manifest)
+    appended_cut_set.to_file(output_cut_manifest)
 
 
 @cut.command()
@@ -230,6 +230,6 @@ def pad(
     Create a new CutSet by padding the cuts in CUT_MANIFEST. The cuts will be right-padded, i.e. the padding
     is placed after the signal ends.
     """
-    cut_set = CutSet.from_json(cut_manifest)
+    cut_set = CutSet.from_file(cut_manifest)
     padded_cut_set = cut_set.pad(desired_duration=duration)
-    padded_cut_set.to_json(output_cut_manifest)
+    padded_cut_set.to_file(output_cut_manifest)

--- a/lhotse/bin/modes/kaldi.py
+++ b/lhotse/bin/modes/kaldi.py
@@ -26,9 +26,9 @@ def import_(data_dir: Pathlike, sampling_rate: int, manifest_dir: Pathlike):
     recording_set, maybe_supervision_set = load_kaldi_data_dir(path=data_dir, sampling_rate=sampling_rate)
     manifest_dir = Path(manifest_dir)
     manifest_dir.mkdir(parents=True, exist_ok=True)
-    recording_set.to_json(manifest_dir / 'audio.json')
+    recording_set.to_file(manifest_dir / 'audio.jsonl')
     if maybe_supervision_set is not None:
-        maybe_supervision_set.to_json(manifest_dir / 'supervision.json')
+        maybe_supervision_set.to_file(manifest_dir / 'supervision.jsonl')
 
 
 @kaldi.command()

--- a/lhotse/features/base.py
+++ b/lhotse/features/base.py
@@ -620,7 +620,7 @@ class FeatureSetBuilder:
                     )
                 )
         if output_manifest is not None:
-            feature_set.to_json(output_manifest)
+            feature_set.to_file(output_manifest)
         return feature_set
 
     def _process_and_store_recording(

--- a/lhotse/serialization.py
+++ b/lhotse/serialization.py
@@ -1,23 +1,25 @@
 import gzip
 import json
 from pathlib import Path
-from typing import Any, Dict, Generator, Iterable, Union
+from typing import Any, Dict, Generator, Iterable, Optional, Type, Union
 
 import yaml
 
 from lhotse.utils import Pathlike
 
+Manifest = Union['RecordingSet', 'SupervisionSet', 'FeatureSet', 'CutSet']
 
-def save_to_yaml(data: Any, path: Pathlike):
+
+def save_to_yaml(data: Any, path: Pathlike) -> None:
     compressed = str(path).endswith('.gz')
     opener = gzip.open if compressed else open
     mode = 'wt' if compressed else 'w'
     with opener(path, mode) as f:
         try:
             # When pyyaml is installed with C extensions, it can speed up the (de)serialization noticeably
-            return yaml.dump(data, stream=f, Dumper=yaml.CSafeDumper)
+            yaml.dump(data, stream=f, Dumper=yaml.CSafeDumper)
         except AttributeError:
-            return yaml.dump(data, stream=f, Dumper=yaml.SafeDumper)
+            yaml.dump(data, stream=f, Dumper=yaml.SafeDumper)
 
 
 def load_yaml(path: Pathlike) -> dict:
@@ -31,22 +33,22 @@ def load_yaml(path: Pathlike) -> dict:
 
 
 class YamlMixin:
-    def to_yaml(self, path: Pathlike):
+    def to_yaml(self, path: Pathlike) -> None:
         save_to_yaml(self.to_dicts(), path)
 
     @classmethod
-    def from_yaml(cls, path: Pathlike):
+    def from_yaml(cls, path: Pathlike) -> Manifest:
         data = load_yaml(path)
         return cls.from_dicts(data)
 
 
-def save_to_json(data: Any, path: Pathlike):
+def save_to_json(data: Any, path: Pathlike) -> None:
     """Save the data to a JSON file. Will use GZip to compress it if the path ends with a ``.gz`` extension."""
     compressed = str(path).endswith('.gz')
     opener = gzip.open if compressed else open
     mode = 'wt' if compressed else 'w'
     with opener(path, mode) as f:
-        return json.dump(data, f, indent=2)
+        json.dump(data, f, indent=2)
 
 
 def load_json(path: Pathlike) -> Union[dict, list]:
@@ -57,16 +59,16 @@ def load_json(path: Pathlike) -> Union[dict, list]:
 
 
 class JsonMixin:
-    def to_json(self, path: Pathlike):
+    def to_json(self, path: Pathlike) -> None:
         save_to_json(self.to_dicts(), path)
 
     @classmethod
-    def from_json(cls, path: Pathlike):
+    def from_json(cls, path: Pathlike) -> Manifest:
         data = load_json(path)
         return cls.from_dicts(data)
 
 
-def save_to_jsonl(data: Iterable[Dict[str, Any]], path: Pathlike):
+def save_to_jsonl(data: Iterable[Dict[str, Any]], path: Pathlike) -> None:
     """Save the data to a JSON file. Will use GZip to compress it if the path ends with a ``.gz`` extension."""
     compressed = str(path).endswith('.gz')
     opener = gzip.open if compressed else open
@@ -87,11 +89,11 @@ def load_jsonl(path: Pathlike) -> Generator[Dict[str, Any], None, None]:
 
 
 class JsonlMixin:
-    def to_jsonl(self, path: Pathlike):
+    def to_jsonl(self, path: Pathlike) -> None:
         save_to_jsonl(self.to_dicts(), path)
 
     @classmethod
-    def from_jsonl(cls, path: Pathlike):
+    def from_jsonl(cls, path: Pathlike) -> Manifest:
         data = load_jsonl(path)
         return cls.from_dicts(data)
 
@@ -100,13 +102,20 @@ def extension_contains(ext: str, path: Path) -> bool:
     return any(ext == sfx for sfx in path.suffixes)
 
 
-def load_manifest(path: Pathlike):
+def load_manifest(path: Pathlike, manifest_cls: Optional[Type] = None) -> Manifest:
     """Generic utility for reading an arbitrary manifest."""
     from lhotse import CutSet, FeatureSet, RecordingSet, SupervisionSet
+    # Determine the serialization format and read the raw data.
     path = Path(path)
     assert path.is_file(), f'No such path: {path}'
     if extension_contains('.jsonl', path):
         raw_data = load_jsonl(path)
+        if manifest_cls is None:
+            # Note: for now, we need to load the whole JSONL rather than read it in
+            # a streaming way, because we have no way to know which type of manifest
+            # we should decode later; since we're consuming the underlying generator
+            # each time we try, not materializing the list first could lead to data loss
+            raw_data = list(raw_data)
     elif extension_contains('.json', path):
         raw_data = load_json(path)
     elif extension_contains('.yaml', path):
@@ -114,9 +123,17 @@ def load_manifest(path: Pathlike):
     else:
         raise ValueError(f"Not a valid manifest: {path}")
     data_set = None
-    for manifest_type in [RecordingSet, SupervisionSet, FeatureSet, CutSet]:
+
+    # The parse the raw data into Lhotse's data structures.
+    # If the user provided a "type hint", use it; otherwise we will try to guess it.
+    if manifest_cls is not None:
+        candidates = [manifest_cls]
+    else:
+        candidates = [RecordingSet, SupervisionSet, FeatureSet, CutSet]
+    for manifest_type in candidates:
         try:
             data_set = manifest_type.from_dicts(raw_data)
+            break
         except Exception:
             pass
     if data_set is None:
@@ -124,5 +141,22 @@ def load_manifest(path: Pathlike):
     return data_set
 
 
+def store_manifest(manifest: Manifest, path: Pathlike) -> None:
+    path = Path(path)
+    if extension_contains('.jsonl', path):
+        manifest.to_jsonl(path)
+    elif extension_contains('.json', path):
+        manifest.to_json(path)
+    elif extension_contains('.yaml', path):
+        manifest.to_yaml(path)
+    else:
+        raise ValueError(f"Unknown serialization format for: {path}")
+
+
 class Serializable(JsonMixin, JsonlMixin, YamlMixin):
-    pass
+    @classmethod
+    def from_file(cls, path: Pathlike) -> Manifest:
+        return load_manifest(path, manifest_cls=cls)
+
+    def to_file(self, path: Pathlike) -> None:
+        store_manifest(self, path)

--- a/lhotse/serialization.py
+++ b/lhotse/serialization.py
@@ -7,7 +7,9 @@ import yaml
 
 from lhotse.utils import Pathlike
 
-Manifest = Union['RecordingSet', 'SupervisionSet', 'FeatureSet', 'CutSet']
+# TODO: figure out how to use some sort of typing stubs
+#  so that linters/static checkers don't complain
+Manifest = Any  # Union['RecordingSet', 'SupervisionSet', 'FeatureSet', 'CutSet']
 
 
 def save_to_yaml(data: Any, path: Pathlike) -> None:

--- a/test/cut/test_cut_set.py
+++ b/test/cut/test_cut_set.py
@@ -46,51 +46,6 @@ def test_cut_set_holds_both_simple_and_mixed_cuts(cut_set_with_mixed_cut):
     assert len(mixed_cuts) == 1
 
 
-@pytest.mark.parametrize(
-    ['format', 'compressed'],
-    [
-        ('yaml', False),
-        ('yaml', True),
-        ('json', False),
-        ('json', True),
-        ('jsonl', False),
-        ('jsonl', True),
-    ]
-)
-def test_simple_cut_set_serialization(cut_set, format, compressed):
-    with NamedTemporaryFile(suffix='.gz' if compressed else '') as f:
-        if format == 'yaml':
-            cut_set.to_yaml(f.name)
-            restored = CutSet.from_yaml(f.name)
-        if format == 'json':
-            cut_set.to_json(f.name)
-            restored = CutSet.from_json(f.name)
-        if format == 'jsonl':
-            cut_set.to_jsonl(f.name)
-            restored = CutSet.from_jsonl(f.name)
-    assert cut_set == restored
-
-
-@pytest.mark.parametrize(
-    ['format', 'compressed'],
-    [
-        ('yaml', False),
-        ('yaml', True),
-        ('json', False),
-        ('json', True),
-    ]
-)
-def test_mixed_cut_set_serialization(cut_set_with_mixed_cut, format, compressed):
-    with NamedTemporaryFile(suffix='.gz' if compressed else '') as f:
-        if format == 'yaml':
-            cut_set_with_mixed_cut.to_yaml(f.name)
-            restored = CutSet.from_yaml(f.name)
-        if format == 'json':
-            cut_set_with_mixed_cut.to_json(f.name)
-            restored = CutSet.from_json(f.name)
-    assert cut_set_with_mixed_cut == restored
-
-
 def test_filter_cut_set(cut_set, cut1):
     filtered = cut_set.filter(lambda cut: cut.id == 'cut-1')
     assert len(filtered) == 1

--- a/test/test_feature_set.py
+++ b/test/test_feature_set.py
@@ -52,49 +52,6 @@ def test_feature_extractor_generic_deserialization():
     assert fe_deserialized.config == fe.config
 
 
-@pytest.mark.parametrize(
-    ['format', 'compressed'],
-    [
-        ('yaml', False),
-        ('yaml', True),
-        ('json', False),
-        ('json', True),
-        ('jsonl', False),
-        ('jsonl', True),
-    ]
-)
-def test_feature_set_serialization(format, compressed):
-    feature_set = FeatureSet(
-        features=[
-            Features(
-                recording_id='irrelevant',
-                channels=0,
-                start=0.0,
-                duration=20.0,
-                type='fbank',
-                num_frames=2000,
-                num_features=20,
-                frame_shift=0.01,
-                sampling_rate=16000,
-                storage_type='lilcom',
-                storage_path='/irrelevant/',
-                storage_key='path.llc'
-            )
-        ]
-    )
-    with NamedTemporaryFile(suffix='.gz' if compressed else '') as f:
-        if format == 'jsonl':
-            feature_set.to_jsonl(f.name)
-            feature_set_deserialized = FeatureSet.from_jsonl(f.name)
-        if format == 'json':
-            feature_set.to_json(f.name)
-            feature_set_deserialized = FeatureSet.from_json(f.name)
-        if format == 'yaml':
-            feature_set.to_yaml(f.name)
-            feature_set_deserialized = FeatureSet.from_yaml(f.name)
-    assert feature_set_deserialized == feature_set
-
-
 @mark.parametrize(
     ['recording_id', 'channel', 'start', 'duration', 'exception_expectation', 'expected_num_frames'],
     [

--- a/test/test_manipulation.py
+++ b/test/test_manipulation.py
@@ -1,13 +1,12 @@
 import pytest
-from pytest import mark, raises
+from pytest import mark
 
-from lhotse import CutSet, load_manifest
+from lhotse import CutSet
 from lhotse.audio import RecordingSet
 from lhotse.features import FeatureSet
 from lhotse.manipulation import combine
 from lhotse.supervision import SupervisionSet
 from lhotse.testing.dummies import DummyManifest
-from lhotse.utils import nullcontext as does_not_raise
 
 
 @mark.parametrize('manifest_type', [RecordingSet, SupervisionSet, FeatureSet, CutSet])
@@ -63,22 +62,6 @@ def test_combine(manifest_type):
         DummyManifest(manifest_type, begin_id=136, end_id=200),
     ])
     assert combined_iterable == expected
-
-
-@mark.parametrize(
-    ['path', 'exception_expectation'],
-    [
-        ('test/fixtures/audio.json', does_not_raise()),
-        ('test/fixtures/supervision.json', does_not_raise()),
-        ('test/fixtures/dummy_feats/feature_manifest.json', does_not_raise()),
-        ('test/fixtures/libri/cuts.json', does_not_raise()),
-        ('test/fixtures/feature_config.yml', raises(ValueError)),
-        ('no/such/path.xd', raises(AssertionError)),
-    ]
-)
-def test_load_any_lhotse_manifest(path, exception_expectation):
-    with exception_expectation:
-        load_manifest(path)
 
 
 @mark.parametrize('manifest_type', [RecordingSet, SupervisionSet, FeatureSet, CutSet])

--- a/test/test_recording_set.py
+++ b/test/test_recording_set.py
@@ -1,5 +1,4 @@
 from functools import lru_cache
-from tempfile import NamedTemporaryFile
 
 import numpy as np
 import pytest
@@ -51,51 +50,6 @@ def test_get_metadata(recording_set):
     assert 8000 == recording_set.sampling_rate('recording-1')
     assert 4000 == recording_set.num_samples('recording-1')
     assert 0.5 == recording_set.duration('recording-1')
-
-
-@pytest.mark.parametrize(
-    ['format', 'compressed'],
-    [
-        ('yaml', False),
-        ('yaml', True),
-        ('json', False),
-        ('json', True),
-        ('jsonl', False),
-        ('jsonl', True),
-    ]
-)
-def test_serialization(format, compressed):
-    recording_set = RecordingSet.from_recordings([
-        Recording(
-            id='x',
-            sources=[
-                AudioSource(
-                    type='file',
-                    channels=[0],
-                    source='text/fixtures/mono_c0.wav'
-                ),
-                AudioSource(
-                    type='command',
-                    channels=[1],
-                    source='cat text/fixtures/mono_c1.wav'
-                )
-            ],
-            sampling_rate=8000,
-            num_samples=4000,
-            duration=0.5
-        )
-    ])
-    with NamedTemporaryFile(suffix='.gz' if compressed else '') as f:
-        if format == 'jsonl':
-            recording_set.to_jsonl(f.name)
-            deserialized = RecordingSet.from_jsonl(f.name)
-        if format == 'yaml':
-            recording_set.to_yaml(f.name)
-            deserialized = RecordingSet.from_yaml(f.name)
-        if format == 'json':
-            recording_set.to_json(f.name)
-            deserialized = RecordingSet.from_json(f.name)
-    assert deserialized == recording_set
 
 
 def test_iteration(recording_set):

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -1,0 +1,287 @@
+from tempfile import NamedTemporaryFile
+
+import pytest
+
+from lhotse import AudioSource, Cut, CutSet, FeatureSet, Features, Recording, RecordingSet, SupervisionSegment, \
+    SupervisionSet, load_manifest, store_manifest
+from lhotse.utils import nullcontext as does_not_raise
+
+
+@pytest.mark.parametrize(
+    ['path', 'exception_expectation'],
+    [
+        ('test/fixtures/audio.json', does_not_raise()),
+        ('test/fixtures/supervision.json', does_not_raise()),
+        ('test/fixtures/dummy_feats/feature_manifest.json', does_not_raise()),
+        ('test/fixtures/libri/cuts.json', does_not_raise()),
+        ('test/fixtures/feature_config.yml', pytest.raises(ValueError)),
+        ('no/such/path.xd', pytest.raises(AssertionError)),
+    ]
+)
+def test_load_any_lhotse_manifest(path, exception_expectation):
+    with exception_expectation:
+        load_manifest(path)
+
+
+@pytest.fixture
+def recording_set():
+    return RecordingSet.from_recordings([
+        Recording(
+            id='x',
+            sources=[
+                AudioSource(
+                    type='file',
+                    channels=[0],
+                    source='text/fixtures/mono_c0.wav'
+                ),
+                AudioSource(
+                    type='command',
+                    channels=[1],
+                    source='cat text/fixtures/mono_c1.wav'
+                )
+            ],
+            sampling_rate=8000,
+            num_samples=4000,
+            duration=0.5
+        )
+    ])
+
+
+@pytest.fixture
+def supervision_set():
+    return SupervisionSet.from_segments([
+        SupervisionSegment(
+            id='segment-1',
+            recording_id='recording-1',
+            channel=0,
+            start=0.1,
+            duration=0.3,
+            text='transcript of the first segment',
+            language='english',
+            speaker='Norman Dyhrentfurth',
+            gender='male'
+        )
+    ])
+
+
+@pytest.fixture
+def feature_set():
+    return FeatureSet(
+        features=[
+            Features(
+                recording_id='irrelevant',
+                channels=0,
+                start=0.0,
+                duration=20.0,
+                type='fbank',
+                num_frames=2000,
+                num_features=20,
+                frame_shift=0.01,
+                sampling_rate=16000,
+                storage_type='lilcom',
+                storage_path='/irrelevant/',
+                storage_key='path.llc'
+            )
+        ]
+    )
+
+
+@pytest.fixture
+def cut_set():
+    cut = Cut(
+        id='cut-1',
+        start=0.0,
+        duration=10.0,
+        channel=0,
+        features=Features(
+            type='fbank',
+            num_frames=100,
+            num_features=40,
+            frame_shift=0.01,
+            sampling_rate=16000,
+            start=0.0,
+            duration=10.0,
+            storage_type='lilcom',
+            storage_path='irrelevant',
+            storage_key='irrelevant',
+        ),
+        recording=Recording(
+            id='rec-1',
+            sampling_rate=16000,
+            num_samples=160000,
+            duration=10.0,
+            sources=[
+                AudioSource(
+                    type='file',
+                    channels=[0],
+                    source='irrelevant'
+                )
+            ]
+        ),
+        supervisions=[
+            SupervisionSegment(id='sup-1', recording_id='irrelevant', start=0.5, duration=6.0),
+            SupervisionSegment(id='sup-2', recording_id='irrelevant', start=7.0, duration=2.0)
+        ])
+    return CutSet.from_cuts([
+        cut,
+        cut.pad(duration=30.0, direction='left'),
+        cut.pad(duration=30.0, direction='right'),
+        cut.pad(duration=30.0, direction='both'),
+        cut.mix(cut, offset_other_by=5.0, snr=8)
+    ])
+
+
+@pytest.mark.parametrize(
+    ['format', 'compressed'],
+    [
+        ('yaml', False),
+        ('yaml', True),
+        ('json', False),
+        ('json', True),
+        ('jsonl', False),
+        ('jsonl', True),
+    ]
+)
+def test_feature_set_serialization(feature_set, format, compressed):
+    with NamedTemporaryFile(suffix='.gz' if compressed else '') as f:
+        if format == 'jsonl':
+            feature_set.to_jsonl(f.name)
+            feature_set_deserialized = FeatureSet.from_jsonl(f.name)
+        if format == 'json':
+            feature_set.to_json(f.name)
+            feature_set_deserialized = FeatureSet.from_json(f.name)
+        if format == 'yaml':
+            feature_set.to_yaml(f.name)
+            feature_set_deserialized = FeatureSet.from_yaml(f.name)
+    assert feature_set_deserialized == feature_set
+
+
+@pytest.mark.parametrize(
+    ['format', 'compressed'],
+    [
+        ('yaml', False),
+        ('yaml', True),
+        ('json', False),
+        ('json', True),
+        ('jsonl', False),
+        ('jsonl', True),
+    ]
+)
+def test_serialization(recording_set, format, compressed):
+    with NamedTemporaryFile(suffix='.gz' if compressed else '') as f:
+        if format == 'jsonl':
+            recording_set.to_jsonl(f.name)
+            deserialized = RecordingSet.from_jsonl(f.name)
+        if format == 'yaml':
+            recording_set.to_yaml(f.name)
+            deserialized = RecordingSet.from_yaml(f.name)
+        if format == 'json':
+            recording_set.to_json(f.name)
+            deserialized = RecordingSet.from_json(f.name)
+    assert deserialized == recording_set
+
+
+@pytest.mark.parametrize(
+    ['format', 'compressed'],
+    [
+        ('yaml', False),
+        ('yaml', True),
+        ('json', False),
+        ('json', True),
+        ('jsonl', False),
+        ('jsonl', True),
+    ]
+)
+def test_supervision_set_serialization(supervision_set, format, compressed):
+    with NamedTemporaryFile(suffix='.gz' if compressed else '') as f:
+        if format == 'yaml':
+            supervision_set.to_yaml(f.name)
+            restored = supervision_set.from_yaml(f.name)
+        if format == 'json':
+            supervision_set.to_json(f.name)
+            restored = supervision_set.from_json(f.name)
+        if format == 'jsonl':
+            supervision_set.to_jsonl(f.name)
+            restored = supervision_set.from_jsonl(f.name)
+    assert supervision_set == restored
+
+
+@pytest.mark.parametrize(
+    ['format', 'compressed'],
+    [
+        ('yaml', False),
+        ('yaml', True),
+        ('json', False),
+        ('json', True),
+        ('jsonl', False),
+        ('jsonl', True),
+    ]
+)
+def test_cut_set_serialization(cut_set, format, compressed):
+    with NamedTemporaryFile(suffix='.gz' if compressed else '') as f:
+        if format == 'yaml':
+            cut_set.to_yaml(f.name)
+            restored = CutSet.from_yaml(f.name)
+        if format == 'json':
+            cut_set.to_json(f.name)
+            restored = CutSet.from_json(f.name)
+        if format == 'jsonl':
+            cut_set.to_jsonl(f.name)
+            restored = CutSet.from_jsonl(f.name)
+    assert cut_set == restored
+
+
+@pytest.fixture
+def manifests(recording_set, supervision_set, feature_set, cut_set):
+    return {
+        'recording_set': recording_set,
+        'supervision_set': supervision_set,
+        'feature_set': feature_set,
+        'cut_set': cut_set
+    }
+
+
+@pytest.mark.parametrize(
+    'manifest_type',
+    ['recording_set', 'supervision_set', 'feature_set', 'cut_set']
+)
+@pytest.mark.parametrize(
+    ['format', 'compressed'],
+    [
+        ('yaml', False),
+        ('yaml', True),
+        ('json', False),
+        ('json', True),
+        ('jsonl', False),
+        ('jsonl', True),
+    ]
+)
+def test_generic_serialization_classmethod(manifests, manifest_type, format, compressed):
+    manifest = manifests[manifest_type]
+    with NamedTemporaryFile(suffix='.' + format + ('.gz' if compressed else '')) as f:
+        manifest.to_file(f.name)
+        restored = type(manifest).from_file(f.name)
+    assert manifest == restored
+
+
+@pytest.mark.parametrize(
+    'manifest_type',
+    ['recording_set', 'supervision_set', 'feature_set', 'cut_set']
+)
+@pytest.mark.parametrize(
+    ['format', 'compressed'],
+    [
+        ('yaml', False),
+        ('yaml', True),
+        ('json', False),
+        ('json', True),
+        ('jsonl', False),
+        ('jsonl', True),
+    ]
+)
+def test_generic_serialization(manifests, manifest_type, format, compressed):
+    manifest = manifests[manifest_type]
+    with NamedTemporaryFile(suffix='.' + format + ('.gz' if compressed else '')) as f:
+        store_manifest(manifest, f.name)
+        restored = load_manifest(f.name)
+        assert manifest == restored

--- a/test/test_supervision_set.py
+++ b/test/test_supervision_set.py
@@ -1,5 +1,3 @@
-from tempfile import NamedTemporaryFile
-
 import pytest
 
 from lhotse.supervision import SupervisionSegment, SupervisionSet
@@ -77,44 +75,6 @@ def test_supervision_set_iteration():
     )
     assert 2 == len(supervision_set)
     assert 2 == len(list(supervision_set))
-
-
-@pytest.mark.parametrize(
-    ['format', 'compressed'],
-    [
-        ('yaml', False),
-        ('yaml', True),
-        ('json', False),
-        ('json', True),
-        ('jsonl', False),
-        ('jsonl', True),
-    ]
-)
-def test_supervision_set_serialization(format, compressed):
-    supervision_set = SupervisionSet.from_segments([
-        SupervisionSegment(
-            id='segment-1',
-            recording_id='recording-1',
-            channel=0,
-            start=0.1,
-            duration=0.3,
-            text='transcript of the first segment',
-            language='english',
-            speaker='Norman Dyhrentfurth',
-            gender='male'
-        )
-    ])
-    with NamedTemporaryFile(suffix='.gz' if compressed else '') as f:
-        if format == 'yaml':
-            supervision_set.to_yaml(f.name)
-            restored = supervision_set.from_yaml(f.name)
-        if format == 'json':
-            supervision_set.to_json(f.name)
-            restored = supervision_set.from_json(f.name)
-        if format == 'jsonl':
-            supervision_set.to_jsonl(f.name)
-            restored = supervision_set.from_jsonl(f.name)
-    assert supervision_set == restored
 
 
 def test_add_supervision_sets():


### PR DESCRIPTION
This adds/improves the following methods:

```python
from lhotse import load_manifest, store_manifest

x = load_manifest('path/to/manifest.{json,yaml,jsonl}[.gz]')
store_manifest(x, 'path/to/manifest.{json,yaml,jsonl}[.gz]')

# Alternatively using a specific class but not a specified serializer
CutSet.from_file(...)  # same for RecordingSet etc.
CutSet.to_file(...)       # same for RecordingSet etc.
```

The CLI should also correctly infer the right manifest type and serializer used to decode (and whether there's compression)

It also adds

```bash
# works with any manifest type and serializer
$ lhotse copy cuts.json cuts.jsonl.gz
```