### PR TITLE
Refactor and document the Cut hierarchy (Cut -> MonoCut, CutUtilsBase -> Cut)

### DIFF
--- a/docs/cuts.rst
+++ b/docs/cuts.rst
@@ -15,6 +15,11 @@ Task-specific datasets can leverage this information to generate masks for such 
     :no-special-members:
     :noindex:
 
+.. autoclass:: lhotse.cut.CutSet
+    :no-members:
+    :no-special-members:
+    :noindex:
+
 Types of cuts
 *************
 
@@ -39,132 +44,17 @@ There are three cut classes: :class:`~lhotse.cut.MonoCut`, :class:`~lhotse.cut.M
 Each of these types has additional attributes that are not common - e.g., it makes sense to specify *start* for
 :class:`MonoCut` to locate it in the source recording, but it is undefined for :class:`MixedCut` and :class:`PaddingCut`.
 
-Cut manifests
-*************
-
-All cut types can be stored in the YAML manifests. An example manifest with simple cuts might look like:
-
-.. code-block:: yaml
-
-    - duration: 10.0
-      features:
-        channels: 0
-        duration: 16.04
-        num_features: 23
-        num_frames: 1604
-        recording_id: recording-1
-        start: 0.0
-        storage_path: test/fixtures/libri/storage/dc2e0952-f2f8-423c-9b8c-f5481652ee1d.llc
-        storage_type: lilcom
-        type: fbank
-      id: 849e13d8-61a2-4d09-a542-dac1aee1b544
-      start: 0.0
-      supervisions: []
-      type: MonoCut
-
-Notice that the cut type is specified in YAML. The supervisions list might be empty - some tasks do not need them,
-e.g. unsupervised training, source separation, or speech enhancement.
-
-Mixed cuts look differently in the manifest:
-
-.. code-block:: yaml
-
-    - id: mixed-cut-id
-      tracks:
-        - cut:
-            duration: 7.78
-            features:
-              channels: 0
-              duration: 7.78
-              type: fbank
-              num_frames: 778
-              num_features: 23
-              recording_id: 7850-286674-0014
-              start: 0.0
-              storage_path: test/fixtures/mix_cut_test/feats/storage/9dc645db-cbe4-4529-85e4-b6ed4f59c340.llc
-              storage_type: lilcom
-            id: 0c5fdf79-efe7-4d45-b612-3d90d9af8c4e
-            start: 0.0
-            supervisions:
-              - channel: 0
-                duration: 7.78
-                gender: f
-                id: 7850-286674-0014
-                language: null
-                recording_id: 7850-286674-0014
-                speaker: 7850-286674
-                start: 0.0
-                text: SURE ENOUGH THERE HE CAME THROUGH THE SHALLOW WATER HIS WET BACK SHELL PARTLY
-                  OUT OF IT AND SHINING IN THE SUNLIGHT
-          offset: 0.0
-        - cut:
-            duration: 9.705
-            features:
-              channels: 0
-              duration: 9.705
-              type: fbank
-              num_frames: 970
-              num_features: 23
-              recording_id: 2412-153948-0014
-              start: 0.0
-              storage_path: test/fixtures/mix_cut_test/feats/storage/5078e7eb-57a6-4000-b0f2-fa4bf9c52090.llc
-              storage_type: lilcom
-            id: 78bef88d-e62e-4cfa-9946-a1311442c6f7
-            start: 0.0
-            supervisions:
-              - channel: 0
-                duration: 9.705
-                gender: f
-                id: 2412-153948-0014
-                language: null
-                recording_id: 2412-153948-0014
-                speaker: 2412-153948
-                start: 0.0
-                text: THERE WAS NO ONE IN THE WHOLE WORLD WHO HAD THE SMALLEST IDEA SAVE THOSE
-                  WHO WERE THEMSELVES ON THE OTHER SIDE OF IT IF INDEED THERE WAS ANY ONE AT ALL
-                  COULD I HOPE TO CROSS IT
-          offset: 3.89
-          snr: 20.0
-      type: MixedCut
-
-Mixed cuts literally consist of simple cuts, their feature descriptions, and their supervisions.
-These are combined together when a user queries :class:`MixedCut` for supervisions, features, or duration.
-Note that the first simple cut is missing an SNR field - it is optional (i.e. *None*).
-That is because the semantics of 0 SNR are: re-scale one of the signals, so that the SNR between two signals is zero.
-We denote no re-scaling by not specifying the SNR at all.
-
-The amount of text in these manifests can be considerable in larger datasets, but they are highly compressible.
-We support their automated (de-)compression with gzip - it's sufficient to add ".gz" at the end of filename
-when writing or reading, both in Python classes and the CLI tools.
-
-Python
-******
-
-Some examples of how cuts can be manipulated to create a desired dataset for model training.
-
-.. code-block:: python
-
-    cuts = CutSet.from_yaml('cuts.yml')
-    # Reject too short segments
-    cuts = cuts.filter(lambda cut: cut.duration >= 3.0)
-    # Pad short segments with silence to 5 seconds.
-    cuts = cuts.pad(desired_duration=5.0)
-    # Truncate longer segments to 5 seconds.
-    cuts = cuts.truncate(max_duration=5.0, offset_type='random')
-    # Save cuts
-    cuts.to_yaml('cuts-5s.yml')
-
 CLI
 ***
 
 We provide a limited CLI to manipulate Lhotse manifests.
-Analogous examples of how to perform the same operations in the terminal:
+Some examples of how to perform manipulations in the terminal:
 
 .. code-block:: bash
 
     # Reject short segments
-    lhotse yaml filter duration>=3.0 cuts.yml cuts-3s.yml
+    lhotse yaml filter 'duration>=3.0' cuts.jsonl cuts-3s.jsonl
     # Pad short segments to 5 seconds.
-    lhotse cut pad --duration 5.0 cuts-3s.yml cuts-5s-pad.yml
+    lhotse cut pad --duration 5.0 cuts-3s.jsonl cuts-5s-pad.jsonl
     # Truncate longer segments to 5 seconds.
-    lhotse cut truncate --max-duration 5.0 --offset-type random cuts-5s-pad.yml cuts-5s.yml
+    lhotse cut truncate --max-duration 5.0 --offset-type random cuts-5s-pad.jsonl cuts-5s.jsonl

--- a/docs/cuts.rst
+++ b/docs/cuts.rst
@@ -10,47 +10,31 @@ The regions without a supervision are just audio that we don't assume we know an
 noise, non-transcribed speech, etc.
 Task-specific datasets can leverage this information to generate masks for such regions.
 
-Currently, cuts are created after the feature extraction step (we might still change that).
-It means that every cut also represents the extracted features for the part of recording it represents.
-
-Cuts can be modified using three basic operations: truncation, mixing and appending.
-These operations are not immediately performed on the audio or features.
-Instead, we create new :class:`Cut` objects, possibly of different types, that represent a cut after modification.
-We only modify the actual audio and feature matrices once the user calls :meth:`load_features` or :meth:`load_audio`.
-
-This design allows for quick on-the-fly data augmentation.
-In each training epoch, we may mix the cuts with different noises, SNRs, etc.
-We also do not need to re-compute and store the features for different mixes, as the mixing process consists of
-element-wise addition of the spectral energies (possibly with additional exp and log operations for log-energies).
-As of now, we only support this dynamic mix on log Mel energy (_fbank_) features.
-We anticipate to add support for other types of features as well.
-
 .. autoclass:: lhotse.cut.Cut
     :no-members:
     :no-special-members:
     :noindex:
 
-The common attributes for all cut objects are the following:
-
-- id
-- duration
-- supervisions
-- num_frames
-- num_features
-- load_features()
-- truncate()
-- mix()
-- append()
-- from_dict()
-
 Types of cuts
 *************
 
-There are three cut classes:
+There are three cut classes: :class:`~lhotse.cut.MonoCut`, :class:`~lhotse.cut.MixedCut`, and :class:`~lhotse.cut.PaddingCut` that are described below in more detail:
 
-- :class:`MonoCut`, also referred to as "simple cut", can be traced back to a single particular recording (and channel).
-- :class:`PaddingCut` is an "artificial" recording used for padding other Cuts through mixing to achieve uniform duration.
-- :class:`MixedCut` is a collection of :class:`MonoCut` and :class:`PaddingCut` objects, together with mix parameters: offset and desired sound-to-noise ratio (SNR) for each track. Both the offset and the SNR are relative to the first cut in the mix.
+.. autoclass:: lhotse.cut.MonoCut
+    :no-members:
+    :no-special-members:
+    :noindex:
+
+.. autoclass:: lhotse.cut.MixedCut
+    :no-members:
+    :no-special-members:
+    :noindex:
+
+
+.. autoclass:: lhotse.cut.PaddingCut
+    :no-members:
+    :no-special-members:
+    :noindex:
 
 Each of these types has additional attributes that are not common - e.g., it makes sense to specify *start* for
 :class:`MonoCut` to locate it in the source recording, but it is undefined for :class:`MixedCut` and :class:`PaddingCut`.
@@ -173,6 +157,7 @@ Some examples of how cuts can be manipulated to create a desired dataset for mod
 CLI
 ***
 
+We provide a limited CLI to manipulate Lhotse manifests.
 Analogous examples of how to perform the same operations in the terminal:
 
 .. code-block:: bash

--- a/docs/cuts.rst
+++ b/docs/cuts.rst
@@ -25,6 +25,11 @@ element-wise addition of the spectral energies (possibly with additional exp and
 As of now, we only support this dynamic mix on log Mel energy (_fbank_) features.
 We anticipate to add support for other types of features as well.
 
+.. autoclass:: lhotse.cut.Cut
+    :no-members:
+    :no-special-members:
+    :noindex:
+
 The common attributes for all cut objects are the following:
 
 - id

--- a/docs/cuts.rst
+++ b/docs/cuts.rst
@@ -43,12 +43,12 @@ Types of cuts
 
 There are three cut classes:
 
-- :class:`Cut`, also referred to as "simple cut", can be traced back to a single particular recording (and channel).
+- :class:`MonoCut`, also referred to as "simple cut", can be traced back to a single particular recording (and channel).
 - :class:`PaddingCut` is an "artificial" recording used for padding other Cuts through mixing to achieve uniform duration.
-- :class:`MixedCut` is a collection of :class:`Cut` and :class:`PaddingCut` objects, together with mix parameters: offset and desired sound-to-noise ratio (SNR) for each track. Both the offset and the SNR are relative to the first cut in the mix.
+- :class:`MixedCut` is a collection of :class:`MonoCut` and :class:`PaddingCut` objects, together with mix parameters: offset and desired sound-to-noise ratio (SNR) for each track. Both the offset and the SNR are relative to the first cut in the mix.
 
 Each of these types has additional attributes that are not common - e.g., it makes sense to specify *start* for
-:class:`Cut` to locate it in the source recording, but it is undefined for :class:`MixedCut` and :class:`PaddingCut`.
+:class:`MonoCut` to locate it in the source recording, but it is undefined for :class:`MixedCut` and :class:`PaddingCut`.
 
 Cut manifests
 *************
@@ -71,7 +71,7 @@ All cut types can be stored in the YAML manifests. An example manifest with simp
       id: 849e13d8-61a2-4d09-a542-dac1aee1b544
       start: 0.0
       supervisions: []
-      type: Cut
+      type: MonoCut
 
 Notice that the cut type is specified in YAML. The supervisions list might be empty - some tasks do not need them,
 e.g. unsupervised training, source separation, or speech enhancement.

--- a/lhotse/__init__.py
+++ b/lhotse/__init__.py
@@ -8,7 +8,7 @@ with warnings.catch_warnings():
 
 from .audio import AudioSource, Recording, RecordingSet
 from .augmentation import *
-from .cut import Cut, CutSet
+from .cut import MonoCut, CutSet
 from .features import *
 from .kaldi import load_kaldi_data_dir
 from .manipulation import combine, to_manifest

--- a/lhotse/audio.py
+++ b/lhotse/audio.py
@@ -391,7 +391,7 @@ class Recording:
 
 class RecordingSet(Serializable, Sequence[Recording]):
     """
-    RecordingSet represents a collection of recordings.
+    :class:`~lhotse.audio.RecordingSet` represents a collection of recordings, indexed by recording IDs.
     It does not contain any annotation such as the transcript or the speaker identity --
     just the information needed to retrieve a recording such as its path, URL, number of channels,
     and some recording metadata (duration, number of samples).
@@ -412,6 +412,10 @@ class RecordingSet(Serializable, Sequence[Recording]):
             >>> from lhotse import RecordingSet
             >>> audio_paths = ['123-5678.wav', ...]
             >>> recs = RecordingSet.from_recordings(Recording.from_file(p) for p in audio_paths)
+
+        As well as from a directory, which will be scanned recursively for files with parallel processing::
+
+            >>> recs2 = RecordingSet.from_dir('/data/audio', pattern='*.flac', num_jobs=4)
 
         It behaves similarly to a ``dict``::
 

--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -100,7 +100,7 @@ class Cut:
         >>> feats = cut.compute_features(extractor=Fbank())
 
     It is also possible to use a :class:`~lhotse.features.io.FeaturesWriter` to store the features and attach
-     their manifest to a copy of the cut::
+    their manifest to a copy of the cut::
 
         >>> from lhotse import LilcomHdf5Writer
         >>> with LilcomHdf5Writer('feats.h5') as storage:

--- a/lhotse/dataset/cut_transforms/concatenate.py
+++ b/lhotse/dataset/cut_transforms/concatenate.py
@@ -1,7 +1,7 @@
 from typing import Optional, Sequence
 
 from lhotse import CutSet
-from lhotse.cut import AnyCut
+from lhotse.cut import Cut
 from lhotse.utils import Seconds
 
 
@@ -38,7 +38,7 @@ class CutConcatenate:
 
 
 def concat_cuts(
-        cuts: Sequence[AnyCut],
+        cuts: Sequence[Cut],
         gap: Seconds = 1.0,
         max_duration: Optional[Seconds] = None
 ) -> CutSet:

--- a/lhotse/dataset/sampling.py
+++ b/lhotse/dataset/sampling.py
@@ -7,7 +7,7 @@ import torch.distributed as dist
 from torch.utils.data import Sampler
 
 from lhotse import CutSet
-from lhotse.cut import AnyCut
+from lhotse.cut import Cut
 from lhotse.utils import Seconds, exactly_one_not_null, is_none_or_gt
 
 
@@ -105,7 +105,7 @@ class CutSampler(Sampler[List[str]]):
 
         self._maybe_init_distributed(world_size=world_size, rank=rank)
         self.num_batches = None
-        self._filter_fn: Optional[Callable[[AnyCut], bool]] = None
+        self._filter_fn: Optional[Callable[[Cut], bool]] = None
 
     def _maybe_init_distributed(self, world_size: Optional[int], rank: Optional[int]):
         if world_size is not None:
@@ -131,7 +131,7 @@ class CutSampler(Sampler[List[str]]):
         self.epoch = epoch
         self.num_batches = None
 
-    def filter(self, predicate: Callable[[AnyCut], bool]) -> None:
+    def filter(self, predicate: Callable[[Cut], bool]) -> None:
         """
         Add a constraint on invidual cuts that has to be satisfied to consider them.
 
@@ -214,7 +214,7 @@ class TimeConstraint:
         """Is it an actual constraint, or a dummy one (i.e. never exceeded)."""
         return any(x is not None for x in self._constraints)
 
-    def add(self, cut: AnyCut) -> None:
+    def add(self, cut: Cut) -> None:
         """
         Increment the internal counter for the time constraint,
         selecting the right property from the input ``cut`` object.
@@ -550,7 +550,7 @@ class BucketingSampler(CutSampler):
             s.set_epoch(epoch)
         super().set_epoch(epoch)
 
-    def filter(self, predicate: Callable[[AnyCut], bool]) -> None:
+    def filter(self, predicate: Callable[[Cut], bool]) -> None:
         """
         Add a constraint on invidual cuts that has to be satisfied to consider them.
 

--- a/lhotse/dataset/source_separation.py
+++ b/lhotse/dataset/source_separation.py
@@ -5,7 +5,7 @@ import torch
 from torch.utils.data import Dataset
 
 from lhotse import validate
-from lhotse.cut import AnyCut, Cut, CutSet
+from lhotse.cut import Cut, CutSet, MonoCut
 from lhotse.utils import EPSILON
 
 
@@ -38,7 +38,7 @@ class SourceSeparationDataset(Dataset):
         self.mixtures_set = mixtures_set
         self.cut_ids = list(self.mixtures_set.ids)
 
-    def _obtain_mixture(self, cut_id: str) -> Tuple[AnyCut, List[Cut]]:
+    def _obtain_mixture(self, cut_id: str) -> Tuple[Cut, List[MonoCut]]:
         raise NotImplementedError("You are using SpeechSeparationDataset, which is an abstract base class; instead, "
                                   "use one of its derived classes that specify whether the mix is pre-computed or "
                                   "done dynamically (on-the-fly).")
@@ -116,7 +116,7 @@ class DynamicallyMixedSourceSeparationDataset(SourceSeparationDataset):
         super().validate()
         validate(self.nonsources_set)
 
-    def _obtain_mixture(self, cut_id: str) -> Tuple[AnyCut, List[Cut]]:
+    def _obtain_mixture(self, cut_id: str) -> Tuple[Cut, List[MonoCut]]:
         mixture_cut = self.mixtures_set.mixed_cuts[cut_id]
         source_cuts = [
             track.cut
@@ -162,7 +162,7 @@ class PreMixedSourceSeparationDataset(SourceSeparationDataset):
         }
         super().__init__(sources_set=sources_set, mixtures_set=mixtures_set)
 
-    def _obtain_mixture(self, cut_id: str) -> Tuple[AnyCut, List[Cut]]:
+    def _obtain_mixture(self, cut_id: str) -> Tuple[Cut, List[MonoCut]]:
         mixture_cut = self.mixtures_set.cuts[cut_id]
         source_cuts = [self.sources_set.cuts[id] for id in self.mixture_to_source[mixture_cut.id]]
         return mixture_cut, source_cuts

--- a/lhotse/manipulation.py
+++ b/lhotse/manipulation.py
@@ -4,11 +4,11 @@ from operator import add
 from typing import Iterable, Optional, TypeVar, Union
 
 from lhotse.audio import Recording, RecordingSet
-from lhotse.cut import Cut, CutSet, MixedCut
+from lhotse.cut import CutSet, MixedCut, MonoCut
 from lhotse.features import FeatureSet, Features
 from lhotse.supervision import SupervisionSegment, SupervisionSet
 
-ManifestItem = TypeVar('ManifestItem', Recording, SupervisionSegment, Features, Cut, MixedCut)
+ManifestItem = TypeVar('ManifestItem', Recording, SupervisionSegment, Features, MonoCut, MixedCut)
 Manifest = TypeVar('Manifest', RecordingSet, SupervisionSet, FeatureSet, CutSet)
 
 
@@ -43,7 +43,7 @@ def to_manifest(items: Iterable[ManifestItem]) -> Optional[Manifest]:
         return RecordingSet.from_recordings(items)
     if isinstance(first_item, SupervisionSegment):
         return SupervisionSet.from_segments(items)
-    if isinstance(first_item, (Cut, MixedCut)):
+    if isinstance(first_item, (MonoCut, MixedCut)):
         return CutSet.from_cuts(items)
     if isinstance(first_item, Features):
         raise ValueError("FeatureSet generic construction from iterable is not possible, as the config information "

--- a/lhotse/supervision.py
+++ b/lhotse/supervision.py
@@ -297,7 +297,8 @@ class SupervisionSegment:
 class SupervisionSet(Serializable, Sequence[SupervisionSegment]):
     """
     :class:`~lhotse.supervision.SupervisionSet` represents a collection of segments containing some
-    supervision information (see :class:`~lhotse.supervision.SupervisionSegment`).
+    supervision information (see :class:`~lhotse.supervision.SupervisionSegment`),
+    that are indexed by segment IDs.
 
     It acts as a Python ``dict``, extended with an efficient ``find`` operation that indexes and caches
     the supervision segments in an interval tree.

--- a/lhotse/supervision.py
+++ b/lhotse/supervision.py
@@ -76,7 +76,7 @@ class SupervisionSegment:
     Since it is difficult to predict all possible types of metadata, the ``custom`` field (a dict) can be used to
     insert types of supervisions that are not supported out of the box.
 
-    :class:`~lhotse.supervsion.SupervisionSegment` may containing multiple types of alignments.
+    :class:`~lhotse.supervsion.SupervisionSegment` may contain multiple types of alignments.
     The ``alignment`` field is a dict, indexed by alignment's type (e.g., ``word`` or ``phone``),
     and contains a list of :class:`~lhotse.supervision.AlignmentItem` objects -- simple structures
     that contain a given symbol and its time interval.

--- a/lhotse/testing/dummies.py
+++ b/lhotse/testing/dummies.py
@@ -1,11 +1,11 @@
-from typing import Optional, Type, Dict, List
+from typing import Dict, List, Optional, Type
 
 from lhotse import AudioSource
 from lhotse.audio import Recording, RecordingSet
-from lhotse.cut import Cut, CutSet
+from lhotse.cut import CutSet, MonoCut
 from lhotse.features import FeatureSet, Features
 from lhotse.manipulation import Manifest
-from lhotse.supervision import SupervisionSegment, SupervisionSet, AlignmentItem
+from lhotse.supervision import AlignmentItem, SupervisionSegment, SupervisionSet
 from lhotse.utils import fastcopy
 
 
@@ -83,7 +83,7 @@ def dummy_features(unique_id: int) -> Features:
 
 
 def dummy_cut(unique_id: int, start: float = 0.0, duration: float = 1.0, supervisions=None):
-    return Cut(
+    return MonoCut(
         id=f'dummy-cut-{unique_id:04d}',
         start=start,
         duration=duration,

--- a/test/augmentation/test_torchaudio.py
+++ b/test/augmentation/test_torchaudio.py
@@ -8,7 +8,7 @@ from hypothesis import strategies as st
 torchaudio = pytest.importorskip('torchaudio', minversion='0.6')
 
 from lhotse.augmentation import SoxEffectTransform, pitch, reverb, speed, Speed
-from lhotse import AudioTransform, Cut, Recording, Resample, Seconds
+from lhotse import AudioTransform, MonoCut, Recording, Resample, Seconds
 
 SAMPLING_RATE = 16000
 
@@ -92,5 +92,5 @@ def test_augmentation_chain_randomized(
     audio_aug = recording_aug.load_audio()
     assert audio_aug.shape[1] == recording_aug.num_samples
 
-    cut_aug = Cut(id='dummy', start=0.5125, duration=cut_duration, channel=0, recording=recording_aug)
+    cut_aug = MonoCut(id='dummy', start=0.5125, duration=cut_duration, channel=0, recording=recording_aug)
     assert cut_aug.load_audio().shape[1] == cut_aug.num_samples

--- a/test/cut/conftest.py
+++ b/test/cut/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 
 from lhotse.audio import AudioSource, Recording
-from lhotse.cut import Cut, CutSet
+from lhotse.cut import CutSet, MonoCut
 from lhotse.features import Features
 from lhotse.supervision import SupervisionSegment
 
@@ -23,19 +23,20 @@ def dummy_recording():
 
 @pytest.fixture
 def cut1(dummy_features, dummy_recording):
-    return Cut(id='cut-1', start=0.0, duration=10.0, channel=0, features=dummy_features, recording=dummy_recording,
-               supervisions=[
-                   SupervisionSegment(id='sup-1', recording_id='irrelevant', start=0.5, duration=6.0),
-                   SupervisionSegment(id='sup-2', recording_id='irrelevant', start=7.0, duration=2.0)
-               ])
+    return MonoCut(id='cut-1', start=0.0, duration=10.0, channel=0, features=dummy_features, recording=dummy_recording,
+                   supervisions=[
+                       SupervisionSegment(id='sup-1', recording_id='irrelevant', start=0.5, duration=6.0),
+                       SupervisionSegment(id='sup-2', recording_id='irrelevant', start=7.0, duration=2.0)
+                   ])
 
 
 @pytest.fixture
 def cut2(dummy_features, dummy_recording):
-    return Cut(id='cut-2', start=180.0, duration=10.0, channel=0, features=dummy_features, recording=dummy_recording,
-               supervisions=[
-                   SupervisionSegment(id='sup-3', recording_id='irrelevant', start=3.0, duration=2.5)
-               ])
+    return MonoCut(id='cut-2', start=180.0, duration=10.0, channel=0, features=dummy_features,
+                   recording=dummy_recording,
+                   supervisions=[
+                       SupervisionSegment(id='sup-3', recording_id='irrelevant', start=3.0, duration=2.5)
+                   ])
 
 
 @pytest.fixture

--- a/test/cut/test_cut.py
+++ b/test/cut/test_cut.py
@@ -1,9 +1,10 @@
-import pytest
 from tempfile import NamedTemporaryFile
+
 import numpy as np
+import pytest
 
 from lhotse.audio import AudioSource, Recording, RecordingSet
-from lhotse.cut import Cut, CutSet
+from lhotse.cut import CutSet, MonoCut
 from lhotse.features import FeatureSet, Features
 from lhotse.supervision import SupervisionSegment, SupervisionSet
 from lhotse.testing.dummies import dummy_cut, dummy_supervision
@@ -30,7 +31,7 @@ def supervision_set():
 
 
 @pytest.fixture
-def libri_cut(libri_cut_set) -> Cut:
+def libri_cut(libri_cut_set) -> MonoCut:
     return libri_cut_set['e3e70682-c209-4cac-629f-6fbed82c07cd']
 
 

--- a/test/cut/test_cut_augmentation.py
+++ b/test/cut/test_cut_augmentation.py
@@ -1,6 +1,6 @@
 import pytest
 
-from lhotse import AudioSource, Cut, CutSet, Recording, SupervisionSegment
+from lhotse import AudioSource, MonoCut, CutSet, Recording, SupervisionSegment
 from lhotse.cut import PaddingCut
 
 
@@ -16,7 +16,7 @@ def recording(file_source):
 
 @pytest.fixture
 def cut_with_supervision(recording):
-    return Cut(
+    return MonoCut(
         id='cut',
         start=0.0,
         duration=0.5,
@@ -81,7 +81,7 @@ def test_cut_perturb_speed09(cut_with_supervision):
 
 @pytest.fixture
 def cut_with_supervision_start01(recording):
-    return Cut(
+    return MonoCut(
         id='cut_start01',
         start=0.1,
         duration=0.4,

--- a/test/cut/test_cut_truncate.py
+++ b/test/cut/test_cut_truncate.py
@@ -2,7 +2,7 @@ from math import isclose
 
 import pytest
 
-from lhotse.cut import Cut, MixTrack, MixedCut
+from lhotse.cut import MonoCut, MixTrack, MixedCut
 from lhotse.features import Features
 from lhotse.supervision import SupervisionSegment
 from lhotse.testing.dummies import dummy_cut
@@ -10,7 +10,7 @@ from lhotse.testing.dummies import dummy_cut
 
 @pytest.fixture
 def overlapping_supervisions_cut():
-    return Cut(
+    return MonoCut(
         id='cut-1',
         start=0.0,
         duration=0.5,
@@ -126,7 +126,7 @@ def test_truncate_mixed_cut_with_small_offset(simple_mixed_cut):
 
 def test_truncate_mixed_cut_with_offset_exceeding_first_track(simple_mixed_cut):
     truncated_cut = simple_mixed_cut.truncate(offset=11.0)
-    assert isinstance(truncated_cut, Cut)
+    assert isinstance(truncated_cut, MonoCut)
     assert truncated_cut.start == 6.0
     assert truncated_cut.duration == 4.0
     assert truncated_cut.end == 10.0
@@ -152,7 +152,7 @@ def test_truncate_mixed_cut_decreased_duration(simple_mixed_cut):
 
 def test_truncate_mixed_cut_decreased_duration_removing_last_cut(simple_mixed_cut):
     truncated_cut = simple_mixed_cut.truncate(duration=4.0)
-    assert isinstance(truncated_cut, Cut)
+    assert isinstance(truncated_cut, MonoCut)
     assert truncated_cut.start == 0.0
     assert truncated_cut.duration == 4.0
     assert truncated_cut.end == 4.0

--- a/test/cut/test_feature_extraction.py
+++ b/test/cut/test_feature_extraction.py
@@ -9,7 +9,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from lhotse import Cut, CutSet, Fbank, LilcomHdf5Writer, Recording
+from lhotse import MonoCut, CutSet, Fbank, LilcomHdf5Writer, Recording
 from lhotse.audio import AudioSource
 from lhotse.cut import MixedCut
 from lhotse.features.io import LilcomFilesWriter
@@ -28,7 +28,7 @@ def recording():
 
 @pytest.fixture
 def cut(recording):
-    return Cut(id='cut', start=0, duration=1.0, channel=0, recording=recording)
+    return MonoCut(id='cut', start=0, duration=1.0, channel=0, recording=recording)
 
 
 def test_extract_features(cut):

--- a/test/cut/test_masks.py
+++ b/test/cut/test_masks.py
@@ -5,7 +5,7 @@ from numpy.lib import index_exp
 import pytest
 import numpy as np
 
-from lhotse import Cut, SupervisionSegment
+from lhotse import MonoCut, SupervisionSegment
 from lhotse.cut import PaddingCut
 from lhotse.supervision import AlignmentItem
 from lhotse.utils import LOG_EPSILON
@@ -13,13 +13,13 @@ from lhotse.utils import LOG_EPSILON
 
 class TestMasksWithoutSupervisions:
     def test_cut_audio_mask(self):
-        cut = Cut('cut', start=0, duration=2, channel=0, recording=Mock(sampling_rate=16000))
+        cut = MonoCut('cut', start=0, duration=2, channel=0, recording=Mock(sampling_rate=16000))
         mask = cut.supervisions_audio_mask()
         assert mask.sum() == 0
 
     def test_cut_features_mask(self):
-        cut = Cut('cut', start=0, duration=2, channel=0,
-                  features=Mock(sampling_rate=16000, frame_shift=0.01, num_frames=2000))
+        cut = MonoCut('cut', start=0, duration=2, channel=0,
+                      features=Mock(sampling_rate=16000, frame_shift=0.01, num_frames=2000))
         mask = cut.supervisions_feature_mask()
         assert mask.sum() == 0
 
@@ -35,13 +35,13 @@ class TestMasksWithoutSupervisions:
         assert mask.sum() == 0
 
     def test_mixed_cut_audio_mask(self):
-        cut = Cut('cut', start=0, duration=2, channel=0, recording=Mock(sampling_rate=16000))
+        cut = MonoCut('cut', start=0, duration=2, channel=0, recording=Mock(sampling_rate=16000))
         mixed_cut = cut.append(cut)
         mask = mixed_cut.supervisions_audio_mask()
         assert mask.sum() == 0
 
     def test_mixed_cut_features_mask(self):
-        cut = Cut('cut', start=0, duration=2, channel=0, features=Mock(sampling_rate=16000, frame_shift=0.01))
+        cut = MonoCut('cut', start=0, duration=2, channel=0, features=Mock(sampling_rate=16000, frame_shift=0.01))
         mixed_cut = cut.append(cut)
         mask = mixed_cut.supervisions_feature_mask()
         assert mask.sum() == 0
@@ -71,46 +71,46 @@ def supervisions():
 class TestMasksWithSupervisions:
     @pytest.mark.parametrize('alignment', [None, 'word'])
     def test_cut_audio_mask(self, supervisions, alignment):
-        cut = Cut('cut', start=0, duration=2, channel=0, recording=Mock(sampling_rate=16000),
-                  supervisions=supervisions)
+        cut = MonoCut('cut', start=0, duration=2, channel=0, recording=Mock(sampling_rate=16000),
+                      supervisions=supervisions)
         mask = cut.supervisions_audio_mask(use_alignment_if_exists=alignment)
         if alignment == "word":
-            ones = np.index_exp[list(chain(range(0,1600), range(3200,6400), range(9600,12800)))]
-            zeros = np.index_exp[list(chain(range(1600,3200), range(6400,9600), range(12800,32000)))]
+            ones = np.index_exp[list(chain(range(0, 1600), range(3200, 6400), range(9600, 12800)))]
+            zeros = np.index_exp[list(chain(range(1600, 3200), range(6400, 9600), range(12800, 32000)))]
         else:
-            ones = np.index_exp[list(chain(range(0,8000), range(9600,12800)))]
-            zeros = np.index_exp[list(chain(range(8000,9600), range(12800,32000)))]
+            ones = np.index_exp[list(chain(range(0, 8000), range(9600, 12800)))]
+            zeros = np.index_exp[list(chain(range(8000, 9600), range(12800, 32000)))]
         assert (mask[ones] == 1).all()
         assert (mask[zeros] == 0).all()
 
     @pytest.mark.parametrize('alignment', [None, 'word'])
     def test_cut_features_mask(self, supervisions, alignment):
-        cut = Cut('cut', start=0, duration=2, channel=0,
-                  features=Mock(sampling_rate=16000, frame_shift=0.01, num_frames=2000),
-                  supervisions=supervisions)
+        cut = MonoCut('cut', start=0, duration=2, channel=0,
+                      features=Mock(sampling_rate=16000, frame_shift=0.01, num_frames=2000),
+                      supervisions=supervisions)
         mask = cut.supervisions_feature_mask(use_alignment_if_exists=alignment)
         if alignment == "word":
-            ones = np.index_exp[list(chain(range(0,10), range(20,40), range(60,80)))]
-            zeros = np.index_exp[list(chain(range(10,20), range(40,60), range(80,200)))]
+            ones = np.index_exp[list(chain(range(0, 10), range(20, 40), range(60, 80)))]
+            zeros = np.index_exp[list(chain(range(10, 20), range(40, 60), range(80, 200)))]
         else:
-            ones = np.index_exp[list(chain(range(0,50), range(60,80)))]
-            zeros = np.index_exp[list(chain(range(50,60), range(80,200)))]
+            ones = np.index_exp[list(chain(range(0, 50), range(60, 80)))]
+            zeros = np.index_exp[list(chain(range(50, 60), range(80, 200)))]
         assert (mask[ones] == 1).all()
         assert (mask[zeros] == 0).all()
 
     @pytest.mark.parametrize('alignment', [None, 'word'])
     def test_cut_speakers_audio_mask(self, supervisions, alignment):
-        cut = Cut('cut', start=0, duration=2, channel=0, recording=Mock(sampling_rate=16000),
-                  supervisions=supervisions)
+        cut = MonoCut('cut', start=0, duration=2, channel=0, recording=Mock(sampling_rate=16000),
+                      supervisions=supervisions)
         mask = cut.speakers_audio_mask(use_alignment_if_exists=alignment)
         if alignment == "word":
             ones = [
-                np.index_exp[list(chain(range(0,1600), range(3200,6400)))],
-                np.index_exp[list(chain(range(9600,12800)))]
+                np.index_exp[list(chain(range(0, 1600), range(3200, 6400)))],
+                np.index_exp[list(chain(range(9600, 12800)))]
             ]
             zeros = [
-                np.index_exp[list(chain(range(1600,3200), range(6400,32000)))],
-                np.index_exp[list(chain(range(0,9600), range(12800,32000)))]
+                np.index_exp[list(chain(range(1600, 3200), range(6400, 32000)))],
+                np.index_exp[list(chain(range(0, 9600), range(12800, 32000)))]
             ]
         else:
             ones = [np.index_exp[range(0,8000)], np.index_exp[range(9600,12800)]]
@@ -125,18 +125,18 @@ class TestMasksWithSupervisions:
 
     @pytest.mark.parametrize('alignment', [None, 'word'])
     def test_cut_speakers_features_mask(self, supervisions, alignment):
-        cut = Cut('cut', start=0, duration=2, channel=0,
-                  features=Mock(sampling_rate=16000, frame_shift=0.01, num_frames=2000),
-                  supervisions=supervisions)
+        cut = MonoCut('cut', start=0, duration=2, channel=0,
+                      features=Mock(sampling_rate=16000, frame_shift=0.01, num_frames=2000),
+                      supervisions=supervisions)
         mask = cut.speakers_feature_mask(use_alignment_if_exists=alignment)
         if alignment == "word":
             ones = [
-                np.index_exp[list(chain(range(0,10), range(20,40)))],
-                np.index_exp[list(chain(range(60,80)))]
+                np.index_exp[list(chain(range(0, 10), range(20, 40)))],
+                np.index_exp[list(chain(range(60, 80)))]
             ]
             zeros = [
-                np.index_exp[list(chain(range(10,20), range(40,200)))],
-                np.index_exp[list(chain(range(0,60), range(80,200)))]
+                np.index_exp[list(chain(range(10, 20), range(40, 200)))],
+                np.index_exp[list(chain(range(0, 60), range(80, 200)))]
             ]
         else:
             ones = [
@@ -153,21 +153,22 @@ class TestMasksWithSupervisions:
         assert (mask[1,zeros[1]] == 0).all()
 
     def test_mixed_cut_audio_mask(self, supervisions):
-        cut = Cut('cut', start=0, duration=2, channel=0, recording=Mock(sampling_rate=16000),
-                  supervisions=supervisions)
+        cut = MonoCut('cut', start=0, duration=2, channel=0, recording=Mock(sampling_rate=16000),
+                      supervisions=supervisions)
         mixed_cut = cut.append(cut)
         mask = mixed_cut.supervisions_audio_mask()
-        ones = np.index_exp[list(chain(range(0,8000), range(9600,12800), range(32000,40000), range(41600,44800)))]
-        zeros = np.index_exp[list(chain(range(8000,9600), range(12800,32000), range(40000,41600), range(44800,64000)))]
+        ones = np.index_exp[list(chain(range(0, 8000), range(9600, 12800), range(32000, 40000), range(41600, 44800)))]
+        zeros = np.index_exp[
+            list(chain(range(8000, 9600), range(12800, 32000), range(40000, 41600), range(44800, 64000)))]
         assert (mask[ones] == 1).all()
         assert (mask[zeros] == 0).all()
 
     def test_mixed_cut_features_mask(self, supervisions):
-        cut = Cut('cut', start=0, duration=2, channel=0, features=Mock(sampling_rate=16000, frame_shift=0.01),
-                  supervisions=supervisions)
+        cut = MonoCut('cut', start=0, duration=2, channel=0, features=Mock(sampling_rate=16000, frame_shift=0.01),
+                      supervisions=supervisions)
         mixed_cut = cut.append(cut)
         mask = mixed_cut.supervisions_feature_mask()
-        ones = np.index_exp[list(chain(range(0,50), range(60,80), range(200,250), range(260,280)))]
-        zeros = np.index_exp[list(chain(range(50,60), range(80,200), range(250,260), range(280,400)))]
+        ones = np.index_exp[list(chain(range(0, 50), range(60, 80), range(200, 250), range(260, 280)))]
+        zeros = np.index_exp[list(chain(range(50, 60), range(80, 200), range(250, 260), range(280, 400)))]
         assert (mask[ones] == 1).all()
         assert (mask[zeros] == 0).all()

--- a/test/cut/test_padding_cut.py
+++ b/test/cut/test_padding_cut.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 from lhotse.audio import AudioSource, Recording
-from lhotse.cut import Cut, CutSet, PaddingCut
+from lhotse.cut import MonoCut, CutSet, PaddingCut
 from lhotse.features import Features
 from lhotse.utils import EPSILON, LOG_EPSILON, nullcontext as does_not_raise
 
@@ -73,7 +73,7 @@ def test_truncate(padding_cut, offset, duration, expected_duration, expected_num
 
 @pytest.fixture
 def libri_cut():
-    return Cut(
+    return MonoCut(
         channel=0,
         duration=16.04,
         features=Features(

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -4,7 +4,7 @@ from lhotse.supervision import AlignmentItem
 
 import pytest
 
-from lhotse import AudioSource, Cut, CutSet, FeatureSet, Features, Recording, RecordingSet, SupervisionSegment, \
+from lhotse import AudioSource, MonoCut, CutSet, FeatureSet, Features, Recording, RecordingSet, SupervisionSegment, \
     SupervisionSet, load_manifest, store_manifest
 from lhotse.testing.dummies import DummyManifest
 from lhotse.utils import fastcopy, is_module_available, nullcontext as does_not_raise
@@ -100,7 +100,7 @@ def feature_set():
 
 @pytest.fixture
 def cut_set():
-    cut = Cut(
+    cut = MonoCut(
         id='cut-1',
         start=0.0,
         duration=10.0,


### PR DESCRIPTION
I am going with the name `MonoCut` because it always represents a single channel. The inheritance from `Cut` (which now is a real base class) is cleaner and shouldn't be confusing like before (especially after I write the updated docs). There is no need for the hacky typing hint `AnyCut` anymore.

In a future PR, I will need to explore if MixedCut is sufficient to represent multi-channel data for training, if not maybe we'll add a MultiCut.

I think that snowfall and existing training data should work fine with these changes, but I will test it anyway before I merge this PR.