### PR TITLE
 Speedup `import lhotse` and CLI with local imports

### DIFF
--- a/lhotse/__init__.py
+++ b/lhotse/__init__.py
@@ -1,11 +1,3 @@
-import warnings
-
-with warnings.catch_warnings():
-    # Those torchaudio warnings are a real nuisance
-    warnings.simplefilter("ignore")
-    # noinspection PyUnresolvedReferences
-    import torchaudio
-
 from .audio import AudioSource, Recording, RecordingSet
 from .augmentation import *
 from .cut import MonoCut, CutSet

--- a/lhotse/bin/modes/cli_base.py
+++ b/lhotse/bin/modes/cli_base.py
@@ -2,8 +2,6 @@ import logging
 
 import click
 
-from lhotse.utils import fix_random_seed
-
 
 @click.group()
 @click.option('-s', '--seed', type=int, help='Random seed.')
@@ -16,6 +14,7 @@ def cli(seed):
         level=logging.INFO
     )
     if seed is not None:
+        from lhotse.utils import fix_random_seed
         fix_random_seed(seed)
 
 

--- a/lhotse/bin/modes/features.py
+++ b/lhotse/bin/modes/features.py
@@ -1,9 +1,7 @@
-from concurrent.futures import ProcessPoolExecutor
 from pathlib import Path
 from typing import Optional
 
 import click
-from tqdm import tqdm
 
 from lhotse import FeatureSet, Features, LilcomURLWriter
 from lhotse.audio import RecordingSet
@@ -100,6 +98,9 @@ def upload(
     This script does not currently support credentials,
     and assumes that you have the write permissions.
     """
+    from concurrent.futures import ProcessPoolExecutor
+    from tqdm import tqdm
+
     output_manifest = Path(output_manifest)
     assert '.jsonl' in output_manifest.suffixes, 'This mode only supports writing to JSONL feature manifests.'
 

--- a/lhotse/bin/modes/kaldi.py
+++ b/lhotse/bin/modes/kaldi.py
@@ -2,9 +2,7 @@ from pathlib import Path
 
 import click
 
-from lhotse import Seconds, load_manifest
 from lhotse.bin.modes.cli_base import cli
-from lhotse.kaldi import export_to_kaldi, load_kaldi_data_dir
 from lhotse.utils import Pathlike
 
 
@@ -20,11 +18,13 @@ def kaldi():
 @click.argument('manifest_dir', type=click.Path())
 @click.option('-f', '--frame-shift', type=float,
               help='Frame shift (in seconds) is required to support reading feats.scp.')
-def import_(data_dir: Pathlike, sampling_rate: int, manifest_dir: Pathlike, frame_shift: Seconds):
+def import_(data_dir: Pathlike, sampling_rate: int, manifest_dir: Pathlike, frame_shift: float):
     """
     Convert a Kaldi data dir DATA_DIR into a directory MANIFEST_DIR of lhotse manifests. Ignores feats.scp.
     The SAMPLING_RATE has to be explicitly specified as it is not available to read from DATA_DIR.
     """
+    from lhotse.kaldi import load_kaldi_data_dir
+
     recording_set, maybe_supervision_set, maybe_feature_set = load_kaldi_data_dir(
         path=data_dir,
         sampling_rate=sampling_rate,
@@ -47,6 +47,9 @@ def export(recordings: Pathlike, supervisions: Pathlike, output_dir: Pathlike):
     """
     Convert a pair of ``RecordingSet`` and ``SupervisionSet`` manifests into a Kaldi-style data directory.
     """
+    from lhotse import load_manifest
+    from lhotse.kaldi import export_to_kaldi
+
     output_dir = Path(output_dir)
     export_to_kaldi(
         recordings=load_manifest(recordings),

--- a/lhotse/bin/modes/manipulation.py
+++ b/lhotse/bin/modes/manipulation.py
@@ -1,18 +1,9 @@
-import operator
-import re
-from math import isclose
 from pathlib import Path
 from typing import Optional
 
 import click
-from cytoolz.functoolz import complement
 
-from lhotse import load_manifest
 from lhotse.bin.modes.cli_base import cli
-from lhotse.manipulation import (
-    combine as combine_manifests,
-    to_manifest
-)
 from lhotse.utils import Pathlike
 
 __all__ = ['split', 'combine', 'subset', 'filter']
@@ -27,6 +18,7 @@ def copy(input_manifest, output_manifest):
     Useful for conversion between different serialization formats (e.g. JSON, JSONL, YAML).
     Automatically supports gzip compression when '.gz' suffix is detected.
     """
+    from lhotse import load_manifest
     data = load_manifest(input_manifest)
     data.to_file(output_manifest)
 
@@ -40,6 +32,8 @@ def split(num_splits: int, manifest: Pathlike, output_dir: Pathlike, shuffle: bo
     """
     Load MANIFEST, split it into NUM_SPLITS equal parts and save as separate manifests in OUTPUT_DIR.
     """
+    from lhotse import load_manifest
+
     output_dir = Path(output_dir)
     manifest = Path(manifest)
     suffix = ''.join(manifest.suffixes)
@@ -57,6 +51,8 @@ def split(num_splits: int, manifest: Pathlike, output_dir: Pathlike, shuffle: bo
 @click.option('--last', type=int)
 def subset(manifest: Pathlike, output_manifest: Pathlike, first: Optional[int], last: Optional[int]):
     """Load MANIFEST, select the FIRST or LAST number of items and store it in OUTPUT_MANIFEST."""
+    from lhotse import load_manifest
+
     output_manifest = Path(output_manifest)
     manifest = Path(manifest)
     any_set = load_manifest(manifest)
@@ -69,6 +65,9 @@ def subset(manifest: Pathlike, output_manifest: Pathlike, first: Optional[int], 
 @click.argument('output_manifest', type=click.Path())
 def combine(manifests: Pathlike, output_manifest: Pathlike):
     """Load MANIFESTS, combine them into a single one, and write it to OUTPUT_MANIFEST."""
+    from lhotse import load_manifest
+    from lhotse.manipulation import combine as combine_manifests
+
     data_set = combine_manifests(*[load_manifest(m) for m in manifests])
     data_set.to_file(output_manifest)
 
@@ -92,6 +91,13 @@ def filter(predicate: str, manifest: Pathlike, output_manifest: Pathlike):
     It currently only supports comparison of numerical manifest item attributes, such as:
     start, duration, end, channel, num_frames, num_features, etc.
     """
+    import operator
+    import re
+    from math import isclose
+    from cytoolz.functoolz import complement
+    from lhotse import load_manifest
+    from lhotse.manipulation import to_manifest
+
     data_set = load_manifest(manifest)
 
     predicate_pattern = re.compile(r'(?P<key>\w+)(?P<op>=|==|!=|>|<|>=|<=)(?P<value>[0-9.]+)')

--- a/lhotse/bin/modes/validate.py
+++ b/lhotse/bin/modes/validate.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import click
 
-from lhotse import RecordingSet, SupervisionSet, fix_manifests, load_manifest, validate
 from lhotse.bin.modes.cli_base import cli
 from lhotse.utils import Pathlike
 
@@ -14,6 +13,7 @@ from lhotse.utils import Pathlike
                    '(could be extremely slow for large manifests).')
 def validate_(manifest: Pathlike, read_data: bool):
     """Validate a Lhotse manifest file."""
+    from lhotse import load_manifest, validate
     data = load_manifest(manifest)
     validate(data, read_data=read_data)
 
@@ -30,6 +30,7 @@ def fix_(recordings: Pathlike, supervisions: Pathlike, output_dir: Pathlike):
     Stores the output files in OUTPUT_DIR under the same names as the input
     files.
     """
+    from lhotse import RecordingSet, SupervisionSet, fix_manifests
     output_dir = Path(output_dir)
     recordings = Path(recordings)
     supervisions = Path(supervisions)

--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -11,8 +11,6 @@ from typing import Any, Callable, Dict, FrozenSet, Iterable, List, Mapping, Opti
     Union
 
 import numpy as np
-from cytoolz import sliding_window
-from cytoolz.itertoolz import groupby
 from intervaltree import Interval, IntervalTree
 from tqdm.auto import tqdm
 from typing_extensions import Literal
@@ -2422,6 +2420,7 @@ class CutSet(Serializable, Sequence[Cut]):
 
         :return: a ``CutSet``.
         """
+        from cytoolz import sliding_window
         cuts = []
         for cut in self:
             segments = []
@@ -2464,6 +2463,7 @@ class CutSet(Serializable, Sequence[Cut]):
         """
         if self.mixed_cuts:
             raise ValueError("This operation is not applicable to CutSet's containing MixedCut's.")
+        from cytoolz.itertoolz import groupby
         groups = groupby(lambda cut: (cut.recording.id, cut.start, cut.end), self)
         return CutSet.from_cuts(mix_cuts(cuts) for cuts in groups.values())
 

--- a/lhotse/features/base.py
+++ b/lhotse/features/base.py
@@ -292,7 +292,7 @@ class TorchaudioFeatureExtractor(FeatureExtractor):
         # Torchaudio Kaldi feature extractors expect the channel dimension to be first.
         if len(samples.shape) == 1:
             samples = samples.unsqueeze(0)
-        features = self.feature_fn(samples, **params).to(torch.float32)
+        features = self._feature_fn(samples, **params).to(torch.float32)
         return features.numpy()
 
     def _feature_fn(self, *args, **kwargs):

--- a/lhotse/features/base.py
+++ b/lhotse/features/base.py
@@ -278,7 +278,6 @@ def register_extractor(cls):
 
 class TorchaudioFeatureExtractor(FeatureExtractor):
     """Common abstract base class for all torchaudio based feature extractors."""
-    feature_fn = None
 
     def extract(self, samples: Union[np.ndarray, torch.Tensor], sampling_rate: int) -> np.ndarray:
         params = asdict(self.config)
@@ -295,6 +294,9 @@ class TorchaudioFeatureExtractor(FeatureExtractor):
             samples = samples.unsqueeze(0)
         features = self.feature_fn(samples, **params).to(torch.float32)
         return features.numpy()
+
+    def _feature_fn(self, *args, **kwargs):
+        raise NotImplementedError()
 
     @property
     def frame_shift(self) -> Seconds:

--- a/lhotse/features/fbank.py
+++ b/lhotse/features/fbank.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 
 import numpy as np
-import torchaudio
 
 from lhotse.features.base import TorchaudioFeatureExtractor, register_extractor
 from lhotse.utils import EPSILON, Seconds
@@ -37,7 +36,10 @@ class Fbank(TorchaudioFeatureExtractor):
     """Log Mel energy filter bank feature extractor based on ``torchaudio.compliance.kaldi.fbank`` function."""
     name = 'fbank'
     config_type = FbankConfig
-    feature_fn = staticmethod(torchaudio.compliance.kaldi.fbank)
+
+    def _feature_fn(self, *args, **kwargs):
+        from torchaudio.compliance.kaldi import fbank
+        return fbank(*args, **kwargs)
 
     def feature_dim(self, sampling_rate: int) -> int:
         return self.config.num_mel_bins

--- a/lhotse/features/mfcc.py
+++ b/lhotse/features/mfcc.py
@@ -1,7 +1,5 @@
 from dataclasses import dataclass
 
-import torchaudio
-
 from lhotse.features.base import TorchaudioFeatureExtractor, register_extractor
 from lhotse.utils import EPSILON, Seconds
 
@@ -38,7 +36,10 @@ class Mfcc(TorchaudioFeatureExtractor):
     """MFCC feature extractor based on ``torchaudio.compliance.kaldi.mfcc`` function."""
     name = 'mfcc'
     config_type = MfccConfig
-    feature_fn = staticmethod(torchaudio.compliance.kaldi.mfcc)
+
+    def _feature_fn(self, *args, **kwargs):
+        from torchaudio.compliance.kaldi import mfcc
+        return mfcc(*args, **kwargs)
 
     def feature_dim(self, sampling_rate: int) -> int:
         return self.config.num_ceps

--- a/lhotse/features/spectrogram.py
+++ b/lhotse/features/spectrogram.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 
 import numpy as np
-import torchaudio
 
 from lhotse.features.base import TorchaudioFeatureExtractor, register_extractor
 from lhotse.utils import EPSILON, Seconds
@@ -29,7 +28,10 @@ class Spectrogram(TorchaudioFeatureExtractor):
     """Log spectrogram feature extractor based on ``torchaudio.compliance.kaldi.spectrogram`` function."""
     name = 'spectrogram'
     config_type = SpectrogramConfig
-    feature_fn = staticmethod(torchaudio.compliance.kaldi.spectrogram)
+
+    def _feature_fn(self, *args, **kwargs):
+        from torchaudio.compliance.kaldi import spectrogram
+        return spectrogram(*args, **kwargs)
 
     def feature_dim(self, sampling_rate: int) -> int:
         from torchaudio.compliance.kaldi import _next_power_of_2

--- a/setup.py
+++ b/setup.py
@@ -148,8 +148,10 @@ try:
     import torch
 
     torch_ver = LooseVersion(torch.__version__)
+    if torch_ver >= LooseVersion("1.9.2"):
+        raise NotImplementedError("PyTorch version >= 1.9.2 is not yet supported")
     if torch_ver >= LooseVersion("1.9.1"):
-        raise NotImplementedError("Not yet supported")
+        install_requires.append("torchaudio==0.9.1")
     elif torch_ver >= LooseVersion("1.9.0"):
         install_requires.append("torchaudio==0.9.0")
     elif torch_ver >= LooseVersion("1.8.1"):


### PR DESCRIPTION
The majority of import time when starting the CLI is now taken by global `import torch` statements, I don't think we want to decouple Lhotse from PyTorch at this time, but we might do it in the future.