### PR TITLE
Overhaul of Dataset API

### DIFF
--- a/lhotse/audio.py
+++ b/lhotse/audio.py
@@ -475,8 +475,8 @@ class RecordingSet(Serializable, Sequence[Recording]):
         """
         Indicates whether this manifest was opened in lazy (read-on-the-fly) mode or not.
         """
-        from lhotse.serialization import LazyDict
-        return isinstance(self.recordings, LazyDict)
+        from lhotse.serialization import LazyJsonlIterator
+        return isinstance(self.recordings, LazyJsonlIterator)
 
     @property
     def ids(self) -> Iterable[str]:

--- a/lhotse/bin/modes/manipulation.py
+++ b/lhotse/bin/modes/manipulation.py
@@ -7,7 +7,7 @@ from typing import Optional
 import click
 from cytoolz.functoolz import complement
 
-from lhotse import CutSet, RecordingSet, SupervisionSet, load_manifest
+from lhotse import load_manifest
 from lhotse.bin.modes.cli_base import cli
 from lhotse.manipulation import (
     combine as combine_manifests,
@@ -29,34 +29,6 @@ def copy(input_manifest, output_manifest):
     """
     data = load_manifest(input_manifest)
     data.to_file(output_manifest)
-
-
-@cli.command()
-@click.argument('input_manifest', type=click.Path(exists=True, dir_okay=False))
-@click.argument('output_manifest', type=click.Path())
-@click.option('-t', '--manifest-type',
-              type=click.Choice(['cut', 'recording', 'supervision']),
-              default='cut',
-              help='The type of items in the INPUT_MANIFEST '
-                   '(has to be explicitly provided for arrow conversion at this time).'
-              )
-def convert_to_arrow(input_manifest, output_manifest, manifest_type: str):
-    """
-    Load INPUT_MANIFEST using lazy loading mechanism and store it in
-    OUTPUT_MANIFEST using Apache Arrow binary format.
-
-    The INPUT_MANIFEST has to be a JSONL file.
-    """
-    assert input_manifest.endswith('.jsonl') or input_manifest.endswith('.jsonl.gz'), \
-        'The INPUT_MANIFEST has to be in a JSONL format for lazy loading.'
-    assert output_manifest.endswith('.arrow'), 'The extension of OUTPUT_MANIFEST has to end with ".arrow"'
-    cls = {
-        'cut': CutSet,
-        'recording': RecordingSet,
-        'supervision': SupervisionSet
-    }[manifest_type]
-    data = cls.from_jsonl_lazy(input_manifest)
-    data.to_arrow(output_manifest)
 
 
 @cli.command()

--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -1864,8 +1864,8 @@ class CutSet(Serializable, Sequence[Cut]):
         """
         Indicates whether this manifest was opened in lazy (read-on-the-fly) mode or not.
         """
-        from lhotse.serialization import LazyDict
-        return isinstance(self.cuts, LazyDict)
+        from lhotse.serialization import LazyJsonlIterator
+        return isinstance(self.cuts, LazyJsonlIterator)
 
     @property
     def mixed_cuts(self) -> Dict[str, MixedCut]:

--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -1806,6 +1806,11 @@ class CutSet(Serializable, Sequence[Cut]):
         >>> random_sample = cuts.sample(n_cuts=10)
         >>> new_ids = cuts.modify_ids(lambda c: c.id + '-newid')
 
+    These operations can be composed to implement more complex operations, e.g.
+    bucketing by duration:
+
+        >>> buckets = cuts.sort_by_duration().split(num_splits=30)
+
     Cuts in a :class:`.CutSet` can be detached from parts of their metadata::
 
         >>> cuts_no_feat = cuts.drop_features()

--- a/lhotse/dataset/diarization.py
+++ b/lhotse/dataset/diarization.py
@@ -1,17 +1,14 @@
-from itertools import chain
-from typing import Dict, Iterable, Optional
-from numpy import record
+from typing import Dict, Optional
 
 import torch
 from torch.nn import CrossEntropyLoss
 from torch.utils.data import Dataset
 
 from lhotse import validate
-from lhotse.cut import CutSet
 from lhotse.audio import RecordingSet
-from lhotse.supervision import SupervisionSet
-from lhotse.utils import overspans, TimeSpan
+from lhotse.cut import CutSet
 from lhotse.dataset.collation import collate_features, collate_matrices
+from lhotse.supervision import SupervisionSet
 
 
 class DiarizationDataset(Dataset):
@@ -95,8 +92,7 @@ class DiarizationDataset(Dataset):
         )
         self.min_speaker_dim = min_speaker_dim
 
-    def __getitem__(self, cut_ids: Iterable[str]) -> Dict[str, torch.Tensor]:
-        cuts = self.cuts.subset(cut_ids=cut_ids)
+    def __getitem__(self, cuts: CutSet) -> Dict[str, torch.Tensor]:
         features, features_lens = collate_features(cuts)
         return {
             "features": features,
@@ -114,6 +110,3 @@ class DiarizationDataset(Dataset):
                 padding_value=CrossEntropyLoss().ignore_index,
             ),
         }
-
-    def __len__(self) -> int:
-        return len(self.cuts)

--- a/lhotse/dataset/sampling.py
+++ b/lhotse/dataset/sampling.py
@@ -165,7 +165,7 @@ class CutSampler(Sampler):
     def __iter__(self):
         raise NotImplementedError("Sub-classes of CutSampler have to implement __iter__()")
 
-    def _next_batch(self) -> T_co:
+    def _next_batch(self):
         raise NotImplementedError("Sub-classes of CutSampler have to implement self._next_batch()")
 
     def __len__(self) -> int:
@@ -176,7 +176,7 @@ class CutSampler(Sampler):
             self.num_batches = sum(1 for _ in self)
         return self.num_batches
 
-    def __next__(self) -> T_co:
+    def __next__(self):
         # We use the following trick to ensure equal number of batches for each distributed
         # worker:
         # Every time a next batch is required, we will sample self.world_size batches first,
@@ -250,7 +250,7 @@ class TimeConstraint:
         self.current = 0
 
 
-class SingleCutSampler(CutSampler[CutSet]):
+class SingleCutSampler(CutSampler):
     """
     Samples cuts from a CutSet to satisfy the input constraints.
     It behaves like an iterable that yields lists of strings (cut IDs).

--- a/lhotse/dataset/speech_recognition.py
+++ b/lhotse/dataset/speech_recognition.py
@@ -96,14 +96,14 @@ class K2SpeechRecognitionDataset(torch.utils.data.Dataset):
     def __len__(self) -> int:
         return len(self.cuts)
 
-    def __getitem__(self, cut_ids: List[str]) -> Dict[str, Union[torch.Tensor, List[str]]]:
+    def __getitem__(self, cuts: CutSet) -> Dict[str, Union[torch.Tensor, List[str]]]:
         """
         Return a new batch, with the batch size automatically determined using the contraints
         of max_frames and max_cuts.
         """
         # Collect the cuts that will form a batch, satisfying the criteria of max_cuts and max_frames.
         # The returned object is a CutSet that we can keep on modifying (e.g. padding, mixing, etc.)
-        cuts = self.cuts.subset(cut_ids=cut_ids)
+        # cuts = self.cuts.subset(cut_ids=cut_ids)
 
         # Sort the cuts by duration so that the first one determines the batch time dimensions.
         cuts = cuts.sort_by_duration(ascending=False)

--- a/lhotse/dataset/speech_recognition.py
+++ b/lhotse/dataset/speech_recognition.py
@@ -59,17 +59,14 @@ class K2SpeechRecognitionDataset(torch.utils.data.Dataset):
 
     def __init__(
             self,
-            cuts: CutSet,
             return_cuts: bool = False,
             cut_transforms: List[Callable[[CutSet], CutSet]] = None,
             input_transforms: List[Callable[[torch.Tensor], torch.Tensor]] = None,
             input_strategy: BatchIO = PrecomputedFeatures(),
-            check_inputs: bool = True
     ):
         """
         K2 ASR IterableDataset constructor.
 
-        :param cuts: the ``CutSet`` to sample data from.
         :param return_cuts: When ``True``, will additionally return a "cut" field in each batch with the Cut
             objects used to create that batch.
         :param cut_transforms: A list of transforms to be applied on each sampled batch,
@@ -80,30 +77,20 @@ class K2SpeechRecognitionDataset(torch.utils.data.Dataset):
             Examples: normalization, SpecAugment, etc.
         :param input_strategy: Converts cuts into a collated batch of audio/features.
             By default, reads pre-computed features from disk.
-        :param check_inputs: Should we iterate over ``cuts`` to validate them.
-            You might want to disable it when using "lazy" CutSets to avoid a very long start up time.
         """
         super().__init__()
         # Initialize the fields
-        self.cuts = cuts
         self.return_cuts = return_cuts
         self.cut_transforms = ifnone(cut_transforms, [])
         self.input_transforms = ifnone(input_transforms, [])
         self.input_strategy = input_strategy
-        if check_inputs:
-            validate_for_asr(self.cuts)
-
-    def __len__(self) -> int:
-        return len(self.cuts)
 
     def __getitem__(self, cuts: CutSet) -> Dict[str, Union[torch.Tensor, List[str]]]:
         """
         Return a new batch, with the batch size automatically determined using the contraints
         of max_frames and max_cuts.
         """
-        # Collect the cuts that will form a batch, satisfying the criteria of max_cuts and max_frames.
-        # The returned object is a CutSet that we can keep on modifying (e.g. padding, mixing, etc.)
-        # cuts = self.cuts.subset(cut_ids=cut_ids)
+        validate_for_asr(cuts)
 
         # Sort the cuts by duration so that the first one determines the batch time dimensions.
         cuts = cuts.sort_by_duration(ascending=False)

--- a/lhotse/dataset/unsupervised.py
+++ b/lhotse/dataset/unsupervised.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Optional
+from typing import Optional
 
 import torch
 
@@ -26,8 +26,8 @@ class UnsupervisedDataset(torch.utils.data.Dataset):
         self.cuts = cuts
         self._validate()
 
-    def __getitem__(self, cut_ids: Iterable[str]) -> torch.Tensor:
-        cuts = self.cuts.subset(cut_ids=cut_ids)
+    def __getitem__(self, cuts: CutSet) -> torch.Tensor:
+        # cuts = self.cuts.subset(cut_ids=cut_ids)
         features, features_lens = collate_features(cuts)
         return {
             'features': features,
@@ -58,8 +58,7 @@ class UnsupervisedWaveformDataset(UnsupervisedDataset):
         }
     """
 
-    def __getitem__(self, cut_ids: Iterable[str]) -> torch.Tensor:
-        cuts = self.cuts.subset(cut_ids=cut_ids)
+    def __getitem__(self, cuts: CutSet) -> torch.Tensor:
         audio, audio_lens = collate_audio(cuts)
         return {
             'audio': audio,
@@ -91,8 +90,7 @@ class DynamicUnsupervisedDataset(UnsupervisedDataset):
         self.feature_extractor = feature_extractor
         self.augment_fn = augment_fn
 
-    def __getitem__(self, cut_ids: Iterable[str]) -> torch.Tensor:
-        cuts = self.cuts.subset(cut_ids=cut_ids)
+    def __getitem__(self, cuts: CutSet) -> torch.Tensor:
         features = collate_matrices(
             cut.compute_features(
                 extractor=self.feature_extractor,

--- a/lhotse/serialization.py
+++ b/lhotse/serialization.py
@@ -405,7 +405,7 @@ def _check_arrow():
 class LazyJsonlIterator:
     def __init__(self, path: Pathlike) -> None:
         self.path = Path(path)
-        assert extension_contains('.jsonl', path)
+        assert extension_contains('.jsonl', self.path)
 
     def _reset(self) -> None:
         opener = gzip.open if str(self.path).endswith('.gz') else open

--- a/lhotse/serialization.py
+++ b/lhotse/serialization.py
@@ -429,7 +429,8 @@ class LazyJsonlIterator:
         return self
 
     def __next__(self):
-        data = next(self._file)
+        line = next(self._file)
+        data = json.loads(line)
         item = deserialize_item(data)
         return item
 

--- a/lhotse/serialization.py
+++ b/lhotse/serialization.py
@@ -2,14 +2,12 @@ import gzip
 import itertools
 import json
 import warnings
-from collections import deque
 from pathlib import Path
 from typing import Any, Dict, Generator, Iterable, Optional, Type, Union
 
-import numpy as np
 import yaml
 
-from lhotse.utils import Pathlike, ifnone, is_module_available
+from lhotse.utils import Pathlike
 
 # TODO: figure out how to use some sort of typing stubs
 #  so that linters/static checkers don't complain
@@ -172,7 +170,7 @@ class SequentialJsonlWriter:
         except AttributeError:
             pass
         print(
-            json.dumps(manifest.to_dict(), cls=NumpyEncoder),
+            json.dumps(manifest.to_dict()),
             file=self.file
         )
 
@@ -228,90 +226,13 @@ class LazyMixin:
     @classmethod
     def from_jsonl_lazy(cls, path: Pathlike) -> Manifest:
         """
-        Read a JSONL manifest in a lazy manner, using pyarrow.
-        The contents of the file are loaded into memory,
-        but in a memory-efficient format, and they are deserialized into
-        Python objects such as Cut, Supervision etc. only upon request.
+        Read a JSONL manifest in a lazy manner, which opens the file but does not
+        read it immediately. It is only suitable for sequential reads and iteration.
 
-        In this mode, most operations on the manifest set may be very slow:
-        including selecting specific manifests by their IDs, or splitting,
-        shuffling, sorting, etc.
-        However, iterating over the manifest is going to fairly fast.
-
-        This method requires ``pyarrow`` and ``pandas`` to be installed.
+        .. warning:: Opening the manifest in this way might cause some methods that
+            rely on random access to fail.
         """
         return cls(LazyJsonlIterator(path))
-
-    def to_arrow(self, path: Pathlike) -> None:
-        """
-        Store the manifest in Apache Arrow streaming binary format.
-        For very large manifests it can be ~5x larger that a corresponding compressed JSONL,
-        but it allows to read the manifest with a relatively small memory footprint (~300M).
-        """
-        import pyarrow as pa
-        # If the underlying storage for manifests is already lazy, we can
-        # access the arrow tables directly without the need to convert items.
-        if self.is_lazy:
-            # TODO: I don't want to add a special method for retrieving those in each manifest type;
-            #       after this work is done, I will make a refactoring PR that renames these members
-            #       to sth like ".data" so that it's uniform across manifests.
-            from lhotse import RecordingSet, SupervisionSet, CutSet
-            if isinstance(self, RecordingSet):
-                table = self.recordings.table
-            elif isinstance(self, SupervisionSet):
-                table = self.segments.table
-            elif isinstance(self, CutSet):
-                table = self.cuts.table
-            else:
-                raise NotImplementedError(f"Unsupported type of manifest for arrow serialization: {type(self)}")
-            with open(path, "wb") as f, pa.RecordBatchFileWriter(f, schema=table.schema) as writer:
-                for batch in table.to_batches():
-                    writer.write_batch(batch)
-        else:
-            # We will take the first 1000 items from the manifest to infer the schema.
-            # TODO: might want to sample items randomly in case their manifests vary...
-            schema = pa.schema(pa.array(list(self.subset(first=1000).to_dicts())).type)
-            # Open the file for writing and initialize the pyarrow batch writer.
-            # Note that the batch size we determine here will be used to load whole chunks into
-            # memory during deserialization.
-            with open(path, "wb") as f, pa.RecordBatchFileWriter(f, schema=schema) as writer:
-                # We are (lazily) grouping the items in manifest into chunks,
-                # each of ``batch_size`` items.
-                batch_size = 10 * 1024
-                chunks = grouper(n=batch_size, iterable=self.to_dicts())
-                for chunk in chunks:
-                    # We convert the items in each chunk into Arrow's columnar representation.
-                    # To do this, we first iterate by available "columns" (i.e. dict keys),
-                    # and for each of them create an Arrow array with the corresponding values.
-                    # These arrays are then used to create an arrow Table.
-                    arrays = [
-                        pa.array(
-                            [item.get(key) for item in chunk],
-                            type=schema.field(key_idx).type
-                        ) for key_idx, key in enumerate(schema.names)
-                    ]
-                    table = pa.Table.from_arrays(arrays, schema=schema)
-                    # The loop below will iterate only once, since we ensured there's exactly one batch.
-                    for idx, batch in enumerate(table.to_batches(max_chunksize=batch_size)):
-                        writer.write_batch(batch)
-
-    @classmethod
-    def from_arrow(cls, path: Pathlike) -> Manifest:
-        """
-        Read a manifest stored in Apache Arrow streaming binary format in a lazy manner.
-        This method is supposed to use mmap, which should significantly ease
-        the memory usage.
-        The manifest items are deserialized into Python objects such as Cut,
-        Supervision etc. only upon request.
-
-        In this mode, most operations on the manifest set may be very slow:
-        including selecting specific manifests by their IDs, or splitting,
-        shuffling, sorting, etc.
-        However, iterating over the manifest is going to fairly fast.
-
-        This method requires ``pyarrow`` and ``pandas`` to be installed.
-        """
-        return cls(LazyDict(path))
 
 
 def grouper(n, iterable):
@@ -346,11 +267,6 @@ def load_manifest(path: Pathlike, manifest_cls: Optional[Type] = None) -> Manife
         raw_data = load_json(path)
     elif extension_contains('.yaml', path):
         raw_data = load_yaml(path)
-    elif extension_contains('.arrow', path):
-        assert manifest_cls is not None, \
-            "For lazy deserialization with arrow, the manifest type has to be known. " \
-            "Try using [CutSet|RecordingSet|SupervisionSet].from_file(...) instead."
-        return manifest_cls.from_arrow(path)
     else:
         raise ValueError(f"Not a valid manifest: {path}")
     data_set = None
@@ -380,8 +296,6 @@ def store_manifest(manifest: Manifest, path: Pathlike) -> None:
         manifest.to_json(path)
     elif extension_contains('.yaml', path):
         manifest.to_yaml(path)
-    elif extension_contains('.arrow', path):
-        manifest.to_arrow(path)
     else:
         raise ValueError(f"Unknown serialization format for: {path}")
 
@@ -395,14 +309,16 @@ class Serializable(JsonMixin, JsonlMixin, LazyMixin, YamlMixin):
         store_manifest(self, path)
 
 
-def _check_arrow():
-    if not is_module_available('pyarrow', 'pandas'):
-        raise ImportError("In order to leverage lazy manifest capabilities of Lhotse, "
-                          "please install additional, optional dependencies: "
-                          "'pip install pyarrow pandas'")
-
-
 class LazyJsonlIterator:
+    """
+    LazyJsonlIterator provides the ability to read Lhotse objects from a
+    JSONL file on-the-fly, without reading its full contents into memory.
+
+    This class is designed to be a partial "drop-in" replacement for ordinary dicts
+    to support lazy loading of RecordingSet, SupervisionSet and CutSet.
+    Since it does not support random access reads, some methods of these classes
+    might not work properly.
+    """
     def __init__(self, path: Pathlike) -> None:
         self.path = Path(path)
         assert extension_contains('.jsonl', self.path)
@@ -447,149 +363,11 @@ class LazyJsonlIterator:
         return count_newlines_fast(self.path)
 
 
-class LazyDict:
-    """
-    LazyDict imitates a ``dict``, but it uses Apache Arrow (via pyarrow) to
-    read the data on-the-fly from disk using mmap.
-
-    This class is designed to be a "drop-in" replacement for ordinary dicts
-    to support lazy loading of RecordingSet, SupervisionSet and CutSet.
-
-    During initialization, Pyarrow scans a JSONL file using multithreaded
-    native code and determines the JSON schema and the number of items.
-    It is reasonably fast when iterated over, and quite slow when looking
-    up single items (unless we are using it incorrectly, which is possible).
-    Thanks to Pyarrow, we are able to open manifests with more than 10 million
-    items in seconds and iterate over them with a small overhead.
-
-    .. caution::
-        This class is optimized for iteration or sequential access (i.e. iterating
-        linearly over contiguous sequence of keys).
-        Random access is possible but it may trigger a pessimistic complexity,
-        making it incredibly slow...
-    """
-
-    def __init__(self, path: Pathlike):
-        self.path = Path(path)
-        self._reset()
-
-    def __getstate__(self):
-        """
-        Store the state for pickling -- we'll only store the path, and re-initialize
-        LazyDict when unpickled. This is necessary to transfer LazyDict across processes
-        for PyTorch's DataLoader workers (otherwise mmapped file gets copied into memory).
-        """
-        state = {'path': self.path}
-        return state
-
-    def __setstate__(self, state):
-        """Restore the state when unpickled -- open the mmap/jsonl file again."""
-        self.__dict__.update(state)
-        self._reset()
-
-    def _reset(self):
-        _check_arrow()
-        self._init_table_from_path()
-        self.batches = deque(self.table.to_batches())
-        self.curr_view = self.batches[0].to_pandas()
-        self.id2pos = dict(zip(self.curr_view.id, range(len(self.curr_view.id))))
-        self.prev_view = None
-        self.prev_id2pos = {}
-
-    def _init_table_from_path(self):
-        if '.jsonl' in self.path.suffixes:
-            # Can read ".jsonl" or ".jsonl.gz"
-            import pyarrow.json as paj
-            self.table = paj.read_json(
-                str(self.path),
-                read_options=paj.ReadOptions(
-                    # magic constants:
-                    # 894 - estimated average number of bytes per JSON item manifest
-                    # 10000 - how many items we want to have in a chunk (Arrow's "batch")
-                    block_size=894 * 10000
-                )
-            )
-        elif '.arrow' == self.path.suffixes[-1]:
-            # Can read ".arrow"
-            import pyarrow as pa
-            mmap = pa.memory_map(str(self.path))
-            stream = pa.ipc.open_file(mmap)
-            self.table = stream.read_all()
-        else:
-            raise ValueError(f"Unknown LazyDict file format : '{self.path}'")
-
-    def _progress(self):
-        # Rotate the deque to the left by one item.
-        # [0, 1, 2] -> [1, 2, 0]
-        self.batches.rotate(-1)
-        self.prev_view = self.curr_view
-        self.curr_view = self.batches[0].to_pandas()
-        self.prev_id2pos = self.id2pos
-        self.id2pos = dict(zip(self.curr_view.id, range(len(self.curr_view.id))))
-
-    def _find_key(self, key: str):
-        # We will rotate the deque with N lazy views at most N times
-        # to search for a given key.
-        max_rotations = len(self.batches)
-        for _ in range(max_rotations):
-            # Try without any rotations in the first iteration --
-            # this should make search faster for contiguous keys.
-            pos = self.id2pos.get(key)
-            if pos is not None:
-                return deserialize_item(self.curr_view.iloc[pos].to_dict())
-            pos = self.prev_id2pos.get(key)
-            if pos is not None:
-                return deserialize_item(self.prev_view.iloc[pos].to_dict())
-            # Not found in the current Arrow's "batch" -- we'll advance
-            # to the next one and try again.
-            self._progress()
-        # Key not found anyhwere.
-        return None
-
-    def __len__(self) -> int:
-        return self.table.num_rows
-
-    def __getitem__(self, key: str):
-        """This is extremely inefficient and should not be used this way."""
-        value = self._find_key(key)
-        if value is None:
-            raise KeyError(f"No such key: {key}")
-        return value
-
-    def get(self, key, or_=None):
-        return ifnone(self._find_key(key), or_)
-
-    def __contains__(self, key: str):
-        value = self._find_key()
-        return value is not None
-
-    def __repr__(self):
-        return f'LazyDict(num_items={len(self)})'
-
-    def __iter__(self):
-        for b in self.table.to_batches():
-            yield from b['id'].tolist()
-
-    def keys(self):
-        return iter(self)
-
-    def values(self):
-        for b in self.table.to_batches():
-            # This seems to be the fastest way to iterate rows in a pyarrow table.
-            # Conversion to pandas seems to have the least overhead
-            # due to Arrow's zero-copy memory sharing policy.
-            yield from (deserialize_item(row.to_dict()) for idx, row in b.to_pandas().iterrows())
-
-    def items(self):
-        yield from ((cut.id, cut) for cut in self.values())
-
-
 def deserialize_item(data: dict) -> Any:
     # Figures out what type of manifest is being decoded with some heuristics
     # and returns a Lhotse manifest object rather than a raw dict.
     from lhotse import MonoCut, Features, Recording, SupervisionSegment
     from lhotse.cut import MixedCut
-    data = arr2list_recursive(data)
     if 'sources' in data:
         return Recording.from_dict(data)
     if 'num_features' in data:
@@ -607,40 +385,6 @@ def deserialize_item(data: dict) -> Any:
     if cut_type == 'MixedCut':
         return MixedCut.from_dict(data)
     raise ValueError(f"Unexpected cut type during deserialization: '{cut_type}'")
-
-
-def arr2list_recursive(data: Union[dict, list], filter_none: bool = True) -> Union[dict, list]:
-    """
-    A helper method for converting dicts read via pyarrow,
-    which have numpy arrays instead of scalars and regular lists.
-    """
-    return {
-        # Array containing objects: go deeper
-        k: [arr2list_recursive(x) for x in v] if isinstance(v, np.ndarray) and v.dtype == np.dtype('O')
-        # Array (likely) containing numeric types: convert to list and to Python numeric types
-        else v.tolist() if isinstance(v, (np.generic, np.ndarray))
-        # Dict: go deeper
-        else arr2list_recursive(v) if isinstance(v, dict)
-        # Don't change anything
-        else v
-        for k, v in data.items()
-        if v is not None or not filter_none
-    }
-
-
-class NumpyEncoder(json.JSONEncoder):
-    """
-    Utility that converts numpy types to native Python types for JSON serialization.
-
-    Example:
-        >>> with open('foo.json', 'w') as f:
-        ...     json.dump({'a': np.arange(10)}, f, cls=NumpyEncoder)
-    """
-    def default(self, obj):
-        if isinstance(obj, (np.generic, np.ndarray)):
-            return obj.tolist()
-        else:
-            return super().default(obj)
 
 
 def count_newlines_fast(path: Pathlike):

--- a/lhotse/serialization.py
+++ b/lhotse/serialization.py
@@ -440,7 +440,7 @@ class LazyJsonlIterator:
         return (item.id for item in self)
 
     def items(self):
-        return (item.id, item for item in self)
+        return ((item.id, item) for item in self)
 
     def __len__(self) -> int:
         return count_newlines_fast(self.path)

--- a/lhotse/serialization.py
+++ b/lhotse/serialization.py
@@ -404,7 +404,7 @@ def _check_arrow():
 
 class LazyJsonlIterator:
     def __init__(self, path: Pathlike) -> None:
-        self.path = path
+        self.path = Path(path)
         assert extension_contains('.jsonl', path)
 
     def _reset(self) -> None:

--- a/lhotse/supervision.py
+++ b/lhotse/supervision.py
@@ -360,8 +360,8 @@ class SupervisionSet(Serializable, Sequence[SupervisionSegment]):
         """
         Indicates whether this manifest was opened in lazy (read-on-the-fly) mode or not.
         """
-        from lhotse.serialization import LazyDict
-        return isinstance(self.segments, LazyDict)
+        from lhotse.serialization import LazyJsonlIterator
+        return isinstance(self.segments, LazyJsonlIterator)
 
     @property
     def ids(self) -> Iterable[str]:

--- a/test/dataset/test_dataloading.py
+++ b/test/dataset/test_dataloading.py
@@ -17,17 +17,12 @@ def cuts():
     )
 
 
-@pytest.fixture
-def dataset(cuts):
-    return UnsupervisedDataset(cuts)
-
-
 @pytest.mark.skipif(
     _version(platform.python_version()) < _version("3.7"),
     reason="LhotseDataLoader requires Python 3.7+",
 )
-def test_lhotse_dataloader_runs(cuts, dataset):
+def test_lhotse_dataloader_runs(cuts):
     sampler = SingleCutSampler(cuts, max_cuts=2)
-    dloader = LhotseDataLoader(dataset, sampler, num_workers=2)
+    dloader = LhotseDataLoader(UnsupervisedDataset(), sampler, num_workers=2)
     batches = list(dloader)
     assert len(batches) == 50

--- a/test/dataset/test_diarization.py
+++ b/test/dataset/test_diarization.py
@@ -59,9 +59,8 @@ def cut_set():
 
 
 def test_diarization_dataset(cut_set):
-    ids = cut_set.ids
     dataset = DiarizationDataset(cut_set)
-    example = dataset[ids]
+    example = dataset[cut_set]
     assert example['features'].shape == (1, 1000, 40)
 
     assert example['speaker_activity'].shape == (1, 4, 1000)

--- a/test/dataset/test_sampling.py
+++ b/test/dataset/test_sampling.py
@@ -8,7 +8,7 @@ from lhotse import CutSet
 from lhotse.dataset.cut_transforms import concat_cuts
 from lhotse.dataset.sampling import BucketingSampler, CutPairsSampler, SingleCutSampler, ZipSampler
 from lhotse.testing.dummies import DummyManifest, dummy_cut
-from lhotse.utils import is_module_available, nullcontext as does_not_raise
+from lhotse.utils import nullcontext as does_not_raise
 
 
 @pytest.fixture
@@ -34,16 +34,16 @@ def test_single_cut_sampler_shuffling():
         # a full epoch.
         max_frames=1000
     )
-    sampler_cut_ids = []
+    sampled_cuts = []
     for batch in sampler:
-        sampler_cut_ids.extend(batch)
+        sampled_cuts.extend(batch)
 
     # Invariant 1: we receive the same amount of items in a dataloader epoch as there we in the CutSet
-    assert len(sampler_cut_ids) == len(cut_set)
+    assert len(sampled_cuts) == len(cut_set)
     # Invariant 2: the items are not duplicated
-    assert len(set(sampler_cut_ids)) == len(sampler_cut_ids)
+    assert len(set(c.id for c in sampled_cuts)) == len(sampled_cuts)
     # Invariant 3: the items are shuffled, i.e. the order is different than that in the CutSet
-    assert sampler_cut_ids != [c.id for c in cut_set]
+    assert [c.id for c in sampled_cuts] != [c.id for c in cut_set]
 
 
 @pytest.mark.parametrize(
@@ -81,9 +81,9 @@ def test_single_cut_sampler_time_constraints(max_duration, max_frames, max_sampl
         # Invariant 1: we receive the same amount of items in a dataloader epoch as there we in the CutSet
         assert len(sampler_cut_ids) == len(cut_set)
         # Invariant 2: the items are not duplicated
-        assert len(set(sampler_cut_ids)) == len(sampler_cut_ids)
+        assert len(set(c.id for c in sampler_cut_ids)) == len(sampler_cut_ids)
         # Invariant 3: the items are shuffled, i.e. the order is different than that in the CutSet
-        assert sampler_cut_ids != [c.id for c in cut_set]
+        assert [c.id for c in sampler_cut_ids] != [c.id for c in cut_set]
 
 
 def test_single_cut_sampler_order_is_deterministic_given_epoch():
@@ -162,16 +162,21 @@ def test_cut_pairs_sampler():
         max_source_frames=1000,
         max_target_frames=500,
     )
-    sampler_cut_ids = []
-    for batch in sampler:
-        sampler_cut_ids.extend(batch)
+    source_cuts, target_cuts = [], []
+    for src_batch, tgt_batch in sampler:
+        source_cuts.extend(src_batch)
+        target_cuts.extend(tgt_batch)
 
     # Invariant 1: we receive the same amount of items in a dataloader epoch as there we in the CutSet
-    assert len(sampler_cut_ids) == len(cut_set)
+    assert len(source_cuts) == len(cut_set)
+    assert len(target_cuts) == len(cut_set)
     # Invariant 2: the items are not duplicated
-    assert len(set(sampler_cut_ids)) == len(sampler_cut_ids)
+    assert len(set(c.id for c in source_cuts)) == len(source_cuts)
+    assert len(set(c.id for c in target_cuts)) == len(target_cuts)
     # Invariant 3: the items are shuffled, i.e. the order is different than that in the CutSet
-    assert sampler_cut_ids != [c.id for c in cut_set]
+    assert [c.id for c in source_cuts] != [c.id for c in cut_set]
+    # Invariant 4: the source and target cuts are in the same order
+    assert [c.id for c in source_cuts] == [c.id for c in target_cuts]
 
 
 def test_cut_pairs_sampler_2():
@@ -221,16 +226,21 @@ def test_cut_pairs_sampler_time_constraints(max_duration, max_frames, max_sample
             max_source_duration=max_duration,
             max_target_duration=max_duration / 2 if max_duration is not None else None,
         )
-        sampler_cut_ids = []
-        for batch in sampler:
-            sampler_cut_ids.extend(batch)
+        source_cuts, target_cuts = [], []
+        for src_batch, tgt_batch in sampler:
+            source_cuts.extend(src_batch)
+            target_cuts.extend(tgt_batch)
 
         # Invariant 1: we receive the same amount of items in a dataloader epoch as there we in the CutSet
-        assert len(sampler_cut_ids) == len(cut_set)
+        assert len(source_cuts) == len(cut_set)
+        assert len(target_cuts) == len(cut_set)
         # Invariant 2: the items are not duplicated
-        assert len(set(sampler_cut_ids)) == len(sampler_cut_ids)
+        assert len(set(c.id for c in source_cuts)) == len(source_cuts)
+        assert len(set(c.id for c in target_cuts)) == len(target_cuts)
         # Invariant 3: the items are shuffled, i.e. the order is different than that in the CutSet
-        assert sampler_cut_ids != [c.id for c in cut_set]
+        assert [c.id for c in source_cuts] != [c.id for c in cut_set]
+        # Invariant 4: the source and target cuts are in the same order
+        assert [c.id for c in source_cuts] == [c.id for c in target_cuts]
 
 
 def test_cut_pairs_sampler_order_is_deterministic_given_epoch():
@@ -334,10 +344,10 @@ def test_concat_cuts_with_duration_factor():
 def test_bucketing_sampler_single_cuts():
     cut_set = DummyManifest(CutSet, begin_id=0, end_id=1000)
     sampler = BucketingSampler(cut_set, sampler_type=SingleCutSampler)
-    cut_ids = []
+    sampled_cuts = []
     for batch in sampler:
-        cut_ids.extend(batch)
-    assert set(cut_set.ids) == set(cut_ids)
+        sampled_cuts.extend(batch)
+    assert set(cut_set.ids) == set(c.id for c in sampled_cuts)
 
 
 def test_bucketing_sampler_shuffle():
@@ -348,13 +358,13 @@ def test_bucketing_sampler_shuffle():
     batches_ep0 = []
     for batch in sampler:
         # Convert List[str] to Tuple[str, ...] so that it's hashable
-        batches_ep0.append(tuple(batch))
+        batches_ep0.append(tuple(c.id for c in batch))
     assert set(cut_set.ids) == set(cid for batch in batches_ep0 for cid in batch)
 
     sampler.set_epoch(1)
     batches_ep1 = []
     for batch in sampler:
-        batches_ep1.append(tuple(batch))
+        batches_ep1.append(tuple(c.id for c in batch))
     assert set(cut_set.ids) == set(cid for batch in batches_ep1 for cid in batch)
 
     # BucketingSampler ordering may be different in different epochs (=> use set() to make it irrelevant)
@@ -367,11 +377,12 @@ def test_bucketing_sampler_cut_pairs():
     cut_set2 = DummyManifest(CutSet, begin_id=0, end_id=1000)
     sampler = BucketingSampler(cut_set1, cut_set2, sampler_type=CutPairsSampler)
 
-    cut_ids = []
-    for batch in sampler:
-        cut_ids.extend(batch)
-    assert set(cut_set1.ids) == set(cut_ids)
-    assert set(cut_set2.ids) == set(cut_ids)
+    src_cuts, tgt_cuts = [], []
+    for src_batch, tgt_batch in sampler:
+        src_cuts.extend(src_batch)
+        tgt_cuts.extend(tgt_batch)
+    assert set(cut_set1.ids) == set(c.id for c in src_cuts)
+    assert set(cut_set2.ids) == set(c.id for c in tgt_cuts)
 
 
 def test_bucketing_sampler_order_is_deterministic_given_epoch():
@@ -435,7 +446,7 @@ def test_bucketing_sampler_buckets_have_different_durations():
 
     # All cuts have the same durations (i.e. are from the same bucket in this case)
     for batch in batches:
-        batch_durs = [cut_set[cid].duration for cid in batch]
+        batch_durs = [cut_set[c.id].duration for c in batch]
         assert all(d == batch_durs[0] for d in batch_durs)
 
     batches = sorted(batches, key=len)
@@ -463,7 +474,7 @@ def test_bucketing_sampler_chooses_buckets_randomly():
     )
 
     # Batches of 1 guarantee that item is always a single-element list of cut IDs.
-    durations = [cut_set[item[0]].duration for item in sampler]
+    durations = [cut_set[item[0].id].duration for item in sampler]
 
     # This is the "trick" part - 'groupby' groups the cuts together by their duration.
     # If there is a group that has a size of 10, that means the same bucket was chosen
@@ -489,10 +500,10 @@ def test_bucketing_sampler_chooses_buckets_randomly():
 def test_bucketing_sampler_time_constraints(constraint):
     cut_set = DummyManifest(CutSet, begin_id=0, end_id=1000)
     sampler = BucketingSampler(cut_set, sampler_type=SingleCutSampler, **constraint)
-    cut_ids = []
+    sampled_cuts = []
     for batch in sampler:
-        cut_ids.extend(batch)
-    assert set(cut_set.ids) == set(cut_ids)
+        sampled_cuts.extend(batch)
+    assert set(cut_set.ids) == set(c.id for c in sampled_cuts)
 
 
 @pytest.mark.parametrize('world_size', [2, 3, 4])
@@ -514,14 +525,19 @@ def test_partitions_are_equal(world_size, n_cuts, sampler_cls):
     assert all(nb == n_batches[0] for nb in n_batches)
 
 
-@pytest.mark.skipif(not is_module_available('pyarrow'), reason='Requires pyarrow.')
-@pytest.mark.parametrize('sampler_cls', [SingleCutSampler, BucketingSampler])
+@pytest.mark.parametrize(
+    'sampler_cls',
+    [
+        SingleCutSampler,
+        pytest.param(BucketingSampler, marks=pytest.mark.xfail())
+    ]
+)
 def test_single_cut_sampler_with_lazy_cuts(sampler_cls):
     # The dummy cuts have a duration of 1 second each
     cut_set = DummyManifest(CutSet, begin_id=0, end_id=100)
-    with NamedTemporaryFile(suffix='.arrow') as f:
-        cut_set.to_arrow(f.name)
-        lazy_cuts = CutSet.from_arrow(f.name)
+    with NamedTemporaryFile(suffix='.jsonl') as f:
+        cut_set.to_jsonl(f.name)
+        lazy_cuts = CutSet.from_jsonl_lazy(f.name)
 
         sampler = sampler_cls(
             lazy_cuts,
@@ -532,14 +548,14 @@ def test_single_cut_sampler_with_lazy_cuts(sampler_cls):
             # a full epoch.
             max_frames=1000
         )
-        sampler_cut_ids = []
+        sampled_cuts = []
         for batch in sampler:
-            sampler_cut_ids.extend(batch)
+            sampled_cuts.extend(batch)
 
         # Invariant 1: we receive the same amount of items in a dataloader epoch as there we in the CutSet
-        assert len(sampler_cut_ids) == len(cut_set)
+        assert len(sampled_cuts) == len(cut_set)
         # Invariant 2: the items are not duplicated
-        assert len(set(sampler_cut_ids)) == len(sampler_cut_ids)
+        assert len(set(c.id for c in sampled_cuts)) == len(sampled_cuts)
 
 
 @pytest.mark.parametrize('sampler_cls', [SingleCutSampler, BucketingSampler])
@@ -556,18 +572,18 @@ def test_sampler_filter(sampler_cls):
     )
     removed_cut_id = 'dummy-cut-0010'
     sampler.filter(lambda cut: cut.id != removed_cut_id)
-    sampler_cut_ids = []
+    sampled_cuts = []
     for batch in sampler:
-        sampler_cut_ids.extend(batch)
+        sampled_cuts.extend(batch)
 
     # The filtered cut is not there
     assert removed_cut_id in set(cut_set.ids)
-    assert removed_cut_id not in set(sampler_cut_ids)
+    assert removed_cut_id not in set(c.id for c in sampled_cuts)
 
     # Invariant 1: we receive the same amount of items in a dataloader epoch as there we in the CutSet
-    assert len(sampler_cut_ids) == len(cut_set) - 1
+    assert len(sampled_cuts) == len(cut_set) - 1
     # Invariant 2: the items are not duplicated
-    assert len(set(sampler_cut_ids)) == len(sampler_cut_ids)
+    assert len(set(c.id for c in sampled_cuts)) == len(sampled_cuts)
 
 
 def test_cut_pairs_sampler_filter():
@@ -584,18 +600,23 @@ def test_cut_pairs_sampler_filter():
     )
     removed_cut_id = 'dummy-cut-0010'
     sampler.filter(lambda cut: cut.id != removed_cut_id)
-    sampler_cut_ids = []
-    for batch in sampler:
-        sampler_cut_ids.extend(batch)
+
+    source_cuts, target_cuts = [], []
+    for src_batch, tgt_batch in sampler:
+        source_cuts.extend(src_batch)
+        target_cuts.extend(tgt_batch)
 
     # The filtered cut is not there
     assert removed_cut_id in set(cut_set.ids)
-    assert removed_cut_id not in set(sampler_cut_ids)
+    assert removed_cut_id not in set(c.id for c in source_cuts)
 
-    # Invariant 1: we receive the same amount of items in a dataloader epoch as there we in the CutSet
-    assert len(sampler_cut_ids) == len(cut_set) - 1
+    # Invariant 1: we receive the same amount of items in a dataloader epoch as there we in the CutSet,
+    # minus the filtered item
+    assert len(source_cuts) == len(cut_set) - 1
+    assert len(target_cuts) == len(cut_set) - 1
     # Invariant 2: the items are not duplicated
-    assert len(set(sampler_cut_ids)) == len(sampler_cut_ids)
+    assert len(set(c.id for c in source_cuts)) == len(source_cuts)
+    assert len(set(c.id for c in target_cuts)) == len(target_cuts)
 
 
 def test_zip_sampler():
@@ -610,5 +631,5 @@ def test_zip_sampler():
     assert len(batches) == 10
     for idx, batch in enumerate(batches):
         assert len(batch) == 12  # twelve 1s items
-        assert len([cid for cid in batch if 0 <= int(cid.split('-')[-1]) <= 100]) == 10  # ten come from cuts1
-        assert len([cid for cid in batch if 1000 <= int(cid.split('-')[-1]) <= 1100]) == 2  # two come from cuts2
+        assert len([c for c in batch if 0 <= int(c.id.split('-')[-1]) <= 100]) == 10  # ten come from cuts1
+        assert len([c for c in batch if 1000 <= int(c.id.split('-')[-1]) <= 1100]) == 2  # two come from cuts2

--- a/test/dataset/test_speech_recognition_dataset.py
+++ b/test/dataset/test_speech_recognition_dataset.py
@@ -36,7 +36,6 @@ def k2_cut_set(libri_cut_set):
 @pytest.mark.parametrize('num_workers', [0, 1])
 def test_k2_speech_recognition_iterable_dataset(k2_cut_set, num_workers):
     dataset = K2SpeechRecognitionDataset(
-        k2_cut_set,
         cut_transforms=[CutConcatenate()]
     )
     sampler = SingleCutSampler(k2_cut_set, shuffle=False)
@@ -57,7 +56,6 @@ def test_k2_speech_recognition_iterable_dataset(k2_cut_set, num_workers):
 def test_k2_speech_recognition_iterable_dataset_multiple_workers(k2_cut_set, num_workers):
     k2_cut_set = k2_cut_set.pad()
     dataset = K2SpeechRecognitionDataset(
-        k2_cut_set,
         cut_transforms=[CutConcatenate()]
     )
     sampler = SingleCutSampler(k2_cut_set, shuffle=False)
@@ -86,7 +84,6 @@ def test_k2_speech_recognition_iterable_dataset_shuffling():
     cut_set = DummyManifest(CutSet, begin_id=0, end_id=100)
 
     dataset = K2SpeechRecognitionDataset(
-        cuts=cut_set,
         return_cuts=True,
         cut_transforms=[
             CutConcatenate(),
@@ -116,7 +113,7 @@ def test_k2_speech_recognition_iterable_dataset_shuffling():
 
 
 def test_k2_speech_recognition_iterable_dataset_low_max_frames(k2_cut_set):
-    dataset = K2SpeechRecognitionDataset(k2_cut_set)
+    dataset = K2SpeechRecognitionDataset()
     sampler = SingleCutSampler(k2_cut_set, shuffle=False, max_frames=2)
     dloader = DataLoader(dataset, sampler=sampler, batch_size=None)
     # Check that it does not crash
@@ -136,7 +133,6 @@ def k2_noise_cut_set(libri_cut_set):
 
 def test_k2_speech_recognition_augmentation(k2_cut_set, k2_noise_cut_set):
     dataset = K2SpeechRecognitionDataset(
-        k2_cut_set,
         cut_transforms=[
             CutConcatenate(),
             CutMix(k2_noise_cut_set)
@@ -162,9 +158,8 @@ def test_extra_padding_transform(k2_cut_set):
 
 
 def test_k2_speech_recognition_on_the_fly_feature_extraction(k2_cut_set):
-    precomputed_dataset = K2SpeechRecognitionDataset(k2_cut_set)
+    precomputed_dataset = K2SpeechRecognitionDataset()
     on_the_fly_dataset = K2SpeechRecognitionDataset(
-        k2_cut_set.drop_features(),
         input_strategy=OnTheFlyFeatures(Fbank())
     )
     sampler = SingleCutSampler(k2_cut_set, shuffle=False, max_cuts=1)
@@ -186,13 +181,11 @@ def test_k2_speech_recognition_on_the_fly_feature_extraction(k2_cut_set):
 
 def test_k2_speech_recognition_on_the_fly_feature_extraction_with_randomized_smoothing(k2_cut_set):
     dataset = K2SpeechRecognitionDataset(
-        k2_cut_set.drop_features(),
         input_strategy=OnTheFlyFeatures(
             extractor=Fbank(),
         )
     )
     rs_dataset = K2SpeechRecognitionDataset(
-        k2_cut_set.drop_features(),
         input_strategy=OnTheFlyFeatures(
             extractor=Fbank(),
             # Use p=1.0 to ensure that smoothing is applied in this test.
@@ -209,7 +202,6 @@ def test_k2_speech_recognition_on_the_fly_feature_extraction_with_randomized_smo
 
 def test_k2_speech_recognition_audio_inputs(k2_cut_set):
     on_the_fly_dataset = K2SpeechRecognitionDataset(
-        k2_cut_set,
         input_strategy=AudioSamples(),
     )
     # all cuts in one batch
@@ -229,7 +221,6 @@ def test_k2_speech_recognition_audio_inputs_with_workers_in_input_strategy(
     k2_cut_set
 ):
     on_the_fly_dataset = K2SpeechRecognitionDataset(
-        k2_cut_set,
         input_strategy=AudioSamples(num_workers=2),
     )
     # all cuts in one batch

--- a/test/dataset/test_speech_recognition_dataset_randomized.py
+++ b/test/dataset/test_speech_recognition_dataset_randomized.py
@@ -52,7 +52,6 @@ class TestCollationRandomized(RandomCutTestCase):
         )
         # Create an ASR dataset
         dataset = K2SpeechRecognitionDataset(
-            mixed_cuts,
             return_cuts=True,
             cut_transforms=[
                 CutConcatenate(duration_factor=3.0)

--- a/test/dataset/test_speech_synthesis_dataset.py
+++ b/test/dataset/test_speech_synthesis_dataset.py
@@ -13,8 +13,6 @@ def cut_set():
 
 @pytest.mark.parametrize('transform', [None, GlobalMVN, [GlobalMVN]])
 def test_speech_synthesis_dataset(cut_set, transform):
-    ids = cut_set.ids
-
     if isinstance(transform, list):
         transform = [transform[0].from_cuts(cut_set)]
     elif isinstance(transform, GlobalMVN):
@@ -23,7 +21,7 @@ def test_speech_synthesis_dataset(cut_set, transform):
         transform = None
 
     dataset = SpeechSynthesisDataset(cut_set, feature_transforms=transform)
-    example = dataset[ids]
+    example = dataset[cut_set]
     assert example['audio'].shape[1] > 0
     assert example['features'].shape[1] > 0
     assert example['tokens'].shape[1] > 0

--- a/test/dataset/test_unsupervised_dataset.py
+++ b/test/dataset/test_unsupervised_dataset.py
@@ -14,25 +14,22 @@ def libri_cut_set():
 
 
 def test_unsupervised_dataset(libri_cut_set):
-    dataset = UnsupervisedDataset(libri_cut_set)
-    assert len(dataset) == 1
+    dataset = UnsupervisedDataset()
     out = dataset[libri_cut_set]
     assert out["features"].shape == (1, 1000, 40)
 
 
 def test_unsupervised_waveform_dataset(libri_cut_set):
-    dataset = UnsupervisedWaveformDataset(libri_cut_set)
-    assert len(dataset) == 1
+    dataset = UnsupervisedWaveformDataset()
     out = dataset[libri_cut_set]
     assert out["audio"].shape == (1, 10 * 16000)
     assert isinstance(out["audio_lens"], torch.IntTensor)
 
 
 def test_on_the_fly_feature_extraction_unsupervised_dataset(libri_cut_set):
-    ref_dataset = UnsupervisedDataset(libri_cut_set)
+    ref_dataset = UnsupervisedDataset()
     tested_dataset = DynamicUnsupervisedDataset(
         feature_extractor=Fbank(),
-        cuts=libri_cut_set
     )
     out = ref_dataset[libri_cut_set]
     ref_feats = out["features"]

--- a/test/dataset/test_unsupervised_dataset.py
+++ b/test/dataset/test_unsupervised_dataset.py
@@ -14,32 +14,29 @@ def libri_cut_set():
 
 
 def test_unsupervised_dataset(libri_cut_set):
-    ids = list(libri_cut_set.ids)
     dataset = UnsupervisedDataset(libri_cut_set)
     assert len(dataset) == 1
-    out = dataset[ids]
+    out = dataset[libri_cut_set]
     assert out["features"].shape == (1, 1000, 40)
 
 
 def test_unsupervised_waveform_dataset(libri_cut_set):
-    ids = list(libri_cut_set.ids)
     dataset = UnsupervisedWaveformDataset(libri_cut_set)
     assert len(dataset) == 1
-    out = dataset[ids]
+    out = dataset[libri_cut_set]
     assert out["audio"].shape == (1, 10 * 16000)
     assert isinstance(out["audio_lens"], torch.IntTensor)
 
 
 def test_on_the_fly_feature_extraction_unsupervised_dataset(libri_cut_set):
-    ids = list(libri_cut_set.ids)
     ref_dataset = UnsupervisedDataset(libri_cut_set)
     tested_dataset = DynamicUnsupervisedDataset(
         feature_extractor=Fbank(),
         cuts=libri_cut_set
     )
-    out = ref_dataset[ids]
+    out = ref_dataset[libri_cut_set]
     ref_feats = out["features"]
-    tested_feats = tested_dataset[ids]
+    tested_feats = tested_dataset[libri_cut_set]
     # Note: comparison to 1 decimal fails.
     #       I'm assuming this is due to lilcom's compression.
     #       Pytest outputs looks like the following:

--- a/test/dataset/test_vad_dataset.py
+++ b/test/dataset/test_vad_dataset.py
@@ -30,9 +30,9 @@ def test_vad_dataset(cut_set):
     # Convert long cuts into 5s cuts
     window_cut_set = cut_set.cut_into_windows(duration=duration)
     # Create a one-element list with the ID of the first cut
-    first_id = [next(iter(window_cut_set.ids))]
-    dataset = VadDataset(window_cut_set)
-    example = dataset[first_id]
+    first = window_cut_set.subset(first=1)
+    dataset = VadDataset()
+    example = dataset[first]
     is_voice = example['is_voice'][0]
     assert isclose(float(torch.mean(is_voice[0:v1_start])), 0)
     assert isclose(float(torch.mean(is_voice[v1_start:v1_end])), 1)


### PR DESCRIPTION
Two changes, really:
- samplers return `CutSet` instead of `List[str]` of cut IDs; this makes lazy manifest support much easier (dataset class doesn't have to lookup IDs with random access requirements)
- remove apache arrow and rely on sequential reads of JSONL instead (it's much faster and much simpler...)

I will make a parallel snowfall PR to ensure it's compatible with the changes.