### PR TITLE
[experimental] Lazy manifest loading for huge datasets

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -32,7 +32,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install --no-cache-dir numpy
-        pip install --no-cache-dir '.[tests]'
+        pip install --no-cache-dir '.[tests,arrow]'
         pip install smart_open[http]  # for URL audio downloading test
     - name: Lint with flake8
       run: |

--- a/lhotse/audio.py
+++ b/lhotse/audio.py
@@ -106,6 +106,9 @@ class AudioSource:
             return self
         return fastcopy(self, source=str(Path(path) / self.source))
 
+    def to_dict(self) -> dict:
+        return asdict_nonull(self)
+
     @staticmethod
     def from_dict(data) -> 'AudioSource':
         return AudioSource(**data)
@@ -168,6 +171,9 @@ class Recording:
                 )
             ]
         )
+
+    def to_dict(self) -> dict:
+        return asdict_nonull(self)
 
     @property
     def num_channels(self):
@@ -368,8 +374,8 @@ class RecordingSet(Serializable, Sequence[Recording]):
     def from_dicts(data: Iterable[dict]) -> 'RecordingSet':
         return RecordingSet.from_recordings(Recording.from_dict(raw_rec) for raw_rec in data)
 
-    def to_dicts(self) -> List[dict]:
-        return [asdict_nonull(r) for r in self]
+    def to_dicts(self) -> Iterable[dict]:
+        return (r.to_dict() for r in self)
 
     def filter(self, predicate: Callable[[Recording], bool]) -> 'RecordingSet':
         """

--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -1234,6 +1234,14 @@ class CutSet(Serializable, Sequence[AnyCut]):
         return self.cuts == other.cuts
 
     @property
+    def is_lazy(self) -> bool:
+        """
+        Indicates whether this manifest was opened in lazy (read-on-the-fly) mode or not.
+        """
+        from lhotse.serialization import LazyDict
+        return isinstance(self.cuts, LazyDict)
+
+    @property
     def mixed_cuts(self) -> Dict[str, MixedCut]:
         return {id_: cut for id_, cut in self.cuts.items() if isinstance(cut, MixedCut)}
 

--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -50,6 +50,9 @@ class CutUtilsMixin:
     for cuts in the future and make this an ABC instead.
     """
 
+    def to_dict(self) -> dict:
+        return {**asdict_nonull(self), 'type': type(self).__name__}
+
     @property
     def trimmed_supervisions(self) -> List[SupervisionSegment]:
         """
@@ -1329,8 +1332,8 @@ class CutSet(Serializable, Sequence[AnyCut]):
 
         return CutSet.from_cuts(deserialize_one(cut) for cut in data)
 
-    def to_dicts(self) -> List[dict]:
-        return [{**asdict_nonull(cut), 'type': type(cut).__name__} for cut in self]
+    def to_dicts(self) -> Iterable[dict]:
+        return (cut.to_dict() for cut in self)
 
     def describe(self) -> None:
         """

--- a/lhotse/features/base.py
+++ b/lhotse/features/base.py
@@ -18,7 +18,7 @@ from lhotse.audio import Recording
 from lhotse.augmentation import AugmentFn
 from lhotse.features.io import FeaturesWriter, get_reader
 from lhotse.serialization import Serializable, load_yaml, save_to_yaml
-from lhotse.utils import (Pathlike, Seconds, compute_num_frames, exactly_one_not_null, fastcopy,
+from lhotse.utils import (Pathlike, Seconds, asdict_nonull, compute_num_frames, exactly_one_not_null, fastcopy,
                           split_sequence,
                           uuid4)
 
@@ -380,6 +380,9 @@ class Features:
     def with_path_prefix(self, path: Pathlike) -> 'Features':
         return fastcopy(self, storage_path=str(Path(path) / self.storage_path))
 
+    def to_dict(self) -> dict:
+        return asdict_nonull(self)
+
     @staticmethod
     def from_dict(data: dict) -> 'Features':
         # The "storage_type" check is to ensure that the "data" dict actually contains
@@ -414,8 +417,8 @@ class FeatureSet(Serializable, Sequence[Features]):
     def from_dicts(data: Iterable[dict]) -> 'FeatureSet':
         return FeatureSet(features=[Features.from_dict(feature_data) for feature_data in data])
 
-    def to_dicts(self) -> List[dict]:
-        return [asdict(f) for f in self]
+    def to_dicts(self) -> Iterable[dict]:
+        return (f.to_dict() for f in self)
 
     def with_path_prefix(self, path: Pathlike) -> 'FeatureSet':
         return FeatureSet.from_features(f.with_path_prefix(path) for f in self)

--- a/lhotse/features/base.py
+++ b/lhotse/features/base.py
@@ -4,7 +4,7 @@ import pickle
 import warnings
 from abc import ABCMeta, abstractmethod
 from concurrent.futures.process import ProcessPoolExecutor
-from dataclasses import asdict, dataclass, field, is_dataclass
+from dataclasses import asdict, dataclass, is_dataclass
 from itertools import chain
 from math import isclose
 from pathlib import Path
@@ -19,7 +19,7 @@ from lhotse.augmentation import AugmentFn
 from lhotse.features.io import FeaturesWriter, get_reader
 from lhotse.serialization import Serializable, load_yaml, save_to_yaml
 from lhotse.utils import (Pathlike, Seconds, asdict_nonull, compute_num_frames, exactly_one_not_null, fastcopy,
-                          split_sequence,
+                          ifnone, split_sequence,
                           uuid4)
 
 
@@ -396,7 +396,6 @@ class Features:
         return Features(**data)
 
 
-@dataclass
 class FeatureSet(Serializable, Sequence[Features]):
     """
     Represents a feature manifest, and allows to read features for given recordings
@@ -404,10 +403,12 @@ class FeatureSet(Serializable, Sequence[Features]):
     It also keeps information about the feature extractor parameters used to obtain this set.
     When a given recording/time-range/channel is unavailable, raises a KeyError.
     """
-    features: List[Features] = field(default_factory=lambda: list())
 
-    def __post_init__(self):
-        self.features = sorted(self.features)
+    def __init__(self, features: List[Features] = None) -> None:
+        self.features = sorted(ifnone(features, []))
+
+    def __eq__(self, other: 'FeatureSet') -> bool:
+        return self.features == other.features
 
     @staticmethod
     def from_features(features: Iterable[Features]) -> 'FeatureSet':

--- a/lhotse/serialization.py
+++ b/lhotse/serialization.py
@@ -233,16 +233,6 @@ class LazyDict:
         # Key not found anyhwere.
         return None
 
-    def _find_key_old(self, key: str):
-        # Iterates all batches to find the item with a given ID.
-        for b in self.table.to_batches():
-            # Conversion to pandas seems to have the least overhead
-            # due to Arrow's zero-copy memory sharing policy.
-            result = b.to_pandas().query(f'id == "{key}"')
-            if len(result):
-                return self._deserialize_one(result.iloc[0].to_dict())
-        return None
-
     def __len__(self) -> int:
         return self.table.num_rows
 

--- a/lhotse/serialization.py
+++ b/lhotse/serialization.py
@@ -37,7 +37,7 @@ def load_yaml(path: Pathlike) -> dict:
 
 class YamlMixin:
     def to_yaml(self, path: Pathlike) -> None:
-        save_to_yaml(self.to_dicts(), path)
+        save_to_yaml(list(self.to_dicts()), path)
 
     @classmethod
     def from_yaml(cls, path: Pathlike) -> Manifest:
@@ -63,7 +63,7 @@ def load_json(path: Pathlike) -> Union[dict, list]:
 
 class JsonMixin:
     def to_json(self, path: Pathlike) -> None:
-        save_to_json(self.to_dicts(), path)
+        save_to_json(list(self.to_dicts()), path)
 
     @classmethod
     def from_json(cls, path: Pathlike) -> Manifest:

--- a/lhotse/serialization.py
+++ b/lhotse/serialization.py
@@ -107,9 +107,9 @@ class LazyMixin:
     @classmethod
     def from_jsonl_lazy(cls, path: Pathlike) -> Manifest:
         """
-        Read a manifest in a lazy manner, using pyarrow.
+        Read a JSONL manifest in a lazy manner, using pyarrow.
         The contents of the file are loaded into memory,
-        but in a memory-saving format, and they are deserialized into
+        but in a memory-efficient format, and they are deserialized into
         Python objects such as Cut, Supervision etc. only upon request.
 
         In this mode, most operations on the manifest set may be very slow:
@@ -122,6 +122,11 @@ class LazyMixin:
         return cls(LazyDict.from_jsonl(path))
 
     def to_arrow(self, path: Pathlike) -> None:
+        """
+        Store the manifest in Apache Arrow streaming binary format.
+        For very large manifests it can be ~5x larger that a corresponding compressed JSONL,
+        but it allows to read the manifest with a relatively small memory footprint (~300M).
+        """
         import pyarrow as pa
         if self.is_lazy:
             # TODO: I don't want to add a special method for retrieving those in each manifest type;
@@ -148,7 +153,7 @@ class LazyMixin:
     @classmethod
     def from_arrow(cls, path: Pathlike) -> Manifest:
         """
-        Read a manifest in a lazy manner, using pyarrow and parquet.
+        Read a manifest stored in Apache Arrow streaming binary format in a lazy manner.
         This method is supposed to use mmap, which should significantly ease
         the memory usage.
         The manifest items are deserialized into Python objects such as Cut,

--- a/lhotse/supervision.py
+++ b/lhotse/supervision.py
@@ -92,6 +92,9 @@ class SupervisionSegment:
             return self
         return fastcopy(self, text=transform_fn(self.text))
 
+    def to_dict(self) -> dict:
+        return asdict_nonull(self)
+
     @staticmethod
     def from_dict(data: dict) -> 'SupervisionSegment':
         return SupervisionSegment(**data)
@@ -117,8 +120,8 @@ class SupervisionSet(Serializable, Sequence[SupervisionSegment]):
     def from_dicts(data: Iterable[Dict]) -> 'SupervisionSet':
         return SupervisionSet.from_segments(SupervisionSegment.from_dict(s) for s in data)
 
-    def to_dicts(self) -> List[dict]:
-        return [asdict_nonull(s) for s in self]
+    def to_dicts(self) -> Iterable[dict]:
+        return (s.to_dict() for s in self)
 
     def split(self, num_splits: int, shuffle: bool = False) -> List['SupervisionSet']:
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ intervaltree>= 3.1.0
 lilcom>=1.1.0
 numpy>=1.18.1
 packaging
+pyarrow>=4.0.0
 pyyaml>=5.3.1
 torch>=1.7.1
 torchaudio>=0.7.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ intervaltree>= 3.1.0
 lilcom>=1.1.0
 numpy>=1.18.1
 packaging
-pyarrow>=4.0.0
 pyyaml>=5.3.1
 torch>=1.7.1
 torchaudio>=0.7.1

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,9 @@ project_root = Path(__file__).parent
 install_requires = (project_root / 'requirements.txt').read_text().splitlines()
 docs_require = (project_root / 'docs' / 'requirements.txt').read_text().splitlines()
 tests_require = ['pytest==5.4.3', 'flake8==3.8.3', 'coverage==5.1', 'hypothesis==5.41.2']
-dev_requires = docs_require + tests_require + ['jupyterlab', 'matplotlib', 'isort']
+arrow_requires = ['pyarrow>=4.0.0', 'pandas>=1.0.0']
+dev_requires = sorted(docs_require + tests_require + ['jupyterlab', 'matplotlib', 'isort'])
+all_requires = sorted(dev_requires + arrow_requires)
 
 if os.environ.get('READTHEDOCS', False):
     # When building documentation, omit torchaudio installation and mock it instead.
@@ -39,7 +41,9 @@ setup(
     extras_require={
         'docs': docs_require,
         'tests': tests_require,
-        'dev': docs_require + tests_require
+        'arrow': arrow_requires,
+        'dev': docs_require + tests_require,
+        'all': all_requires
     },
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -303,10 +303,13 @@ def test_lazy_jsonl_deserialization(manifests, manifest_type, format, compressed
     manifest = manifests[manifest_type]
     with NamedTemporaryFile(suffix='.' + format + ('.gz' if compressed else '')) as f:
         store_manifest(manifest, f.name)
-
         lazy_manifest = type(manifest).from_jsonl_lazy(f.name)
+        # Test iteration
         for eager_obj, lazy_obj in zip(manifest, lazy_manifest):
             assert eager_obj == lazy_obj
+        # Test accessing elements by ID
+        for lazy_obj in lazy_manifest:
+            lazy_manifest[lazy_obj.id]
 
 
 @pytest.mark.skipif(not is_module_available('pyarrow'), reason='Requires pyarrow')

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -4,7 +4,7 @@ import pytest
 
 from lhotse import AudioSource, Cut, CutSet, FeatureSet, Features, Recording, RecordingSet, SupervisionSegment, \
     SupervisionSet, load_manifest, store_manifest
-from lhotse.utils import nullcontext as does_not_raise
+from lhotse.utils import is_module_available, nullcontext as does_not_raise
 
 
 @pytest.mark.parametrize(
@@ -287,6 +287,7 @@ def test_generic_serialization(manifests, manifest_type, format, compressed):
         assert manifest == restored
 
 
+@pytest.mark.skipif(not is_module_available('pyarrow'), reason='Requires pyarrow')
 @pytest.mark.parametrize(
     'manifest_type',
     ['recording_set', 'supervision_set', 'cut_set']
@@ -308,6 +309,7 @@ def test_lazy_jsonl_deserialization(manifests, manifest_type, format, compressed
             assert eager_obj == lazy_obj
 
 
+@pytest.mark.skipif(not is_module_available('pyarrow'), reason='Requires pyarrow')
 @pytest.mark.parametrize(
     'manifest_type',
     ['recording_set', 'supervision_set', 'cut_set']

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -285,3 +285,49 @@ def test_generic_serialization(manifests, manifest_type, format, compressed):
         store_manifest(manifest, f.name)
         restored = load_manifest(f.name)
         assert manifest == restored
+
+
+@pytest.mark.parametrize(
+    'manifest_type',
+    ['recording_set', 'supervision_set', 'cut_set']
+)
+@pytest.mark.parametrize(
+    ['format', 'compressed'],
+    [
+        ('jsonl', False),
+        ('jsonl', True),
+    ]
+)
+def test_lazy_jsonl_deserialization(manifests, manifest_type, format, compressed):
+    manifest = manifests[manifest_type]
+    with NamedTemporaryFile(suffix='.' + format + ('.gz' if compressed else '')) as f:
+        store_manifest(manifest, f.name)
+
+        lazy_manifest = type(manifest).from_jsonl_lazy(f.name)
+        for eager_obj, lazy_obj in zip(manifest, lazy_manifest):
+            assert eager_obj == lazy_obj
+
+
+@pytest.mark.parametrize(
+    'manifest_type',
+    ['recording_set', 'supervision_set', 'cut_set']
+)
+@pytest.mark.parametrize(
+    ['format', 'compressed'],
+    [
+        ('jsonl', False),
+        ('jsonl', True),
+    ]
+)
+def test_lazy_arrow_serialization(manifests, manifest_type, format, compressed):
+    manifest = manifests[manifest_type]
+    with NamedTemporaryFile(suffix='.' + format + ('.gz' if compressed else '')) as jsonl_f, \
+            NamedTemporaryFile(suffix='.arrow') as arrow_f:
+        store_manifest(manifest, jsonl_f.name)
+        # For now, we have to first create a JSONL so that we can create mmapped arrow...
+        lazy_temp_manifest = type(manifest).from_jsonl_lazy(jsonl_f.name)
+        lazy_temp_manifest.to_arrow(arrow_f.name)
+        # Now read the real mmapped arrow manifest.
+        lazy_manifest = type(manifest).from_arrow(arrow_f.name)
+        for eager_obj, lazy_obj in zip(manifest, lazy_manifest):
+            assert eager_obj == lazy_obj


### PR DESCRIPTION
This is an early draft and not a complete solution (but possibly not that far from it).

The issue being solved is that huge corpora, such as 40k hours English portion of MLS, cannot be handled well by Lhotse _currently_, as they consume a lot of time and memory to be read from disk (and to be created, but that'll be addressed separately).

Fortunately, there seems to be an elegant way to solve this issue with not too many changes to the library. Apache Arrow allows to mmap (compressed/uncompressed) JSONL files and iterate over them surprisingly quickly, avoiding the loading speed and memory issues. I've tried to explain how it works in the code comments; here I'll show some measurements instead.

The supervision set JSONL is 1GB large (even though it's compressed with gzip) and contains ~11M supervision segments. The "loading" time is ~13s wall time, which is very low for this size. Checking length does not cost anything, and retrieving a single item is very slow (~5s):
<img width="1287" alt="image" src="https://user-images.githubusercontent.com/15930688/116177465-cf421900-a6e1-11eb-8c8e-4da200318393.png">

On the other hand, iteration is fairly fast, with dicts being deserialized into SupervisionSegments on the fly:
<img width="533" alt="image" src="https://user-images.githubusercontent.com/15930688/116177523-e8e36080-a6e1-11eb-8ffe-4c2e3db2584a.png">

The next steps involve adjusting it further to work well with the samplers so that they can leverage the batched loads... the overhead coming from mmap shouldn't affect the training as it will happen in dataloader processes. I think I'll also need to add a utility to speed up creating the manifests and write them to disk in a streaming way. Then we should be able to fully support very large corpora.