### PR TITLE
Explicitly set UTF-8 encoding when reading README.md in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     description='Data preparation for speech processing models training.',
     author='The Lhotse Development Team',
     author_email="pzelasko@jhu.edu",
-    long_description=(project_root / 'README.md').read_text(),
+    long_description=(project_root / 'README.md').read_text(encoding='utf-8'),
     long_description_content_type="text/markdown",
     license='Apache-2.0 License',
     packages=find_packages(),


### PR DESCRIPTION
This fixes an installation error (UnicodeDecodeError) on Windows/Python 3.8.

```
python setup.py install
Traceback (most recent call last):
  File "setup.py", line 44, in <module>
    long_description=(project_root / 'README.md').read_text(),
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.8_3.8.2544.0_x64__qbz5n2kfra8p0\lib\pathlib.py", line 1236, in read_text
    return f.read()
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.8_3.8.2544.0_x64__qbz5n2kfra8p0\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 1392: character maps to <undefined>
```