### PR TITLE
Fix test for sphere files.

### DIFF
--- a/lhotse/audio.py
+++ b/lhotse/audio.py
@@ -30,7 +30,7 @@ class AudioSource:
     """
     AudioSource represents audio data that can be retrieved from somewhere.
     Supported sources of audio are currently:
-    - 'file' (formats supported by librosa, possibly multi-channel)
+    - 'file' (formats supported by soundfile, possibly multi-channel)
     - 'command' [unix pipe] (must be WAVE, possibly multi-channel)
     - 'url' (any URL type that is supported by "smart_open" library, e.g. http/https/s3/gcp/azure/etc.)
     """
@@ -44,10 +44,13 @@ class AudioSource:
             duration: Optional[Seconds] = None,
     ) -> np.ndarray:
         """
-        Load the AudioSource (both files and commands) with librosa,
+        Load the AudioSource (from files, commands, or URLs) with soundfile,
         accounting for many audio formats and multi-channel inputs.
-        Returns numpy array with shapes: (n_samples) for single-channel,
+        Returns numpy array with shapes: (n_samples,) for single-channel,
         (n_channels, n_samples) for multi-channel.
+
+        Note: The elements in the returned array are in the range [-1.0, 1.0]
+        and are of dtype `np.floatt32`.
         """
         assert self.type in ('file', 'command', 'url')
 

--- a/lhotse/augmentation/torchaudio.py
+++ b/lhotse/augmentation/torchaudio.py
@@ -17,12 +17,12 @@ if not during_docs_build() and _version(torchaudio.__version__) < _version('0.7'
 @dataclass
 class RandomValue:
     """
-    Represents a uniform distribution in the range [start, end].
+    Represents a uniform distribution in the range [start, end).
     """
     start: Union[int, float]
     end: Union[int, float]
 
-    def sample(self):
+    def sample(self) -> float:
         return np.random.uniform(self.start, self.end)
 
 

--- a/lhotse/augmentation/torchaudio.py
+++ b/lhotse/augmentation/torchaudio.py
@@ -103,7 +103,7 @@ class AudioTransform:
     Furthermore, ``AudioTransform`` can be easily (de)serialized to/from dict
     that contains its name and parameters.
     This enables storing recording and cut manifests with the transform info
-    inside, avoiding the need to store the augmented recoreding version on disk.
+    inside, avoiding the need to store the augmented recording version on disk.
 
     All audio transforms derived from this class are "automagically" registered,
     so that ``AudioTransform.from_dict()`` can "find" the right type given its name

--- a/lhotse/features/base.py
+++ b/lhotse/features/base.py
@@ -79,7 +79,7 @@ class FeatureExtractor(metaclass=ABCMeta):
     @staticmethod
     def mix(features_a: np.ndarray, features_b: np.ndarray, energy_scaling_factor_b: float) -> np.ndarray:
         """
-        Perform feature-domain mix of two singals, ``a`` and ``b``, and return the mixed signal.
+        Perform feature-domain mix of two signals, ``a`` and ``b``, and return the mixed signal.
 
         :param features_a: Left-hand side (reference) signal.
         :param features_b: Right-hand side (mixed-in) signal.
@@ -478,7 +478,7 @@ class FeatureSet(Serializable, Sequence[Features]):
         :param duration: optional float, requested duration in seconds for the feature chunk.
             By default, return everything from the start.
         :param leeway: float, controls how strictly we have to match the requested start and duration criteria.
-            It is necessary to keep a small positive value here (default 0.05s), as there might be differneces between
+            It is necessary to keep a small positive value here (default 0.05s), as there might be differences between
             the duration of recording/supervision segment, and the duration of features. The latter one is constrained
             to be a multiple of frame_shift, while the former can be arbitrary.
         :return: a Features object satisfying the search criteria.

--- a/lhotse/manifest.py
+++ b/lhotse/manifest.py
@@ -11,7 +11,7 @@ RecordingSet: // I know this name has been taken already...
    - For each recording, you would be able to access: the number of channels, the sampling rate, the number of samples (and of course the length in seconds); and when needed you'd be able to access the audio (or at least, selected channels of it).  Of course the metadata would be in the manifest.
    - Where possible it would be nice to support getting a chunk of a selected subset of channels of the audio.  (i.e. have that in the interface, to account for cases where it's possible to seek in the data).
    - Bear in mind that there may be cases where different channels are stored in different files, like in AMI, and cases where we need a command to extract the data, so the interface should be general enough, e.g. don't enable extracting the filename.
-   - When distrbuting data, like from OpenSLR, we may in some cases want to distribute the manifest file along with it, to avoid the user having to launch a time-consuming command, so it might be nice to support relative pathnames and setting a global root-directory prefix.
+   - When distributing data, like from OpenSLR, we may in some cases want to distribute the manifest file along with it, to avoid the user having to launch a time-consuming command, so it might be nice to support relative pathnames and setting a global root-directory prefix.
 
 TextSupervisionSet:
    - This object would contain plaintext supervision information associated with audio.

--- a/lhotse/recipes/babel.py
+++ b/lhotse/recipes/babel.py
@@ -54,7 +54,7 @@ def prepare_single_babel_language(corpus_dir: Pathlike, output_dir: Optional[Pat
     manifests = defaultdict(dict)
     for split in ('dev', 'eval', 'training'):
         audio_dir = corpus_dir / f'conversational/{split}/audio'
-        recordings = RecordingSet.from_recordings(Recording.from_sphere(p) for p in audio_dir.glob('*.sph'))
+        recordings = RecordingSet.from_recordings(Recording.from_file(p) for p in audio_dir.glob('*.sph'))
         if len(recordings) == 0:
             logging.warning(f"No SPHERE files found in {audio_dir}")
         manifests[split]['recordings'] = recordings

--- a/lhotse/recipes/broadcast_news.py
+++ b/lhotse/recipes/broadcast_news.py
@@ -48,7 +48,7 @@ def prepare_broadcast_news(
     sgml_paths = check_and_rglob(transcripts_dir, '*.sgml')
 
     recordings = RecordingSet.from_recordings(
-        Recording.from_sphere(p, relative_path_depth=None if absolute_paths else 3)
+        Recording.from_file(p, relative_path_depth=None if absolute_paths else 3)
         for p in audio_paths
     )
 

--- a/lhotse/recipes/switchboard.py
+++ b/lhotse/recipes/switchboard.py
@@ -57,7 +57,7 @@ def prepare_switchboard(
         groups.append({'audio': ap, 'text-0': name_to_text[f'{name}A'], 'text-1': name_to_text[f'{name}B']})
 
     recordings = RecordingSet.from_recordings(
-        Recording.from_sphere(group['audio'], relative_path_depth=None if absolute_paths else 3)
+        Recording.from_file(group['audio'], relative_path_depth=None if absolute_paths else 3)
         for group in groups
     )
     supervisions = SupervisionSet.from_segments(chain.from_iterable(

--- a/lhotse/recipes/tedlium.py
+++ b/lhotse/recipes/tedlium.py
@@ -91,7 +91,7 @@ def prepare_tedlium(
     for split in ('train', 'dev', 'test'):
         root = tedlium_root / 'legacy' / split
         recordings = RecordingSet.from_recordings(
-            Recording.from_sphere(p) for p in (root / 'sph').glob('*.sph')
+            Recording.from_file(p) for p in (root / 'sph').glob('*.sph')
         )
         stms = list((root / 'stm').glob('*.stm'))
         assert len(stms) == len(recordings), f'Mismatch: found {len(recordings)} ' \

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ lilcom>=1.1.0
 numpy>=1.18.1
 packaging
 pyyaml>=5.3.1
-sphfile>=1.0.3
 torch>=1.7.1
 torchaudio>=0.7.1
 tqdm

--- a/test/test_recording_set.py
+++ b/test/test_recording_set.py
@@ -38,7 +38,7 @@ def expected_stereo_two_sources() -> np.ndarray:
 
 @lru_cache(1)
 def expected_stereo_single_source() -> np.ndarray:
-    """Contents of test/fixtures/stereo.wav"""
+    """Contents of test/fixtures/stereo.{wav,sph}"""
     return np.vstack([
         np.arange(8000, 16000, dtype=np.int16),
         np.arange(16000, 24000, dtype=np.int16)
@@ -67,7 +67,7 @@ def test_get_stereo_audio_from_single_file(recording_set):
 
 
 def test_load_audio_from_sphere_file(recording_set):
-    samples = recording_set.load_audio('recording-2')
+    samples = recording_set.load_audio('recording-3')
     np.testing.assert_almost_equal(samples, expected_stereo_single_source())
 
 

--- a/test/test_recording_set.py
+++ b/test/test_recording_set.py
@@ -135,7 +135,7 @@ def test_add_recording_sets():
     ]
 )
 def test_recording_from_sphere(relative_path_depth, expected_source_path):
-    rec = Recording.from_sphere('test/fixtures/stereo.sph', relative_path_depth=relative_path_depth)
+    rec = Recording.from_file('test/fixtures/stereo.sph', relative_path_depth=relative_path_depth)
     assert rec == Recording(
         id='stereo',
         sampling_rate=8000,


### PR DESCRIPTION
As the test shows, `soundfile` can handle `.sph` files correctly.

Should we remove the dependency on `sphfile` from `requirements.txt`? (It was introduced in https://github.com/lhotse-speech/lhotse/issues/43)