### PR TITLE
Store waveforms of cuts as audio recordings to disk

### DIFF
--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -2143,7 +2143,7 @@ class CutSet(Serializable, Sequence[AnyCut]):
             https://lhotse.readthedocs.io/en/latest/parallelism.html
         :param progress_bar: Should a progress bar be displayed (automatically turned off
             for parallel computation).
-        :return: Returns a new ``CutSet`` with ``Features`` manifests attached to the cuts.
+        :return: Returns a new ``CutSet``.
         """
         from lhotse.manipulation import combine
         from cytoolz import identity

--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -127,6 +127,58 @@ class CutUtilsMixin:
         features = np.flip(self.load_features().transpose(1, 0), 0)
         return plt.matshow(features)
 
+    def compute_and_store_recording(
+            self,
+            storage_path: Pathlike,
+            augment_fn: Optional[AugmentFn] = None,
+    ) -> Cut:
+        """
+        Store this cut's waveform as audio recording to disk.
+
+        :param storage_path: The path to location where we will store the audio recordings.
+            If it ends in '.flac', it is taken as the exact output path; otherwise, it is
+            considered as the base directory, a sub-directory that starts with the first
+            three characters of the cut's ID is created, and the audio recording is stored
+            in the sub-directory, named as the cut's ID and '.flac' as suffix.
+        :param augment_fn: an optional callable used for audio augmentation.
+            Be careful with the types of augmentations used: if they modify
+            the start/end/duration times of the cut and its supervisions,
+            you will end up with incorrect supervision information when using this API.
+            E.g. for speed perturbation, use ``CutSet.perturb_speed()`` instead.
+        :return: a new Cut instance.
+        """
+        if Path(storage_path).suffix == '.flac':
+            output_audio_path = storage_path
+        else:
+            # Introduce a sub-directory that starts with the first 3 characters of the cut's ID.
+            # This allows to avoid filesystem performance problems related to storing
+            # too many files in a single directory.
+            subdir = storage_path / self.id[:3]
+            subdir.mkdir(exist_ok=True)
+            output_audio_path = (subdir / self.id).with_suffix('.flac')
+
+        samples = self.load_audio()
+        if augment_fn is not None:
+            samples = augment_fn(samples, self.sampling_rate)
+        # Store audio as FLAC
+        import soundfile as sf
+        sf.write(
+            output_audio_path,
+            samples,
+            self.sampling_rate,
+            format='FLAC',
+            subtype='PCM_16'
+        )
+        recording = Recording.from_file(output_audio_path)
+        return Cut(
+            id=self.id,
+            start=0,
+            duration=recording.duration,
+            channel=0,
+            supervisions=self.supervisions,
+            recording=recording
+        )
+
     def speakers_feature_mask(
             self,
             min_speaker_dim: Optional[int] = None,
@@ -2076,6 +2128,90 @@ class CutSet(Serializable, Sequence[AnyCut]):
 
         cuts_with_feats = combine(progress(f.result() for f in futures))
         return cuts_with_feats
+
+    def compute_and_store_recordings(
+            self,
+            storage_path: Pathlike,
+            num_jobs: Optional[int] = None,
+            executor: Optional[Executor] = None,
+            augment_fn: Optional[AugmentFn] = None,
+            progress_bar: bool = True
+        ) -> 'CutSet':
+        """
+        Store audio recordings of all cuts
+
+        :param storage_path: The path to location where we will store the audio recordings.
+        :param num_jobs: The number of parallel processes used to store the audio recordings.
+            We will internally split the CutSet into this many chunks
+            and process each chunk in parallel.
+        :param augment_fn: an optional callable used for audio augmentation.
+            Be careful with the types of augmentations used: if they modify
+            the start/end/duration times of the cut and its supervisions,
+            you will end up with incorrect supervision information when using this API.
+            E.g. for speed perturbation, use ``CutSet.perturb_speed()`` instead.
+        :param executor: when provided, will be used to parallelize the process.
+            By default, we will instantiate a ProcessPoolExecutor.
+            Learn more about the ``Executor`` API at
+            https://lhotse.readthedocs.io/en/latest/parallelism.html
+        :param progress_bar: Should a progress bar be displayed (automatically turned off
+            for parallel computation).
+        :return: Returns a new ``CutSet`` with ``Features`` manifests attached to the cuts.
+        """
+        from lhotse.manipulation import combine
+        from cytoolz import identity
+
+        # Pre-conditions and args setup
+        progress = identity  # does nothing, unless we overwrite it with an actual prog bar
+        if num_jobs is None:
+            num_jobs = 1
+        if num_jobs == 1 and executor is not None:
+            logging.warning('Executor argument was passed but num_jobs set to 1: '
+                            'we will ignore the executor and use non-parallel execution.')
+            executor = None
+
+        # Non-parallel execution
+        if executor is None and num_jobs == 1:
+            if progress_bar:
+                progress = partial(
+                    tqdm, desc='Storing audio recordings', total=len(self)
+                )
+            return CutSet.from_cuts(
+                progress(
+                    cut.compute_and_store_recording(
+                        storage_path=storage_path,
+                        augment_fn=augment_fn
+                    ) for cut in self
+                )
+            )
+
+        # Parallel execution: prepare the CutSet splits
+        cut_sets = self.split(num_jobs, shuffle=True)
+
+        # Initialize the default executor if None was given
+        if executor is None:
+            executor = ProcessPoolExecutor(num_jobs)
+
+        # Submit the chunked tasks to parallel workers.
+        # Each worker runs the non-parallel version of this function inside.
+        futures = [
+            executor.submit(
+                CutSet.compute_and_store_recording,
+                cs,
+                storage_path=storage_path,
+                augment_fn=augment_fn,
+                # Disable individual workers progress bars for readability
+                progress_bar=False
+            )
+            for i, cs in enumerate(cut_sets)
+        ]
+
+        if progress_bar:
+            progress = partial(
+                tqdm, desc='Storing audio recordings (chunks progress)', total=len(futures)
+            )
+
+        cuts = combine(progress(f.result() for f in futures))
+        return cuts
 
     def compute_global_feature_stats(
             self,

--- a/test/cut/test_cut.py
+++ b/test/cut/test_cut.py
@@ -1,4 +1,6 @@
 import pytest
+from tempfile import NamedTemporaryFile
+import numpy as np
 
 from lhotse.audio import AudioSource, Recording, RecordingSet
 from lhotse.cut import Cut, CutSet
@@ -76,6 +78,18 @@ def test_load_none_features(libri_cut):
     libri_cut.features = None
     feats = libri_cut.load_features()
     assert feats is None
+
+
+def test_store_audio(libri_cut):
+    with NamedTemporaryFile() as f:
+        stored_cut = libri_cut.compute_and_store_recording(f.name)
+        samples1 = libri_cut.load_audio()
+        rec = Recording.from_file(f.name)
+        samples2 = rec.load_audio()
+        assert np.array_equal(samples1, samples2)
+        assert rec.duration == libri_cut.duration
+        assert rec.duration == stored_cut.duration
+        assert libri_cut.duration == stored_cut.duration
 
 
 @pytest.fixture

--- a/test/cut/test_cut_set.py
+++ b/test/cut/test_cut_set.py
@@ -1,5 +1,6 @@
 import pickle
-from tempfile import NamedTemporaryFile
+from tempfile import NamedTemporaryFile, TemporaryDirectory
+import numpy as np
 
 import pytest
 
@@ -278,3 +279,14 @@ def test_map_cut_set(cut_set_with_mixed_cut):
 def test_map_cut_set_rejects_noncut(cut_set_with_mixed_cut):
     with pytest.raises(AssertionError):
         cut_set = cut_set_with_mixed_cut.map(lambda cut: 'not-a-cut')
+
+
+def test_store_audio(cut_set):
+    cut_set = CutSet.from_json('test/fixtures/libri/cuts.json')
+    with TemporaryDirectory() as tmpdir:
+        stored_cut_set = cut_set.compute_and_store_recordings(tmpdir)
+        for cut1, cut2 in zip(cut_set, stored_cut_set):
+            samples1 = cut1.load_audio()
+            samples2 = cut2.load_audio()
+            assert np.array_equal(samples1, samples2)
+        assert len(stored_cut_set) == len(cut_set)


### PR DESCRIPTION
This PR implements a method `compute_and_store_recordings` in `CutSet` that stores waveforms of cuts as audio recordings (specifically FLAC) to disk. It addresses issues #150 and #314. I added some basic tests.

As proposed in #150, for each cut, a sub-directory will be created that starts with the first three characters of the cut ID. The waveform of the cut is then stored as FLAC audio file in the sub-directory using the cut ID as filename and `.flac` as suffix.
