### PR TITLE
Samplers: `drop_last` option and `get_report()` diagnostic method

### DIFF
--- a/lhotse/dataset/sampling.py
+++ b/lhotse/dataset/sampling.py
@@ -326,6 +326,8 @@ class SamplingDiagnostics:
     def reset(self) -> None:
         self.kept_stats.reset()
         self.discarded_stats.reset()
+        self.num_kept_batches = 0
+        self.num_discarded_batches = 0
 
     @property
     def total_cuts(self) -> int:
@@ -349,7 +351,7 @@ class SamplingDiagnostics:
             f"Kept {self.num_kept_batches:d}/{self.total_batches:d} "
             f"({self.num_kept_batches / self.total_batches:.2%}) batches "
             f"({self.num_discarded_batches:d} batches discarded).\n"
-            f"Overall, {self.discarded_stats.current:.1f} seconds of supervision were discarded."
+            f"Overall, {round(self.discarded_stats.current):d} seconds of supervision were discarded."
         )
 
     def __add__(self, other: 'SamplingDiagnostics') -> 'SamplingDiagnostics':

--- a/test/dataset/test_sampling.py
+++ b/test/dataset/test_sampling.py
@@ -675,7 +675,7 @@ def test_bucketing_sampler_drop_last(drop_last):
     )
     batches = []
     for batch in sampler:
-        # Assert there is a single cut duration per bucket.
+        # Assert there is a consistent cut duration per bucket in this test.
         for cut in batch:
             assert cut.duration == batch[0].duration
         batches.append(batch)


### PR DESCRIPTION
Following up on the discussion in #356. Here are some examples of usage of `drop_last`, and how the sampler report looks like for dev-clean-2 split of mini_librispeech:

![image](https://user-images.githubusercontent.com/15930688/128400335-89ebdf76-6c8e-4cb0-a21f-f0da1f72a017.png)

@danpovey @pkufool