### PR TITLE
Improving and fixing trim_to_supervisions, adding more documentation, fixes to filter_supervisions

### DIFF
--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -123,6 +123,16 @@ class Cut:
         All cut transformations are performed lazily, on-the-fly, upon calling ``load_audio`` or ``load_features``.
         The stored waveforms and features are untouched.
 
+    .. caution::
+        Operations on cuts are not mutating -- they return modified copies of :class:`.Cut` objects,
+        leaving the original object unmodified.
+
+    Cuts can be detached from parts of their metadata::
+
+        >>> cut_no_feat = cut.drop_features()
+        >>> cut_no_rec = cut.drop_recording()
+        >>> cut_no_sup = cut.drop_supervisions()
+
     Finally, cuts provide convenience methods to compute feature frame and audio sample masks for supervised regions::
 
         >>> sup_frames = cut.supervisions_feature_mask()
@@ -1611,6 +1621,10 @@ class CutSet(Serializable, Sequence[Cut]):
         >>> cuts_B = cuts.cut_into_windows(duration=5.0)
         >>> cuts_C = cuts.trim_to_unsupervised_segments()
 
+    .. caution::
+        Operations on cut sets are not mutating -- they return modified copies of :class:`.CutSet` objects,
+        leaving the original object unmodified (and all of its cuts are also unmodified).
+
     :class:`~lhotse.cut.CutSet` can be stored and read from JSON, JSONL, etc. and supports optional gzip compression::
 
         >>> cuts.to_file('cuts.jsonl.gz')
@@ -1654,6 +1668,12 @@ class CutSet(Serializable, Sequence[Cut]):
         >>> split_into_4 = cuts.split(num_splits=4)
         >>> random_sample = cuts.sample(n_cuts=10)
         >>> new_ids = cuts.modify_ids(lambda c: c.id + '-newid')
+
+    Cuts in a :class:`.CutSet` can be detached from parts of their metadata::
+
+        >>> cuts_no_feat = cuts.drop_features()
+        >>> cuts_no_rec = cuts.drop_recordings()
+        >>> cuts_no_sup = cuts.drop_supervisions()
 
     Sometimes specific sorting patterns are useful when a small CutSet represents a mini-batch::
 

--- a/test/cut/test_cut_drop_attributes.py
+++ b/test/cut/test_cut_drop_attributes.py
@@ -1,0 +1,83 @@
+import pytest
+
+from lhotse import CutSet
+from lhotse.cut import PaddingCut
+from lhotse.testing.dummies import dummy_cut, dummy_supervision
+
+parametrize_on_cut_types = pytest.mark.parametrize(
+    'cut', [
+        # MonoCut
+        dummy_cut(0, supervisions=[dummy_supervision(0)]),
+        # PaddingCut
+        PaddingCut('pad', duration=1.0, sampling_rate=16000, feat_value=-100,
+                   num_frames=100, frame_shift=0.01, num_features=80, num_samples=16000),
+        # MixedCut
+        dummy_cut(0, supervisions=[dummy_supervision(0)]).mix(
+            dummy_cut(1, supervisions=[dummy_supervision(1)]),
+            offset_other_by=0.5,
+            snr=10
+        )
+    ]
+)
+
+
+@parametrize_on_cut_types
+def test_drop_features(cut):
+    assert cut.has_features
+    cut_drop = cut.drop_features()
+    assert cut.has_features
+    assert not cut_drop.has_features
+
+
+@parametrize_on_cut_types
+def test_drop_recording(cut):
+    assert cut.has_recording
+    cut_drop = cut.drop_recording()
+    assert cut.has_recording
+    assert not cut_drop.has_recording
+
+
+@parametrize_on_cut_types
+def test_drop_supervisions(cut):
+    assert len(cut.supervisions) > 0 or isinstance(cut, PaddingCut)
+    cut_drop = cut.drop_supervisions()
+    assert len(cut.supervisions) > 0 or isinstance(cut, PaddingCut)
+    assert len(cut_drop.supervisions) == 0
+
+
+@pytest.fixture()
+def cutset():
+    return CutSet.from_cuts([
+        # MonoCut
+        dummy_cut(0, supervisions=[dummy_supervision(0)]),
+        # PaddingCut
+        PaddingCut('pad', duration=1.0, sampling_rate=16000, feat_value=-100,
+                   num_frames=100, frame_shift=0.01, num_features=80, num_samples=16000),
+        # MixedCut
+        dummy_cut(0, supervisions=[dummy_supervision(0)]).mix(
+            dummy_cut(1, supervisions=[dummy_supervision(1)]),
+            offset_other_by=0.5,
+            snr=10
+        )
+    ])
+
+
+def test_drop_features_cutset(cutset):
+    assert any(cut.has_features for cut in cutset)
+    cutset_drop = cutset.drop_features()
+    assert any(cut.has_features for cut in cutset)
+    assert all(not cut.has_features for cut in cutset_drop)
+
+
+def test_drop_recordings_cutset(cutset):
+    assert any(cut.has_recording for cut in cutset)
+    cutset_drop = cutset.drop_recordings()
+    assert any(cut.has_recording for cut in cutset)
+    assert all(not cut.has_recording for cut in cutset_drop)
+
+
+def test_drop_supervisions_cutset(cutset):
+    assert any(len(cut.supervisions) > 0 for cut in cutset)
+    cutset_drop = cutset.drop_supervisions()
+    assert any(len(cut.supervisions) > 0 for cut in cutset)
+    assert all(len(cut.supervisions) == 0 for cut in cutset_drop)


### PR DESCRIPTION
The changes to `trim_to_supervisions` will be useful for building conversational training datasets.