### PR TITLE
Fix cut num of samples bug

### DIFF
--- a/lhotse/kaldi.py
+++ b/lhotse/kaldi.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Optional, Tuple
 from lhotse import CutSet, FeatureSet, Features, Seconds
 from lhotse.audio import AudioSource, Recording, RecordingSet
 from lhotse.supervision import SupervisionSegment, SupervisionSet
-from lhotse.utils import Pathlike, is_module_available
+from lhotse.utils import Pathlike, is_module_available, compute_num_samples
 from lhotse.audio import audioread_info 
 
 
@@ -63,7 +63,7 @@ def load_kaldi_data_dir(
                 )
             ],
             sampling_rate=sampling_rate,
-            num_samples=int(durations[recording_id] * sampling_rate),
+            num_samples=compute_num_samples(durations[recording_id], sampling_rate),
             duration=durations[recording_id]
         )
         for recording_id, path_or_cmd in recordings.items()

--- a/lhotse/qa.py
+++ b/lhotse/qa.py
@@ -168,7 +168,7 @@ def validate_recording(r: Recording, read_data: bool = False) -> None:
     assert r.num_channels > 0, f'Recording {r.id}: no channels available'
     assert isclose(expected_duration, r.duration), \
         f'Recording {r.id}: mismatched declared duration ({r.duration}) with ' \
-        f'num_samples:{r.num_samples} / sampling_rate:{r.sampling_rate} ({expected_duration}).'
+        f'num_samples / sampling_rate ({expected_duration}).'
     if read_data:
         samples = r.load_audio()
         n_ch, n_s = samples.shape

--- a/lhotse/qa.py
+++ b/lhotse/qa.py
@@ -168,7 +168,7 @@ def validate_recording(r: Recording, read_data: bool = False) -> None:
     assert r.num_channels > 0, f'Recording {r.id}: no channels available'
     assert isclose(expected_duration, r.duration), \
         f'Recording {r.id}: mismatched declared duration ({r.duration}) with ' \
-        f'num_samples / sampling_rate ({expected_duration}).'
+        f'num_samples:{r.num_samples} / sampling_rate:{r.sampling_rate} ({expected_duration}).'
     if read_data:
         samples = r.load_audio()
         n_ch, n_s = samples.shape


### PR DESCRIPTION
* Bug description:
Kaldi data loading utility is now using int() to compute `num_samples`, this may introduce rounding error that fails to pass QA check(default tolerance=1e-3) in 16k setup.

* detail example
BAC009S0002W0147.wav has 64192 samples:
```
$ soxi BAC009S0002W0147.wav
Input File     : 'BAC009S0002W0147.wav'
Channels       : 1
Sample Rate    : 16000
Precision      : 16-bit
Duration       : 00:00:04.01 = 64192 samples ~ 300.9 CDDA sectors
File Size      : 128k
Bit Rate       : 256k
Sample Encoding: 16-bit Signed Integer PCM
```

However from loaded cut, `BAC009S0002W0147` has num_samples = 64191:
```
Traceback (most recent call last):
  File "xxx.py", line 25, in <module>
    dataset = lhotse.dataset.K2SpeechRecognitionDataset(trn_cuts)
  File "/data/work/git/lhotse/lhotse/dataset/speech_recognition.py", line 94, in __init__
    validate_for_asr(self.cuts)
  File "/data/work/git/lhotse/lhotse/dataset/speech_recognition.py", line 150, in validate_for_asr
    validate(cuts)
  File "/data/work/git/lhotse/lhotse/qa.py", line 34, in validate
    valid(obj, read_data=read_data)
  File "/data/work/git/lhotse/lhotse/qa.py", line 314, in validate_cut_set
    validate_cut(c, read_data=read_data)
  File "/data/work/git/lhotse/lhotse/qa.py", line 253, in validate_cut
    validate_recording(c.recording)
  File "/data/work/git/lhotse/lhotse/qa.py", line 169, in validate_recording
    assert isclose(expected_duration, r.duration), \
AssertionError: Recording BAC009S0002W0147: mismatched declared duration (4.012) with num_samples=64191 / sampling_rate=16000 (4.0119375).
```

* fix
use lhotse.utils.compute_num_samples() instead of int() rounding