### PR TITLE
don't using kaldi reco2dur  and fix some error in bin/lhotse

### DIFF
--- a/lhotse/audio.py
+++ b/lhotse/audio.py
@@ -156,7 +156,7 @@ class Recording:
             info = soundfile.info(str(path))
         except:
             # Try to parse the file using audioread as a fallback.
-            info = _audioread_info(str(path))
+            info = audioread_info(str(path))
             # If both fail, then Python 3 will display both exception messages.
         return Recording(
             id=recording_id if recording_id is not None else Path(path).stem,
@@ -641,7 +641,7 @@ def read_audio(
         return _audioread_load(path_or_fd, offset=offset, duration=duration)
 
 
-def _audioread_info(path):
+def audioread_info(path):
     """
     Return an audio info data structure that's a compatible subset of ``pysoundfile.info()``
     that we need to create a ``Recording`` manifest.

--- a/lhotse/bin/lhotse
+++ b/lhotse/bin/lhotse
@@ -6,7 +6,7 @@ $ lhotse --help
 $ lhotse make-feats --help
 $ lhotse make-feats --compressed recording_manifest.yml mfcc_dir/
 $ lhotse write-default-feature-config feat-conf.yml
-$ lhotse kaldi import  data/train 16000 train_manifests/
+$ lhotse kaldi import data/train 16000 train_manifests/
 $ lhotse split 3 audio.yml split_manifests/
 $ lhotse combine feature.1.yml feature.2.yml combined_feature.yml
 $ lhotse recipe --help

--- a/lhotse/bin/lhotse
+++ b/lhotse/bin/lhotse
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 Use this script like:
 
@@ -6,7 +6,7 @@ $ lhotse --help
 $ lhotse make-feats --help
 $ lhotse make-feats --compressed recording_manifest.yml mfcc_dir/
 $ lhotse write-default-feature-config feat-conf.yml
-$ lhotse convert-kaldi data/train/ 16000 train_manifests/
+$ lhotse kaldi import  data/train 16000 train_manifests/
 $ lhotse split 3 audio.yml split_manifests/
 $ lhotse combine feature.1.yml feature.2.yml combined_feature.yml
 $ lhotse recipe --help

--- a/lhotse/kaldi.py
+++ b/lhotse/kaldi.py
@@ -1,7 +1,7 @@
 import warnings
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple, NamedTuple
 
 from lhotse import CutSet, FeatureSet, Features, Seconds
 from lhotse.audio import AudioSource, Recording, RecordingSet
@@ -11,7 +11,16 @@ from lhotse.audio import _audioread_info
 
 def from_file(
     path: Pathlike,
-):  
+) - > NamedTuple: 
+    """
+    Read a audio file, it supports pipeline style wave path and real waveform.
+    
+    :param path: Path to an audio file supported by libsoundfile (pysoundfile).
+    :return: NamedTuple, it contains some information of the audio.
+                         duration = info.duration
+                         num_samples = info.frames
+                         sampling_rate = info.samplerate
+    """ 
     try:
         # Try to parse the file using pysoundfile first.
         import soundfile

--- a/lhotse/kaldi.py
+++ b/lhotse/kaldi.py
@@ -7,19 +7,17 @@ from lhotse import CutSet, FeatureSet, Features, Seconds
 from lhotse.audio import AudioSource, Recording, RecordingSet
 from lhotse.supervision import SupervisionSegment, SupervisionSet
 from lhotse.utils import Pathlike, is_module_available
-from lhotse.audio import _audioread_info 
+from lhotse.audio import audioread_info 
+
 
 def from_file(
     path: Pathlike,
-) - > NamedTuple: 
+) -> Tuple[float]: 
     """
     Read a audio file, it supports pipeline style wave path and real waveform.
     
     :param path: Path to an audio file supported by libsoundfile (pysoundfile).
-    :return: NamedTuple, it contains some information of the audio.
-                         duration = info.duration
-                         num_samples = info.frames
-                         sampling_rate = info.samplerate
+    :return: duration of wav it is float.
     """ 
     try:
         # Try to parse the file using pysoundfile first.
@@ -27,8 +25,8 @@ def from_file(
         info = soundfile.info(str(path))
     except:
         # Try to parse the file using audioread as a fallback.
-        info = _audioread_info(str(path))
-    return info
+        info = audioread_info(str(path))
+    return info.duration
 
 
 def load_kaldi_data_dir(
@@ -51,8 +49,8 @@ def load_kaldi_data_dir(
 
     durations = defaultdict(float)
     for recording_id, path_or_cmd in recordings.items():
-        info = from_file(path_or_cmd)
-        duration = info.duration
+        duration = from_file(path_or_cmd)
+        #duration = info.duration
         durations[recording_id] = duration 
 
     recording_set = RecordingSet.from_recordings(

--- a/lhotse/kaldi.py
+++ b/lhotse/kaldi.py
@@ -1,7 +1,7 @@
 import warnings
 from collections import defaultdict
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple, NamedTuple
+from typing import Any, Dict, Optional, Tuple
 
 from lhotse import CutSet, FeatureSet, Features, Seconds
 from lhotse.audio import AudioSource, Recording, RecordingSet
@@ -10,9 +10,9 @@ from lhotse.utils import Pathlike, is_module_available
 from lhotse.audio import audioread_info 
 
 
-def from_file(
+def get_duration(
     path: Pathlike,
-) -> Tuple[float]: 
+) -> float: 
     """
     Read a audio file, it supports pipeline style wave path and real waveform.
     
@@ -49,8 +49,7 @@ def load_kaldi_data_dir(
 
     durations = defaultdict(float)
     for recording_id, path_or_cmd in recordings.items():
-        duration = from_file(path_or_cmd)
-        #duration = info.duration
+        duration = get_duration(path_or_cmd)
         durations[recording_id] = duration 
 
     recording_set = RecordingSet.from_recordings(
@@ -64,7 +63,7 @@ def load_kaldi_data_dir(
                 )
             ],
             sampling_rate=sampling_rate,
-            num_samples=int(durations[recording_id]* sampling_rate),
+            num_samples=int(durations[recording_id] * sampling_rate),
             duration=durations[recording_id]
         )
         for recording_id, path_or_cmd in recordings.items()


### PR DESCRIPTION
closed #320 
I add some code to ignore read duration from reco2dur and read real audio_path in` wav.scp` to get duration.
Test time consumption: about 100 hours and ten seconds.

