### PR TITLE
Mutable supervisions

### DIFF
--- a/lhotse/supervision.py
+++ b/lhotse/supervision.py
@@ -9,7 +9,7 @@ from lhotse.utils import Pathlike, Seconds, TimeSpan, asdict_nonull, compute_num
     fastcopy, ifnone, index_by_id_and_check, overspans, perturb_num_samples, split_sequence
 
 
-@dataclass#(frozen=True, unsafe_hash=True)
+@dataclass
 class AlignmentItem:
     """
     This class contains an alignment item, for example a word, along with its
@@ -61,7 +61,7 @@ class AlignmentItem:
         return AlignmentItem(transform_fn(self.symbol), self.start, self.duration)
 
 
-@dataclass#(frozen=True, unsafe_hash=True)
+@dataclass
 class SupervisionSegment:
     """
     :class:`~lhotse.supervsion.SupervisionSegment` represents a time interval (segment) annotated with some

--- a/lhotse/supervision.py
+++ b/lhotse/supervision.py
@@ -9,7 +9,7 @@ from lhotse.utils import Pathlike, Seconds, TimeSpan, asdict_nonull, compute_num
     fastcopy, ifnone, index_by_id_and_check, overspans, perturb_num_samples, split_sequence
 
 
-@dataclass(frozen=True, unsafe_hash=True)
+@dataclass#(frozen=True, unsafe_hash=True)
 class AlignmentItem:
     """
     This class contains an alignment item, for example a word, along with its
@@ -61,7 +61,7 @@ class AlignmentItem:
         return AlignmentItem(transform_fn(self.symbol), self.start, self.duration)
 
 
-@dataclass(frozen=True, unsafe_hash=True)
+@dataclass#(frozen=True, unsafe_hash=True)
 class SupervisionSegment:
     """
     :class:`~lhotse.supervsion.SupervisionSegment` represents a time interval (segment) annotated with some

--- a/test/test_supervision_set.py
+++ b/test/test_supervision_set.py
@@ -217,8 +217,3 @@ def test_supervision_trim_does_not_affect_nonnegative_start(supervision, start):
     supervision = fastcopy(supervision, start=start)
     trimmed = supervision.trim(50)
     assert trimmed.start == start
-
-
-def test_supervision_is_hashable(supervision):
-    # Check that we can create a dict with the supervision object as the key.
-    d = {supervision: supervision.duration}


### PR DESCRIPTION
I don't think that it makes sense to make any Lhotse manifest immutable. For large datasets like GigaSpeech, it is sometimes worth avoiding copying stuff around. It seems no code in Lhotse actually depended on them being immutable (I thought something did but I apparently re-wrote it in the past).

BTW I heard reports that `@dataclass(frozen=True)` is actually 10% slower than `frozen=False` due to how dataclasses are implemented -- so it might be a small win, although I did not measure it...