### PR TITLE
Chunked HDF5 feature storage + minor recording fixes + adjust GigaSpeech recipe

### DIFF
--- a/lhotse/audio.py
+++ b/lhotse/audio.py
@@ -349,7 +349,7 @@ class Recording:
             by affixing it with "_sp{factor}".
         :return: a modified copy of the current ``Recording``.
         """
-        transforms = self.transforms if self.transforms is not None else []
+        transforms = self.transforms.copy() if self.transforms is not None else []
         transforms.append(Speed(factor=factor).to_dict())
         new_num_samples = perturb_num_samples(self.num_samples, factor)
         new_duration = new_num_samples / self.sampling_rate
@@ -367,9 +367,10 @@ class Recording:
         :param sampling_rate: The new sampling rate.
         :return: A resampled ``Recording``.
         """
-        resampling = [
+        transforms = self.transforms.copy() if self.transforms is not None else []
+        transforms.append(
             Resample(source_sampling_rate=self.sampling_rate, target_sampling_rate=sampling_rate).to_dict()
-        ]
+        )
         new_num_samples = compute_num_samples(self.duration, sampling_rate, rounding=ROUND_HALF_UP)
         # Duration might need an adjustment when doing a non-trivial resampling
         # (e.g. 16000 -> 22050), where the resulting number of samples cannot
@@ -380,7 +381,7 @@ class Recording:
             duration=new_duration,
             num_samples=new_num_samples,
             sampling_rate=sampling_rate,
-            transforms=(self.transforms or []) + resampling
+            transforms=transforms
         )
 
     @staticmethod

--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -744,9 +744,14 @@ class MonoCut(Cut):
             # The result of calling that method with a range of (begin, end) is an iterable
             # of Intervals that contain the SupervisionSegments matching our criterion.
             # We call "interval.data" to obtain the underlying SupervisionSegment.
-            match_supervisions = tree.overlap if keep_excessive_supervisions else tree.envelop
+            # Additionally, when the method is tree.envelop, we use a small epsilon to
+            # extend the searched boundaries to account for possible float arithmetic errors.
+            if keep_excessive_supervisions:
+                intervals = tree.overlap(begin=offset, end=offset + new_duration)
+            else:
+                intervals = tree.envelop(begin=offset - 1e-3, end=offset + new_duration + 1e-3)
             supervisions = []
-            for interval in match_supervisions(begin=offset, end=offset + new_duration):
+            for interval in intervals:
                 # We are going to measure the overlap ratio of the supervision with the "truncated" cut
                 # and reject segments that overlap less than 1%. This way we can avoid quirks and errors
                 # of limited float precision.

--- a/lhotse/dataset/speech_recognition.py
+++ b/lhotse/dataset/speech_recognition.py
@@ -148,7 +148,7 @@ class K2SpeechRecognitionDataset(torch.utils.data.Dataset):
 
 def validate_for_asr(cuts: CutSet) -> None:
     validate(cuts)
-    tol = 1e-3  # 1ms
+    tol = 2e-3  # 1ms
     for cut in cuts:
         for supervision in cut.supervisions:
             assert supervision.start >= -tol, f"Supervisions starting before the cut are not supported for ASR" \

--- a/lhotse/features/__init__.py
+++ b/lhotse/features/__init__.py
@@ -10,6 +10,8 @@ from .fbank import (
     FbankConfig
 )
 from .io import (
+    ChunkedLilcomHdf5Reader,
+    ChunkedLilcomHdf5Writer,
     FeaturesReader,
     FeaturesWriter,
     KaldiReader,

--- a/lhotse/features/base.py
+++ b/lhotse/features/base.py
@@ -366,7 +366,7 @@ class Features:
                                                     sampling_rate=self.sampling_rate)
         # Right trim
         end = start + duration if duration is not None else None
-        if duration is not None and not isclose(end, self.end):
+        if duration is not None:
             right_offset_frames = left_offset_frames + compute_num_frames(duration, frame_shift=self.frame_shift,
                                                                           sampling_rate=self.sampling_rate)
 

--- a/lhotse/features/base.py
+++ b/lhotse/features/base.py
@@ -365,7 +365,6 @@ class Features:
             left_offset_frames = compute_num_frames(start - self.start, frame_shift=self.frame_shift,
                                                     sampling_rate=self.sampling_rate)
         # Right trim
-        end = start + duration if duration is not None else None
         if duration is not None:
             right_offset_frames = left_offset_frames + compute_num_frames(duration, frame_shift=self.frame_shift,
                                                                           sampling_rate=self.sampling_rate)

--- a/lhotse/features/compression.py
+++ b/lhotse/features/compression.py
@@ -1,0 +1,20 @@
+from typing import List
+
+import lilcom
+import numpy as np
+
+
+def lilcom_compress_chunked(
+        data: np.ndarray, tick_power: int = -5, do_regression=True, chunk_size: int = 100
+) -> List[bytes]:
+    num_frames, num_feats = data.shape
+    compressed = []
+    for begin in range(0, num_frames, chunk_size):
+        compressed.append(
+            lilcom.compress(
+                data[begin: begin + chunk_size],
+                tick_power=tick_power,
+                do_regression=do_regression,
+            )
+        )
+    return compressed

--- a/lhotse/features/io.py
+++ b/lhotse/features/io.py
@@ -1,5 +1,6 @@
 from abc import ABCMeta, abstractmethod
 from functools import lru_cache
+from math import ceil, floor
 from pathlib import Path
 from typing import List, Optional, Type
 
@@ -293,9 +294,19 @@ def lookup_cache_or_open(storage_path: str):
     return h5py.File(storage_path, 'r')
 
 
+@lru_cache(maxsize=None)
+def lookup_chunk_size(h5_file_handle) -> int:
+    """
+    Helper internal function to retrieve the chunk size from an HDF5 file.
+    Helps avoid unnecessary repeated disk reads.
+    """
+    return h5_file_handle[CHUNK_SIZE_KEY][()]  # [()] retrieves a scalar
+
+
 def close_cached_file_handles() -> None:
     """Closes the cached file handles in ``lookup_cache_or_open`` (see its docs for more details)."""
     lookup_cache_or_open.cache_clear()
+    lookup_chunk_size.cache_clear()
 
 
 @register_reader
@@ -448,6 +459,139 @@ class LilcomHdf5Writer(FeaturesWriter):
     def write(self, key: str, value: np.ndarray) -> str:
         serialized_feats = lilcom.compress(value, tick_power=self.tick_power)
         self.hdf.create_dataset(key, data=np.void(serialized_feats))
+        return key
+
+    def close(self) -> None:
+        return self.hdf.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+
+"""
+Lilcom-compressed numpy arrays, stored in HDF5 file, that store chunked features.
+They are suitable for storing features for long recordings since they are able to
+retrieve small chunks instead of full matrices.
+"""
+
+CHUNK_SIZE_KEY = '__LHOTSE_INTERNAL_CHUNK_SIZE__'
+
+
+@register_reader
+class ChunkedLilcomHdf5Reader(FeaturesReader):
+    """
+    Reads lilcom-compressed numpy arrays from a HDF5 file with chunked lilcom storage.
+    Each feature matrix is stored in an array of chunks - binary data compressed with lilcom.
+    Upon reading, we check how many chunks need to be retrieved to avoid excessive I/O.
+
+    ``storage_path`` corresponds to the HDF5 file path;
+    ``storage_key`` for each utterance is the key corresponding to the array (i.e. HDF5 "Group" name).
+    """
+    name = 'chunked_lilcom_hdf5'
+
+    def __init__(self, storage_path: Pathlike, *args, **kwargs):
+        super().__init__()
+        self.hdf = lookup_cache_or_open(storage_path)
+
+    def read(
+            self,
+            key: str,
+            left_offset_frames: int = 0,
+            right_offset_frames: Optional[int] = None
+    ) -> np.ndarray:
+        # First, determine which range of chunks need to be read.
+        chunk_size = lookup_chunk_size(self.hdf)
+        left_chunk_idx = floor(left_offset_frames / chunk_size)
+        if right_offset_frames is not None:
+            right_chunk_idx = ceil(right_offset_frames / chunk_size)
+        else:
+            right_chunk_idx = None
+
+        # Read, decode, concat
+        arr = np.concatenate([
+            lilcom.decompress(data.tobytes())
+            for data in self.hdf[key][left_chunk_idx: right_chunk_idx]
+        ], axis=0)
+
+        # Determine what piece of decoded data should be returned;
+        # we offset the input offsets by left_chunk_idx * chunk_size.
+        shift_frames = chunk_size * left_chunk_idx
+        left_offset_shift = left_offset_frames - shift_frames
+        if right_offset_frames is not None:
+            right_offset_shift = right_offset_frames - shift_frames
+        else:
+            right_offset_shift = None
+
+        return arr[left_offset_shift: right_offset_shift]
+
+
+@register_writer
+class ChunkedLilcomHdf5Writer(FeaturesWriter):
+    """
+    Writes lilcom-compressed numpy arrays to a HDF5 file with chunked lilcom storage.
+    Each feature matrix is stored in an array of chunks - binary data compressed with lilcom.
+    Upon reading, we check how many chunks need to be retrieved to avoid excessive I/O.
+
+    ``storage_path`` corresponds to the HDF5 file path;
+    ``storage_key`` for each utterance is the key corresponding to the array (i.e. HDF5 "Group" name).
+    """
+    name = 'chunked_lilcom_hdf5'
+
+    def __init__(
+            self,
+            storage_path: Pathlike,
+            tick_power: int = -5,
+            chunk_size: int = 100,
+            mode: str = 'w',
+            *args,
+            **kwargs
+    ):
+        """
+        :param storage_path: Path under which we'll create the HDF5 file.
+            We will add a ``.h5`` suffix if it is not already in ``storage_path``.
+        :param tick_power: Determines the lilcom compression accuracy;
+            the input will be compressed to integer multiples of 2^tick_power.
+        :param chunk_size: How many frames to store per chunk.
+            Too low a number will require many reads for long feature matrices,
+            too high a number will require to read more redundant data.
+        :param mode: Modes supported by h5py:
+            w        Create file, truncate if exists (default)
+            w- or x  Create file, fail if exists
+            a        Read/write if exists, create otherwise
+        """
+        super().__init__()
+        import h5py
+        self.storage_path_ = Path(storage_path).with_suffix('.h5')
+        self.tick_power = tick_power
+        self.chunk_size = chunk_size
+        self.hdf = h5py.File(self.storage_path, mode=mode)
+        if CHUNK_SIZE_KEY in self.hdf:
+            retrieved_chunk_size = self.hdf[CHUNK_SIZE_KEY][()]
+            assert retrieved_chunk_size == CHUNK_SIZE_KEY, \
+                f'Error: attempted to write with chunk size {self.chunk_size} to an h5py file that ' \
+                f'was created with chunk size {retrieved_chunk_size}.'
+        else:
+            self.hdf.create_dataset(CHUNK_SIZE_KEY, data=self.chunk_size)
+
+    @property
+    def storage_path(self) -> str:
+        return str(self.storage_path_)
+
+    def write(self, key: str, value: np.ndarray) -> str:
+        import h5py
+        from lhotse.features.compression import lilcom_compress_chunked
+
+        serialized_feats = lilcom_compress_chunked(
+            value, tick_power=self.tick_power, chunk_size=self.chunk_size
+        )
+        dset = self.hdf.create_dataset(
+            key, dtype=h5py.vlen_dtype(np.dtype('uint8')), shape=(len(serialized_feats),)
+        )
+        for idx, feat in enumerate(serialized_feats):
+            dset[idx] = np.frombuffer(feat, dtype=np.uint8)
         return key
 
     def close(self) -> None:

--- a/lhotse/recipes/gigaspeech.py
+++ b/lhotse/recipes/gigaspeech.py
@@ -65,6 +65,8 @@ def prepare_gigaspeech(
     corpus_dir = Path(corpus_dir)
     gigaspeech = GigaSpeech(corpus_dir)
 
+    manifests = defaultdict(dict)
+
     if output_dir is not None:
         output_dir = Path(output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
@@ -72,12 +74,12 @@ def prepare_gigaspeech(
         maybe_manifests = read_manifests_if_cached(
             dataset_parts=dataset_parts,
             output_dir=output_dir,
-            suffix='jsonl.gz'
+            suffix='jsonl.gz',
+            prefix='gigaspeech'
         )
         if maybe_manifests is not None:
             return maybe_manifests
 
-    manifests = defaultdict(dict)
     with ProcessPoolExecutor(num_jobs) as ex:
         for part in subsets:
             logging.info(f'Processing GigaSpeech subset: {part}')
@@ -97,8 +99,8 @@ def prepare_gigaspeech(
             }
 
             if output_dir is not None:
-                manifests[part]['recordings'].to_file(output_dir / f'recordings_gigaspeech_{part}.jsonl.gz')
-                manifests[part]['supervisions'].to_file(output_dir / f'supervisions_gigaspeech_{part}.jsonl.gz')
+                manifests[part]['recordings'].to_file(output_dir / f'gigaspeech_recordings_{part}.jsonl.gz')
+                manifests[part]['supervisions'].to_file(output_dir / f'gigaspeech_supervisions_{part}.jsonl.gz')
 
     return dict(manifests)
 

--- a/lhotse/recipes/utils.py
+++ b/lhotse/recipes/utils.py
@@ -6,12 +6,15 @@ from lhotse.audio import RecordingSet
 from lhotse.supervision import SupervisionSet
 from lhotse.utils import Pathlike
 
+DEFAULT_DETECTED_MANIFEST_TYPES = ('recordings', 'supervisions')
+
 
 def read_manifests_if_cached(
         dataset_parts: Optional[Sequence[str]],
         output_dir: Optional[Pathlike],
         prefix: str = '',
-        suffix: Optional[str] = 'json'
+        suffix: Optional[str] = 'json',
+        types: Iterable[str] = DEFAULT_DETECTED_MANIFEST_TYPES
 ) -> Dict[str, Dict[str, Union[RecordingSet, SupervisionSet]]]:
     """
     Loads manifests from the disk, or a subset of them if only some exist.
@@ -23,6 +26,7 @@ def read_manifests_if_cached(
     :param output_dir: Where to look for the files.
     :param prefix: Optional common prefix for the manifest files (underscore is automatically added).
     :param suffix: Optional common suffix for the manifest files ("json" by default).
+    :param types: Which types of manifests are searched for (default: 'recordings' and 'supervisions').
     :return: A dict with manifest (``d[dataset_part]['recording'|'manifest']``) or ``None``.
     """
     if output_dir is None:
@@ -33,7 +37,7 @@ def read_manifests_if_cached(
         suffix = suffix[1:]
     manifests = defaultdict(dict)
     for part in dataset_parts:
-        for manifest in ('recordings', 'supervisions'):
+        for manifest in types:
             path = output_dir / f'{prefix}{manifest}_{part}.{suffix}'
             if not path.is_file():
                 continue
@@ -44,7 +48,7 @@ def read_manifests_if_cached(
 def manifests_exist(
         part: str,
         output_dir: Optional[Pathlike],
-        types: Iterable[str] = ('recordings', 'supervision'),
+        types: Iterable[str] = DEFAULT_DETECTED_MANIFEST_TYPES,
         prefix: str = '',
         suffix: str = 'json'
 ) -> bool:

--- a/lhotse/recipes/utils.py
+++ b/lhotse/recipes/utils.py
@@ -44,7 +44,7 @@ def read_manifests_if_cached(
 def manifests_exist(
         part: str,
         output_dir: Optional[Pathlike],
-        types: Iterable[str] = ('recording', 'supervision'),
+        types: Iterable[str] = ('recordings', 'supervision'),
         prefix: str = '',
         suffix: str = 'json'
 ) -> bool:

--- a/test/cut/test_cut_augmentation.py
+++ b/test/cut/test_cut_augmentation.py
@@ -1,6 +1,6 @@
 import pytest
 
-from lhotse import AudioSource, MonoCut, CutSet, Recording, SupervisionSegment
+from lhotse import AudioSource, CutSet, MonoCut, Recording, SupervisionSegment
 from lhotse.cut import PaddingCut
 
 
@@ -77,6 +77,24 @@ def test_cut_perturb_speed09(cut_with_supervision):
     recording_samples = cut_sp.recording.load_audio()
     assert recording_samples.shape[0] == 1
     assert recording_samples.shape[1] == 4444
+
+
+def test_cut_set_perturb_speed_doesnt_duplicate_transforms(cut_with_supervision):
+    cuts = CutSet.from_cuts([cut_with_supervision, cut_with_supervision.with_id('other-id')])
+    cuts_sp = cuts.perturb_speed(1.1)
+    for cut in cuts_sp:
+        # This prevents a bug regression where multiple cuts referencing the same recording would
+        # attach transforms to the same manifest
+        assert len(cut.recording.transforms) == 1
+
+
+def test_cut_set_resample_doesnt_duplicate_transforms(cut_with_supervision):
+    cuts = CutSet.from_cuts([cut_with_supervision, cut_with_supervision.with_id('other-id')])
+    cuts_sp = cuts.resample(44100)
+    for cut in cuts_sp:
+        # This prevents a bug regression where multiple cuts referencing the same recording would
+        # attach transforms to the same manifest
+        assert len(cut.recording.transforms) == 1
 
 
 @pytest.fixture

--- a/test/test_feature_set.py
+++ b/test/test_feature_set.py
@@ -10,7 +10,8 @@ from pytest import mark, raises
 from lhotse.audio import RecordingSet
 from lhotse.features import (Fbank, FeatureExtractor, FeatureMixer, FeatureSet, FeatureSetBuilder, Features, Mfcc,
                              Spectrogram, create_default_feature_extractor)
-from lhotse.features.io import LilcomFilesWriter, LilcomHdf5Writer, NumpyFilesWriter, NumpyHdf5Writer
+from lhotse.features.io import ChunkedLilcomHdf5Writer, LilcomFilesWriter, LilcomHdf5Writer, NumpyFilesWriter, \
+    NumpyHdf5Writer
 from lhotse.testing.dummies import DummyManifest
 from lhotse.utils import Seconds, time_diff_to_num_frames
 from lhotse.utils import nullcontext as does_not_raise
@@ -114,6 +115,7 @@ def test_compute_global_stats():
     'storage', [
         LilcomFilesWriter(TemporaryDirectory().name),
         LilcomHdf5Writer(NamedTemporaryFile().name),
+        ChunkedLilcomHdf5Writer(NamedTemporaryFile().name),
         NumpyFilesWriter(TemporaryDirectory().name),
         NumpyHdf5Writer(NamedTemporaryFile().name)
     ]


### PR DESCRIPTION
This is to solve an issue with GigaSpeech-like data prep; basically, computing features for a lot of short cuts of long recordings may be very wasteful, if:
a) the whole recording needs to be read each time; or
b) we are running some data augmentation with sox etc. on the recordings.

On the other hand, Lhotse storages we had so far didn't allow for both high compression with lilcom, and reading select chunks of data. This PR fixes it by adding a chunked lilcom storage (for now, just for HDF5).

It is somewhat slower to read (or decompress, I haven't profiled it in detail) whole matrices, but it's faster when we collect chunks. The benchmark below is done on mini-librispeech dev-clean-2, comparing old and new lilcom HDF5 storage readers.

<img width="605" alt="image" src="https://user-images.githubusercontent.com/15930688/124830182-827f8780-df47-11eb-8841-74c1ee307f80.png">

The difference in storage size is minimal (36M old vs 37M chunked). Not sure whether to make it default or not -- not changing that for now.