### PR TITLE
Pickling support for LazyDict + minor fixes

### DIFF
--- a/lhotse/audio.py
+++ b/lhotse/audio.py
@@ -684,7 +684,6 @@ def _available_audioread_backends():
     import audioread
     backends = audioread.available_backends()
     logging.info(f'Using audioread. Available backends: {backends}')
-    print(f'Using audioread. Available backends: {backends}')
     return backends
 
 

--- a/lhotse/bin/modes/manipulation.py
+++ b/lhotse/bin/modes/manipulation.py
@@ -34,8 +34,7 @@ def copy(input_manifest, output_manifest):
 @cli.command()
 @click.argument('input_manifest', type=click.Path(exists=True, dir_okay=False))
 @click.argument('output_manifest', type=click.Path())
-@click.option('-t', '--type',
-              metavar='manifest_type',
+@click.option('-t', '--manifest-type',
               type=click.Choice(['cut', 'recording', 'supervision']),
               default='cut',
               help='The type of items in the INPUT_MANIFEST '

--- a/lhotse/dataset/cut_transforms/perturb_speed.py
+++ b/lhotse/dataset/cut_transforms/perturb_speed.py
@@ -17,13 +17,15 @@ class PerturbSpeed:
             self,
             factors: Union[float, List[float]],
             p: float,
-            randgen: random.Random = random
+            randgen: random.Random = None
     ) -> None:
         self.factors = factors if isinstance(factors, Sequence) else [factors]
         self.p = p
         self.random = randgen
 
     def __call__(self, cuts: CutSet) -> CutSet:
+        if self.random is None:
+            self.random = random
         return CutSet.from_cuts(
             cut.perturb_speed(factor=self.random.choice(self.factors))
             if self.random.random() >= self.p

--- a/lhotse/serialization.py
+++ b/lhotse/serialization.py
@@ -120,7 +120,7 @@ class LazyMixin:
 
         This method requires ``pyarrow`` and ``pandas`` to be installed.
         """
-        return cls(LazyDict.from_jsonl(path))
+        return cls(LazyDict(path))
 
     def to_arrow(self, path: Pathlike) -> None:
         """
@@ -191,7 +191,7 @@ class LazyMixin:
 
         This method requires ``pyarrow`` and ``pandas`` to be installed.
         """
-        return cls(LazyDict.from_arrow(path))
+        return cls(LazyDict(path))
 
 
 def grouper(n, iterable):
@@ -332,11 +332,11 @@ class LazyDict:
         self.prev_id2pos = {}
 
     def _init_table_from_path(self):
-        if 'jsonl' in self.path.suffixes:
+        if '.jsonl' in self.path.suffixes:
             # Can read ".jsonl" or ".jsonl.gz"
             import pyarrow.json as paj
             self.table = paj.read_json(str(self.path))
-        elif 'arrow' == self.path.suffixes[-1]:
+        elif '.arrow' == self.path.suffixes[-1]:
             # Can read ".arrow"
             import pyarrow as pa
             mmap = pa.memory_map(str(self.path))


### PR DESCRIPTION
This solves an issue that is hard to notice unless one uses very large manifests -- when the mmapped file gets pickled for transfer to dataloader's worker processes, Python reads the whole file and tries to pickle it which blows up RAM. I changed the pickling behaviour for that class to only transfer the path to the file and re-open it in the new process. After this change, the training takes approx. 5-6GB CPU RAM per GPU, and I'm able to run snowfall training on full MLS with 4xGPU and on-the-fly feature extraction with no I/O or memory issues (with shuffle=False).