### PR TITLE
fix dev requires in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ setup(
     extras_require={
         'docs': docs_require,
         'tests': tests_require,
-        'dev': docs_require + tests_require,
+        'dev': dev_requires,
         'all': all_requires
     },
     classifiers=[


### PR DESCRIPTION
To solve the issue:
The dev_requires wasn't used. And won't be install through `pip install -e '.[dev]'`.

