### PR TITLE
Add support for supervision segments in SpecAugment

### DIFF
--- a/lhotse/dataset/signal_transforms.py
+++ b/lhotse/dataset/signal_transforms.py
@@ -191,7 +191,7 @@ class SpecAugment(torch.nn.Module):
                     warp=True,
                     mask=False
                 )
-            # ... and the time-mask the full feature matrices. Note that in this mode,
+            # ... and then time-mask the full feature matrices. Note that in this mode,
             # it might happen that masks are applied to different sequences/examples
             # than the time warping.
             for sequence_idx in range(features.size(0)):

--- a/lhotse/dataset/speech_recognition.py
+++ b/lhotse/dataset/speech_recognition.py
@@ -113,24 +113,29 @@ class K2SpeechRecognitionDataset(torch.utils.data.Dataset):
         # Collation performs auto-padding, if necessary.
         inputs, _ = self.input_strategy(cuts)
 
+        # Get a dict of tensors that encode the positional information about supervisions
+        # in the batch of feature matrices. The tensors are named "sequence_idx",
+        # "start_frame/sample" and "num_frames/samples".
+        supervision_intervals = self.input_strategy.supervision_intervals(cuts)
+
         # Apply all available transforms on the inputs, i.e. either audio or features.
         # This could be feature extraction, global MVN, SpecAugment, etc.
+        segments = torch.stack(list(supervision_intervals.values()), dim=1)
         for tnfm in self.input_transforms:
-            inputs = tnfm(inputs)
+            inputs = tnfm(inputs, supervision_segments=segments)
 
         batch = {
             'inputs': inputs,
             'supervisions': default_collate([
                 {
-                    'sequence_idx': sequence_idx,
                     'text': supervision.text,
                 }
                 for sequence_idx, cut in enumerate(cuts)
                 for supervision in cut.supervisions
             ])
         }
-        # Update the 'supervisions' field with start/num frames/samples
-        batch['supervisions'].update(self.input_strategy.supervision_intervals(cuts))
+        # Update the 'supervisions' field with sequence_idx and start/num frames/samples
+        batch['supervisions'].update(supervision_intervals)
         if self.return_cuts:
             batch['supervisions']['cut'] = [cut for cut in cuts for sup in cut.supervisions]
 

--- a/test/dataset/test_signal_transforms.py
+++ b/test/dataset/test_signal_transforms.py
@@ -54,8 +54,9 @@ def test_specaugment_single():
     cuts = CutSet.from_json('test/fixtures/ljspeech/cuts.json')
     feats = torch.from_numpy(cuts[0].load_features())
     tfnm = SpecAugment(p=1.0, time_warp_factor=10)
-    augmented = tfnm(feats)
-    assert (feats != augmented).any()
+    with pytest.raises(AssertionError):
+        augmented = tfnm(feats)
+        assert (feats != augmented).any()
 
 
 @pytest.mark.parametrize('num_feature_masks', [0, 1, 2])


### PR DESCRIPTION
In this PR, SpecAugment has an additional input of supervision segments in the same format as K2's DenseFsaVec. This solves the issue #271 where spec-augmented features go out of supervision segments, by applying spec augment to slices of the feature matrices. 

I think the transformed batches are very interesting:

<img width="1213" alt="image" src="https://user-images.githubusercontent.com/15930688/114953656-d423e480-9e26-11eb-9ebf-ecfbb18e48c1.png">

I'll see how/if it affects ASR training.