### PR TITLE
Lazy manifests usable with a non-shuffled sampler + dataset

### DIFF
--- a/lhotse/bin/modes/manipulation.py
+++ b/lhotse/bin/modes/manipulation.py
@@ -41,7 +41,7 @@ def copy(input_manifest, output_manifest):
               help='The type of items in the INPUT_MANIFEST '
                    '(has to be explicitly provided for arrow conversion at this time).'
               )
-def convert_arrow(input_manifest, output_manifest, manifest_type: str):
+def convert_to_arrow(input_manifest, output_manifest, manifest_type: str):
     """
     Load INPUT_MANIFEST using lazy loading mechanism and store it in
     OUTPUT_MANIFEST using Apache Arrow binary format.

--- a/lhotse/serialization.py
+++ b/lhotse/serialization.py
@@ -284,6 +284,7 @@ class LazyDict:
         self.batches = deque(self.table.to_batches())
         self.curr_view = self.batches[0].to_pandas()
         self.id2pos = dict(zip(self.curr_view.id, range(len(self.curr_view.id))))
+        self.prev_view = None
         self.prev_id2pos = {}
 
     @classmethod
@@ -306,6 +307,7 @@ class LazyDict:
         # Rotate the deque to the left by one item.
         # [0, 1, 2] -> [1, 2, 0]
         self.batches.rotate(-1)
+        self.prev_view = self.curr_view
         self.curr_view = self.batches[0].to_pandas()
         self.prev_id2pos = self.id2pos
         self.id2pos = dict(zip(self.curr_view.id, range(len(self.curr_view.id))))
@@ -317,9 +319,12 @@ class LazyDict:
         for _ in range(max_rotations):
             # Try without any rotations in the first iteration --
             # this should make search faster for contiguous keys.
-            pos = self.id2pos.get(key, self.prev_id2pos.get(key))
+            pos = self.id2pos.get(key)
             if pos is not None:
                 return self._deserialize_one(self.curr_view.iloc[pos].to_dict())
+            pos = self.prev_id2pos.get(key)
+            if pos is not None:
+                return self._deserialize_one(self.prev_view.iloc[pos].to_dict())
             # Not found in the current Arrow's "batch" -- we'll advance
             # to the next one and try again.
             self._progress()


### PR DESCRIPTION
With these changes (a utility for format conversion and one more optimization) I'm able to use the cuts in the mmapped arrow format for training full LibriSpeech in snowfall without a noticeable performance penalty. It requires setting ``check_inputs`` in K2 ASR dataset to `False` to avoid costly double iteration over the inputs though.