### PR TITLE
Custom DataLoader with two levels of subprocess workers

### DIFF
--- a/docs/datasets.rst
+++ b/docs/datasets.rst
@@ -49,11 +49,11 @@ A typical Lhotse's dataset API usage might look like this:
     for batch in dloader:
         ...  # process data
 
-Pre-computed vs. on-the-fly: input strategies
----------------------------------------------
+Batch I/O: pre-computed vs. on-the-fly features
+-----------------------------------------------
 
 Depending on the experimental setup and infrastructure, it might be more convenient to either pre-compute and store features like filter-bank energies for later use (as traditionally done in Kaldi/ESPnet/Espresso toolkits), or compute them dynamically during training ("on-the-fly").
-Lhotse supports both modes of computation by introducing a class called :class:`~lhotse.dataset.input_strategies.InputStrategy`.
+Lhotse supports both modes of computation by introducing a class called :class:`~lhotse.dataset.input_strategies.BatchIO`.
 It is accepted as an argument in most dataset classes, and defaults to :class:`~lhotse.dataset.input_strategies.PrecomputedFeatures`.
 Other available choices are :class:`~lhotse.dataset.input_strategies.AudioSamples` for working with waveforms directly,
 and :class:`~lhotse.dataset.input_strategies.OnTheFlyFeatures`, which wraps a :class:`~lhotse.features.base.FeatureExtractor` and applies it to a batch of recordings. These strategies automatically pad and collate the inputs, and provide information about the original signal lengths: as a number of frames/samples, binary mask, or start-end frame/sample pairs.
@@ -122,3 +122,8 @@ Collation utilities for building custom Datasets
 ------------------------------------------------
 
 .. automodule:: lhotse.dataset.collation
+
+Experimental: LhotseDataLoader
+------------------------------
+
+.. autoclass:: lhotse.dataset.dataloading.LhotseDataLoader

--- a/lhotse/augmentation/torchaudio.py
+++ b/lhotse/augmentation/torchaudio.py
@@ -12,7 +12,8 @@ from lhotse.utils import Seconds, compute_num_samples, during_docs_build, pertur
 
 if not during_docs_build() and _version(torchaudio.__version__) < _version('0.7'):
     warnings.warn('Torchaudio SoX effects chains are only introduced in version 0.7 - '
-                  'please upgrade your PyTorch to 1.7+ and torchaudio to 0.7+ to use them.')
+                  'please upgrade your PyTorch to 1.7.1 and torchaudio to 0.7.2 (or higher) '
+                  'to use them.')
 
 
 @dataclass

--- a/lhotse/dataset/dataloading.py
+++ b/lhotse/dataset/dataloading.py
@@ -1,48 +1,86 @@
+from collections import deque
 from concurrent.futures import ProcessPoolExecutor
+from typing import Any, Dict, List
+
+import torch.utils.data
+
+from lhotse.dataset.sampling import CutSampler
 
 
 class LhotseDataLoader:
-    def __init__(self, dataset, sampler, num_workers: int = 1, prefetch_factor: int = 2) -> None:
+    """
+    A simplified ``DataLoader`` implementation that relies on a ``ProcessPoolExecutor``.
+    The main difference between this and ``torch.utils.data.DataLoader`` is that
+    :class:`.LhotseDataLoader` allows to launch subprocesses inside of its workers.
+    This is useful for working with dataset classes which perform dynamic batching
+    and need to perform concurrent I/O to read all the necessary data from disk/network.
+    """
+    def __init__(
+        self,
+        dataset: torch.utils.data.Dataset,
+        sampler: CutSampler,
+        num_workers: int = 1,
+        prefetch_factor: int = 2,
+    ) -> None:
+        assert num_workers >= 1
+        assert prefetch_factor >= 1
         self.dataset = dataset
         self.sampler = sampler
-        self.pool = ProcessPoolExecutor(num_workers, initializer=_init_worker, initargs=(dataset,))
         self.num_workers = num_workers
         self.prefetch_factor = prefetch_factor
+        # Mutable state
         self._iter = None
-        self._futures = []
+        self._futures = deque([])
+        # Start the worker processes. The initializer receives the dataset object
+        # from the main process and caches it globally, so that it can be re-used
+        # for subsequent tasks sent to the worker. This helps avoid excessive
+        # communication between the processes.
+        self.pool = ProcessPoolExecutor(
+            num_workers, initializer=_init_worker, initargs=(dataset,)
+        )
 
-    def __iter__(self):
+    def __iter__(self) -> 'LhotseDataLoader':
+        """Prepares the sampler for iteration and schedules initial tasks to the workers."""
         self._iter = iter(self.sampler)
         for _ in range(self.prefetch_factor * self.num_workers):
             self._schedule_one()
         return self
 
-    def _schedule_one(self):
+    def _schedule_one(self) -> None:
+        """Submits a task and stores the future for results retrieval."""
         if self._iter is not None:
             try:
-                self._futures.append(
-                    self.pool.submit(_get_item, next(self._iter))
-                )
+                self._futures.append(self.pool.submit(_get_item, next(self._iter)))
             except StopIteration:
                 self._iter = None
 
-    def _retrieve_one(self):
+    def _retrieve_one(self) -> Dict[str, Any]:
+        """Retrieves the result from the earliest submitted task."""
         if self._futures:
-            return self._futures.pop().result()
+            return self._futures.popleft().result()
         raise StopIteration()
 
-    def __next__(self):
+    def __next__(self) -> Dict[str, Any]:
+        """Submits a new batch to process and then retrieves and returns a completed batch."""
         self._schedule_one()
         return self._retrieve_one()
 
 
-def _init_worker(dataset):
+def _init_worker(dataset: torch.utils.data.Dataset) -> None:
+    """
+    Stores the dataset in the global state of the process -- this is safe because
+    the process is initialized only once and used for unique dataset in its life span.
+    """
     global _GLOBAL_DATASET_CACHE
     _GLOBAL_DATASET_CACHE = dataset
 
 
-def _get_item(arg):
-    return _GLOBAL_DATASET_CACHE[arg]
+def _get_item(cut_ids: List[str]) -> Dict[str, Any]:
+    """
+    Queries the globally cached dataset to retrieve a batch. Has to be run
+    inside a worker process that was initialized with :meth:`._init_worker`.
+    """
+    return _GLOBAL_DATASET_CACHE[cut_ids]
 
 
-_GLOBAL_DATASET_CACHE = None
+_GLOBAL_DATASET_CACHE: torch.utils.data.Dataset = None

--- a/lhotse/dataset/dataloading.py
+++ b/lhotse/dataset/dataloading.py
@@ -14,6 +14,13 @@ class LhotseDataLoader:
     :class:`.LhotseDataLoader` allows to launch subprocesses inside of its workers.
     This is useful for working with dataset classes which perform dynamic batching
     and need to perform concurrent I/O to read all the necessary data from disk/network.
+
+    .. note:: :class:`.LhotseDataLoader` does not support ``num_workers=0``.
+
+    .. warning:: :class:`.LhotseDataLoader` is experimental and not guaranteed to work
+        correctly across all possible edge cases related to subprocess worker termination.
+        If you experience stability problems, contact us or use a standard ``DataLoader``
+        instead.
     """
     def __init__(
         self,

--- a/lhotse/dataset/dataloading.py
+++ b/lhotse/dataset/dataloading.py
@@ -1,0 +1,36 @@
+from concurrent.futures import ProcessPoolExecutor
+
+
+class LhotseDataLoader:
+    def __init__(self, dataset, sampler, num_workers: int = 1, prefetch_factor: int = 2) -> None:
+        self.dataset = dataset
+        self.sampler = sampler
+        self.pool = ProcessPoolExecutor(num_workers)
+        self.num_workers = num_workers
+        self.prefetch_factor = prefetch_factor
+        self._iter = None
+        self._futures = []
+
+    def __iter__(self):
+        self._iter = iter(self.sampler)
+        for _ in range(self.prefetch_factor * self.num_workers):
+            self._schedule_one()
+        return self
+
+    def _schedule_one(self):
+        if self._iter is not None:
+            try:
+                self._futures.append(
+                    self.pool.submit(self.dataset.__getitem__, next(self._iter))
+                )
+            except StopIteration:
+                self._iter = None
+
+    def _retrieve_one(self):
+        if self._futures:
+            return self._futures.pop().result()
+        raise StopIteration()
+
+    def __next__(self):
+        self._schedule_one()
+        return self._retrieve_one()

--- a/lhotse/dataset/dataloading.py
+++ b/lhotse/dataset/dataloading.py
@@ -90,4 +90,4 @@ def _get_item(cut_ids: List[str]) -> Dict[str, Any]:
     return _GLOBAL_DATASET_CACHE[cut_ids]
 
 
-_GLOBAL_DATASET_CACHE: torch.utils.data.Dataset = None
+_GLOBAL_DATASET_CACHE = None

--- a/lhotse/dataset/input_strategies.py
+++ b/lhotse/dataset/input_strategies.py
@@ -11,7 +11,7 @@ from lhotse.dataset.collation import collate_audio, collate_features, collate_ve
 from lhotse.utils import compute_num_frames, ifnone, supervision_to_frames, supervision_to_samples
 
 
-class InputStrategy:
+class BatchIO:
     """
     Converts a :class:`CutSet` into a collated batch of audio representations.
     These representations can be e.g. audio samples or features.
@@ -78,7 +78,7 @@ class InputStrategy:
         raise NotImplementedError()
 
 
-class PrecomputedFeatures(InputStrategy):
+class PrecomputedFeatures(BatchIO):
     """
     :class:`InputStrategy` that reads pre-computed features, whose manifests
     are attached to cuts, from disk.
@@ -133,7 +133,7 @@ class PrecomputedFeatures(InputStrategy):
         return collate_vectors([cut.supervisions_feature_mask(use_alignment_if_exists=use_alignment_if_exists) for cut in cuts])
 
 
-class AudioSamples(InputStrategy):
+class AudioSamples(BatchIO):
     """
     :class:`InputStrategy` that reads single-channel recordings, whose manifests
     are attached to cuts, from disk (or other audio source).
@@ -189,7 +189,7 @@ class AudioSamples(InputStrategy):
         return collate_vectors([cut.supervisions_audio_mask(use_alignment_if_exists=use_alignment_if_exists) for cut in cuts])
 
 
-class OnTheFlyFeatures(InputStrategy):
+class OnTheFlyFeatures(BatchIO):
     """
     :class:`InputStrategy` that reads single-channel recordings, whose manifests
     are attached to cuts, from disk (or other audio source).

--- a/lhotse/dataset/speech_recognition.py
+++ b/lhotse/dataset/speech_recognition.py
@@ -5,7 +5,7 @@ from torch.utils.data.dataloader import DataLoader, default_collate
 
 from lhotse import validate
 from lhotse.cut import CutSet
-from lhotse.dataset.input_strategies import InputStrategy, PrecomputedFeatures
+from lhotse.dataset.input_strategies import BatchIO, PrecomputedFeatures
 from lhotse.utils import ifnone
 
 
@@ -63,7 +63,7 @@ class K2SpeechRecognitionDataset(torch.utils.data.Dataset):
             return_cuts: bool = False,
             cut_transforms: List[Callable[[CutSet], CutSet]] = None,
             input_transforms: List[Callable[[torch.Tensor], torch.Tensor]] = None,
-            input_strategy: InputStrategy = PrecomputedFeatures(),
+            input_strategy: BatchIO = PrecomputedFeatures(),
             check_inputs: bool = True
     ):
         """

--- a/lhotse/dataset/speech_synthesis.py
+++ b/lhotse/dataset/speech_synthesis.py
@@ -5,7 +5,7 @@ import torch
 from lhotse import validate
 from lhotse.cut import CutSet
 from lhotse.dataset.collation import TokenCollater, collate_audio
-from lhotse.dataset.input_strategies import InputStrategy, PrecomputedFeatures
+from lhotse.dataset.input_strategies import BatchIO, PrecomputedFeatures
 from lhotse.utils import ifnone
 
 
@@ -30,7 +30,7 @@ class SpeechSynthesisDataset(torch.utils.data.Dataset):
             self,
             cuts: CutSet,
             cut_transforms: List[Callable[[CutSet], CutSet]] = None,
-            feature_input_strategy: InputStrategy = PrecomputedFeatures(),
+            feature_input_strategy: BatchIO = PrecomputedFeatures(),
             feature_transforms: Union[Sequence[Callable], Callable] = None,
             add_eos: bool = True,
             add_bos: bool = True,

--- a/lhotse/dataset/vad.py
+++ b/lhotse/dataset/vad.py
@@ -4,7 +4,7 @@ import torch
 
 from lhotse import validate
 from lhotse.cut import CutSet
-from lhotse.dataset.input_strategies import InputStrategy, PrecomputedFeatures
+from lhotse.dataset.input_strategies import BatchIO, PrecomputedFeatures
 from lhotse.utils import ifnone
 
 
@@ -26,7 +26,7 @@ class VadDataset(torch.utils.data.Dataset):
     def __init__(
             self,
             cuts: CutSet,
-            input_strategy: InputStrategy = PrecomputedFeatures(),
+            input_strategy: BatchIO = PrecomputedFeatures(),
             cut_transforms: Sequence[Callable[[CutSet], CutSet]] = None,
             input_transforms: Sequence[Callable[[torch.Tensor], torch.Tensor]] = None
     ) -> None:

--- a/test/dataset/test_dataloading.py
+++ b/test/dataset/test_dataloading.py
@@ -1,4 +1,7 @@
+import platform
+
 import pytest
+from packaging.version import parse as _version
 
 from lhotse.cut import CutSet
 from lhotse.dataset import SingleCutSampler, UnsupervisedDataset
@@ -19,6 +22,10 @@ def dataset(cuts):
     return UnsupervisedDataset(cuts)
 
 
+@pytest.mark.skipif(
+    _version(platform.python_version()) < _version("3.7"),
+    reason="LhotseDataLoader requires Python 3.7+",
+)
 def test_lhotse_dataloader_runs(cuts, dataset):
     sampler = SingleCutSampler(cuts, max_cuts=2)
     dloader = LhotseDataLoader(dataset, sampler, num_workers=2)

--- a/test/dataset/test_dataloading.py
+++ b/test/dataset/test_dataloading.py
@@ -8,8 +8,9 @@ from lhotse.dataset.dataloading import LhotseDataLoader
 @pytest.fixture
 def cuts():
     cuts = CutSet.from_file("test/fixtures/libri/cuts.json")
+    # Concatenate 100 cut sets together, starting with an empty CutSet()
     return sum(
-        (cuts.modify_ids(lambda cid: cid + str(i)) for i in range(100)), start=CutSet()
+        (cuts.modify_ids(lambda cid: cid + str(i)) for i in range(100)), CutSet()
     )
 
 

--- a/test/dataset/test_dataloading.py
+++ b/test/dataset/test_dataloading.py
@@ -1,0 +1,25 @@
+import pytest
+
+from lhotse.cut import CutSet
+from lhotse.dataset import SingleCutSampler, UnsupervisedDataset
+from lhotse.dataset.dataloading import LhotseDataLoader
+
+
+@pytest.fixture
+def cuts():
+    cuts = CutSet.from_file("test/fixtures/libri/cuts.json")
+    return sum(
+        (cuts.modify_ids(lambda cid: cid + str(i)) for i in range(100)), start=CutSet()
+    )
+
+
+@pytest.fixture
+def dataset(cuts):
+    return UnsupervisedDataset(cuts)
+
+
+def test_lhotse_dataloader_runs(cuts, dataset):
+    sampler = SingleCutSampler(cuts, max_cuts=2)
+    dloader = LhotseDataLoader(dataset, sampler, num_workers=2)
+    batches = list(dloader)
+    assert len(batches) == 50

--- a/test/dataset/test_speech_recognition_dataset.py
+++ b/test/dataset/test_speech_recognition_dataset.py
@@ -12,7 +12,6 @@ from lhotse.dataset.input_strategies import AudioSamples, OnTheFlyFeatures
 from lhotse.dataset.sampling import SingleCutSampler
 from lhotse.dataset.speech_recognition import K2SpeechRecognitionDataset
 from lhotse.testing.dummies import DummyManifest
-from lhotse.utils import nullcontext as does_not_raise
 
 torch.set_num_threads(1)
 torch.set_num_interop_threads(1)
@@ -226,15 +225,8 @@ def test_k2_speech_recognition_audio_inputs(k2_cut_set):
     assert (batch['supervisions']['num_samples'] == tensor([160000] * 5)).all()
 
 
-@pytest.mark.parametrize(
-    ["num_dataloader_workers", 'exception_expectation'],
-    [
-        (0, does_not_raise()),
-        (1, pytest.raises(Exception)),
-    ]
-)
 def test_k2_speech_recognition_audio_inputs_with_workers_in_input_strategy(
-    k2_cut_set, num_dataloader_workers, exception_expectation
+    k2_cut_set
 ):
     on_the_fly_dataset = K2SpeechRecognitionDataset(
         k2_cut_set,
@@ -242,18 +234,17 @@ def test_k2_speech_recognition_audio_inputs_with_workers_in_input_strategy(
     )
     # all cuts in one batch
     sampler = SingleCutSampler(k2_cut_set, shuffle=False, max_duration=100000.0)
-    with exception_expectation:
-        dloader = DataLoader(
-            on_the_fly_dataset,
-            batch_size=None,
-            sampler=sampler,
-            num_workers=num_dataloader_workers,
-        )
-        batch = next(iter(dloader))
-        assert batch['inputs'].shape == (4, 320000)
-        # Each list has 5 items, to account for:
-        # one cut with two supervisions + 3 three cuts with one supervision
-        assert (batch['supervisions']['sequence_idx'] == tensor([0, 0, 1, 2, 3])).all()
-        assert batch['supervisions']['text'] == ['EXAMPLE OF TEXT'] * 5  # a list, not tensor
-        assert (batch['supervisions']['start_sample'] == tensor([0, 160000, 0, 0, 0])).all()
-        assert (batch['supervisions']['num_samples'] == tensor([160000] * 5)).all()
+    dloader = DataLoader(
+        on_the_fly_dataset,
+        batch_size=None,
+        sampler=sampler,
+        num_workers=0,  # has to be 0 because DataLoader workers can't spawn subprocesses
+    )
+    batch = next(iter(dloader))
+    assert batch['inputs'].shape == (4, 320000)
+    # Each list has 5 items, to account for:
+    # one cut with two supervisions + 3 three cuts with one supervision
+    assert (batch['supervisions']['sequence_idx'] == tensor([0, 0, 1, 2, 3])).all()
+    assert batch['supervisions']['text'] == ['EXAMPLE OF TEXT'] * 5  # a list, not tensor
+    assert (batch['supervisions']['start_sample'] == tensor([0, 160000, 0, 0, 0])).all()
+    assert (batch['supervisions']['num_samples'] == tensor([160000] * 5)).all()

--- a/test/dataset/test_speech_recognition_dataset.py
+++ b/test/dataset/test_speech_recognition_dataset.py
@@ -1,5 +1,3 @@
-from concurrent.futures import ProcessPoolExecutor
-
 import pytest
 import torch
 from torch import tensor
@@ -235,12 +233,12 @@ def test_k2_speech_recognition_audio_inputs(k2_cut_set):
         (1, pytest.raises(Exception)),
     ]
 )
-def test_k2_speech_recognition_audio_inputs_with_executor(
+def test_k2_speech_recognition_audio_inputs_with_workers_in_input_strategy(
     k2_cut_set, num_dataloader_workers, exception_expectation
 ):
     on_the_fly_dataset = K2SpeechRecognitionDataset(
         k2_cut_set,
-        input_strategy=AudioSamples(executor=ProcessPoolExecutor(2)),
+        input_strategy=AudioSamples(num_workers=2),
     )
     # all cuts in one batch
     sampler = SingleCutSampler(k2_cut_set, shuffle=False, max_duration=100000.0)

--- a/test/dataset/test_speech_recognition_dataset.py
+++ b/test/dataset/test_speech_recognition_dataset.py
@@ -1,3 +1,5 @@
+from concurrent.futures import ProcessPoolExecutor
+
 import pytest
 import torch
 from torch import tensor
@@ -12,6 +14,7 @@ from lhotse.dataset.input_strategies import AudioSamples, OnTheFlyFeatures
 from lhotse.dataset.sampling import SingleCutSampler
 from lhotse.dataset.speech_recognition import K2SpeechRecognitionDataset
 from lhotse.testing.dummies import DummyManifest
+from lhotse.utils import nullcontext as does_not_raise
 
 torch.set_num_threads(1)
 torch.set_num_interop_threads(1)
@@ -223,3 +226,36 @@ def test_k2_speech_recognition_audio_inputs(k2_cut_set):
     assert batch['supervisions']['text'] == ['EXAMPLE OF TEXT'] * 5  # a list, not tensor
     assert (batch['supervisions']['start_sample'] == tensor([0, 160000, 0, 0, 0])).all()
     assert (batch['supervisions']['num_samples'] == tensor([160000] * 5)).all()
+
+
+@pytest.mark.parametrize(
+    ["num_dataloader_workers", 'exception_expectation'],
+    [
+        (0, does_not_raise()),
+        (1, pytest.raises(Exception)),
+    ]
+)
+def test_k2_speech_recognition_audio_inputs_with_executor(
+    k2_cut_set, num_dataloader_workers, exception_expectation
+):
+    on_the_fly_dataset = K2SpeechRecognitionDataset(
+        k2_cut_set,
+        input_strategy=AudioSamples(executor=ProcessPoolExecutor(2)),
+    )
+    # all cuts in one batch
+    sampler = SingleCutSampler(k2_cut_set, shuffle=False, max_duration=100000.0)
+    with exception_expectation:
+        dloader = DataLoader(
+            on_the_fly_dataset,
+            batch_size=None,
+            sampler=sampler,
+            num_workers=num_dataloader_workers,
+        )
+        batch = next(iter(dloader))
+        assert batch['inputs'].shape == (4, 320000)
+        # Each list has 5 items, to account for:
+        # one cut with two supervisions + 3 three cuts with one supervision
+        assert (batch['supervisions']['sequence_idx'] == tensor([0, 0, 1, 2, 3])).all()
+        assert batch['supervisions']['text'] == ['EXAMPLE OF TEXT'] * 5  # a list, not tensor
+        assert (batch['supervisions']['start_sample'] == tensor([0, 160000, 0, 0, 0])).all()
+        assert (batch['supervisions']['num_samples'] == tensor([160000] * 5)).all()


### PR DESCRIPTION
... for the lack of a better name, `LhotseDataLoader`. The main difference between this and `torch.utils.data.DataLoader` is that `LhotseDataLoader` allows to launch subprocesses inside of its workers. This is useful for working with dataset classes which perform dynamic batching and need to perform concurrent I/O to read all the necessary data from disk/network.

This is tested locally with good speed-ups from the inner worker pool, I'll have to test it on the real thing next.