### PR TITLE
Options to preserve cut IDs in cut operations and transforms

### DIFF
--- a/lhotse/dataset/cut_transforms/__init__.py
+++ b/lhotse/dataset/cut_transforms/__init__.py
@@ -2,6 +2,7 @@ from .concatenate import CutConcatenate, concat_cuts
 from .extra_padding import ExtraPadding
 from .mix import CutMix
 from .perturb_speed import PerturbSpeed
+from .perturb_tempo import PerturbTempo
 from .perturb_volume import PerturbVolume
 
 __all__ = [
@@ -9,5 +10,6 @@ __all__ = [
     'CutMix',
     'ExtraPadding',
     'PerturbSpeed',
+    'PerturbTempo',
     'PerturbVolume'
 ]

--- a/lhotse/dataset/cut_transforms/extra_padding.py
+++ b/lhotse/dataset/cut_transforms/extra_padding.py
@@ -29,7 +29,8 @@ class ExtraPadding:
             extra_samples: Optional[int] = None,
             extra_seconds: Optional[Seconds] = None,
             pad_feat_value: float = LOG_EPSILON,
-            randomized: bool = False
+            randomized: bool = False,
+            preserve_id: bool = False,
     ) -> None:
         """
         ExtraPadding's constructor.
@@ -45,6 +46,8 @@ class ExtraPadding:
         :param randomized: When ``True``, we will sample a value from a uniform distribution of
             ``[0, extra_X]`` for each cut (for samples/frames -- sample an int,
             for duration -- sample a float).
+        :param preserve_id: When ``True``, preserves the IDs the cuts had before augmentation.
+            Otherwise, new random IDs are generated for the augmented cuts (default).
         """
         assert exactly_one_not_null(extra_frames, extra_samples, extra_seconds), \
             "For ExtraPadding, you have to specify exactly one of: frames, samples, or duration."
@@ -53,6 +56,7 @@ class ExtraPadding:
         self.extra_seconds = extra_seconds
         self.pad_feat_value = pad_feat_value
         self.randomized = randomized
+        self.preserve_id = preserve_id
 
     def __call__(self, cuts: CutSet) -> CutSet:
         if self.extra_frames is not None:
@@ -63,7 +67,8 @@ class ExtraPadding:
                         sample=self.randomized
                     ),
                     pad_feat_value=self.pad_feat_value,
-                    direction='both'
+                    direction='both',
+                    preserve_id=self.preserve_id,
                 ) for c in cuts
             )
         if self.extra_samples is not None:
@@ -73,7 +78,8 @@ class ExtraPadding:
                         value=self.extra_samples,
                         sample=self.randomized
                     ),
-                    direction='both'
+                    direction='both',
+                    preserve_id=self.preserve_id,
                 ) for c in cuts
             )
         if self.extra_seconds is not None:
@@ -84,7 +90,8 @@ class ExtraPadding:
                         sample=self.randomized,
                     ),
                     pad_feat_value=self.pad_feat_value,
-                    direction='both'
+                    direction='both',
+                    preserve_id=self.preserve_id,
                 ) for c in cuts
             )
         raise ValueError("Implementation error in ExtraPadding (please report this issue).")

--- a/lhotse/dataset/cut_transforms/mix.py
+++ b/lhotse/dataset/cut_transforms/mix.py
@@ -15,7 +15,8 @@ class CutMix:
             cuts: CutSet,
             snr: Optional[Union[Decibels, Tuple[Decibels, Decibels]]] = (10, 20),
             prob: float = 0.5,
-            pad_to_longest: bool = True
+            pad_to_longest: bool = True,
+            preserve_id: bool = False,
     ) -> None:
         """
         CutMix's constructor.
@@ -30,11 +31,14 @@ class CutMix:
             Specifies the probability with which we will mix augment the cuts.
         :param pad_to_longest: when `True`, each processed :class:`CutSet` will be padded with noise
             to match the duration of the longest Cut in a batch.
+        :param preserve_id: When ``True``, preserves the IDs the cuts had before augmentation.
+            Otherwise, new random IDs are generated for the augmented cuts (default).
         """
         self.cuts = cuts
         self.snr = snr
         self.prob = prob
         self.pad_to_longest = pad_to_longest
+        self.preserve_id = preserve_id
 
     def __call__(self, cuts: CutSet) -> CutSet:
         maybe_max_duration = max(c.duration for c in cuts) if self.pad_to_longest else None
@@ -42,5 +46,6 @@ class CutMix:
             cuts=self.cuts,
             duration=maybe_max_duration,
             snr=self.snr,
-            mix_prob=self.prob
+            mix_prob=self.prob,
+            preserve_id='left' if self.preserve_id else None,
         )

--- a/lhotse/dataset/cut_transforms/perturb_speed.py
+++ b/lhotse/dataset/cut_transforms/perturb_speed.py
@@ -17,17 +17,21 @@ class PerturbSpeed:
             self,
             factors: Union[float, Sequence[float]],
             p: float,
-            randgen: random.Random = None
+            randgen: random.Random = None,
+            preserve_id: bool = False,
     ) -> None:
         self.factors = factors if isinstance(factors, Sequence) else [factors]
         self.p = p
         self.random = randgen
+        self.preserve_id = preserve_id
 
     def __call__(self, cuts: CutSet) -> CutSet:
         if self.random is None:
             self.random = random
         return CutSet.from_cuts(
-            cut.perturb_speed(factor=self.random.choice(self.factors))
+            cut.perturb_speed(
+                factor=self.random.choice(self.factors), affix_id=not self.preserve_id
+            )
             if self.random.random() >= self.p
             else cut
             for cut in cuts

--- a/lhotse/dataset/cut_transforms/perturb_tempo.py
+++ b/lhotse/dataset/cut_transforms/perturb_tempo.py
@@ -4,9 +4,9 @@ from typing import List, Sequence, Union
 from lhotse import CutSet
 
 
-class PerturbVolume:
+class PerturbTempo:
     """
-    A transform on batch of cuts (``CutSet``) that perturbs the volume of the recordings
+    A transform on batch of cuts (``CutSet``) that perturbs the tempo of the recordings
     with a given probability :attr:`p`.
 
     If the effect is applied, then one of the perturbation factors from the constructor's
@@ -29,7 +29,7 @@ class PerturbVolume:
         if self.random is None:
             self.random = random
         return CutSet.from_cuts(
-            cut.perturb_volume(
+            cut.perturb_tempo(
                 factor=self.random.choice(self.factors), affix_id=not self.preserve_id
             )
             if self.random.random() >= self.p

--- a/test/cut/test_cut_ops_preserve_id.py
+++ b/test/cut/test_cut_ops_preserve_id.py
@@ -1,0 +1,231 @@
+import pytest
+
+# Note:
+# Definitions for `cut1`, `cut2` and `cut_set` parameters are standard Pytest fixtures located in test/cut/conftest.py
+
+
+# ########################################
+# ############### PADDING ################
+# ########################################
+
+
+@pytest.mark.parametrize('direction', ['right', 'left', 'both'])
+def test_pad_cut_preserve_id_false(cut1, direction: str):
+    padded = cut1.pad(duration=300, direction=direction)
+    assert padded.id != cut1.id
+
+
+@pytest.mark.parametrize('direction', ['right', 'left', 'both'])
+def test_pad_cut_preserve_id_true(cut1, direction: str):
+    padded = cut1.pad(duration=300, direction=direction, preserve_id=True)
+    assert padded.id == cut1.id
+
+
+@pytest.mark.parametrize('direction', ['right', 'left', 'both'])
+def test_pad_mixed_cut_preserve_id_false(cut1, direction: str):
+    mixed = cut1.append(cut1)
+    padded = mixed.pad(duration=300, direction=direction)
+    assert padded.id != mixed.id
+
+
+@pytest.mark.parametrize('direction', ['right', 'left', 'both'])
+def test_pad_mixed_cut_preserve_id_true(cut1, direction: str):
+    mixed = cut1.append(cut1)
+    padded = mixed.pad(duration=300, direction=direction, preserve_id=True)
+    assert padded.id == mixed.id
+
+
+# ########################################
+# ############## APPENDING ###############
+# ########################################
+
+
+def test_append_cut_preserve_id_none(cut1, cut2):
+    appended = cut1.append(cut2)
+    assert appended.id != cut1.id
+    assert appended.id != cut2.id
+
+
+def test_append_cut_preserve_id_left(cut1, cut2):
+    appended = cut1.append(cut2, preserve_id='left')
+    assert appended.id == cut1.id
+    assert appended.id != cut2.id
+
+
+def test_append_cut_preserve_id_right(cut1, cut2):
+    appended = cut1.append(cut2, preserve_id='right')
+    assert appended.id != cut1.id
+    assert appended.id == cut2.id
+
+
+def test_append_mixed_cut_preserve_id_none(cut1, cut2):
+    premixed = cut1.append(cut1)
+    appended = premixed.append(cut2)
+    assert appended.id != premixed.id
+    assert appended.id != cut2.id
+
+
+def test_append_mixed_cut_preserve_id_left(cut1, cut2):
+    premixed = cut1.append(cut1)
+    appended = premixed.append(cut2, preserve_id='left')
+    assert appended.id == premixed.id
+    assert appended.id != cut2.id
+
+
+def test_append_mixed_cut_preserve_id_right(cut1, cut2):
+    premixed = cut1.append(cut1)
+    appended = premixed.append(cut2, preserve_id='right')
+    assert appended.id != premixed.id
+    assert appended.id == cut2.id
+
+
+# ########################################
+# ############### MIXING #################
+# ########################################
+
+
+def test_mix_cut_preserve_id_none(cut1, cut2):
+    mixed = cut1.mix(cut2)
+    assert mixed.id != cut1.id
+    assert mixed.id != cut2.id
+
+
+def test_mix_cut_preserve_id_left(cut1, cut2):
+    mixed = cut1.mix(cut2, preserve_id='left')
+    assert mixed.id == cut1.id
+    assert mixed.id != cut2.id
+
+
+def test_mix_cut_preserve_id_right(cut1, cut2):
+    mixed = cut1.mix(cut2, preserve_id='right')
+    assert mixed.id != cut1.id
+    assert mixed.id == cut2.id
+
+
+def test_mix_mixed_cut_preserve_id_none(cut1, cut2):
+    premixed = cut1.append(cut1)
+    mixed = premixed.mix(cut2)
+    assert mixed.id != premixed.id
+    assert mixed.id != cut2.id
+
+
+def test_mix_mixed_cut_preserve_id_left(cut1, cut2):
+    premixed = cut1.append(cut1)
+    mixed = premixed.mix(cut2, preserve_id='left')
+    assert mixed.id == premixed.id
+    assert mixed.id != cut2.id
+
+
+def test_mix_mixed_cut_preserve_id_right(cut1, cut2):
+    premixed = cut1.append(cut1)
+    mixed = premixed.mix(cut2, preserve_id='right')
+    assert mixed.id != premixed.id
+    assert mixed.id == cut2.id
+
+
+# ########################################
+# ############ PERTURB SPEED #############
+# ########################################
+
+
+def test_cut_perturb_speed_affix_id_true(cut1):
+    cut_sp = cut1.perturb_speed(1.1)
+    assert cut_sp.id != cut1.id
+
+
+def test_cut_perturb_speed_affix_id_false(cut1):
+    cut_sp = cut1.perturb_speed(1.1, affix_id=False)
+    assert cut_sp.id == cut1.id
+
+
+def test_mixed_cut_perturb_speed_affix_id_true(cut1):
+    premixed = cut1.append(cut1)
+    cut_sp = premixed.perturb_speed(1.1)
+    assert cut_sp.id != premixed.id
+
+
+def test_mixed_cut_perturb_speed_affix_id_false(cut1):
+    premixed = cut1.append(cut1)
+    cut_sp = premixed.perturb_speed(1.1, affix_id=False)
+    assert cut_sp.id == premixed.id
+
+
+# ########################################
+# ############ PERTURB TEMPO #############
+# ########################################
+
+
+def test_cut_perturb_tempo_affix_id_true(cut1):
+    cut_tp = cut1.perturb_tempo(1.1)
+    assert cut_tp.id != cut1.id
+
+
+def test_cut_perturb_tempo_affix_id_false(cut1):
+    cut_tp = cut1.perturb_tempo(1.1, affix_id=False)
+    assert cut_tp.id == cut1.id
+
+
+def test_mixed_cut_perturb_tempo_affix_id_true(cut1):
+    premixed = cut1.append(cut1)
+    cut_tp = premixed.perturb_tempo(1.1)
+    assert cut_tp.id != premixed.id
+
+
+def test_mixed_cut_perturb_tempo_affix_id_false(cut1):
+    premixed = cut1.append(cut1)
+    cut_tp = premixed.perturb_tempo(1.1, affix_id=False)
+    assert cut_tp.id == premixed.id
+
+
+# ########################################
+# ########### PERTURB VOLUME #############
+# ########################################
+
+
+def test_cut_perturb_volume_affix_id_true(cut1):
+    cut_vp = cut1.perturb_volume(1.1)
+    assert cut_vp.id != cut1.id
+
+
+def test_cut_perturb_volume_affix_id_false(cut1):
+    cut_vp = cut1.perturb_volume(1.1, affix_id=False)
+    assert cut_vp.id == cut1.id
+
+
+def test_mixed_cut_perturb_volume_affix_id_true(cut1):
+    premixed = cut1.append(cut1)
+    cut_vp = premixed.perturb_volume(1.1)
+    assert cut_vp.id != premixed.id
+
+
+def test_mixed_cut_perturb_volume_affix_id_false(cut1):
+    premixed = cut1.append(cut1)
+    cut_vp = premixed.perturb_volume(1.1, affix_id=False)
+    assert cut_vp.id == premixed.id
+
+
+# ########################################
+# ############## RESAMPLE ################
+# ########################################
+
+
+def test_cut_resample_affix_id_true(cut1):
+    cut_rs = cut1.resample(44100, affix_id=True)
+    assert cut_rs.id != cut1.id
+
+
+def test_cut_resample_affix_id_false(cut1):
+    cut_rs = cut1.resample(44100)
+    assert cut_rs.id == cut1.id
+
+
+def test_mixed_cut_resample_affix_id_true(cut1):
+    premixed = cut1.append(cut1)
+    cut_rs = premixed.resample(44100, affix_id=True)
+    assert cut_rs.id != premixed.id
+
+
+def test_mixed_cut_resample_affix_id_false(cut1):
+    premixed = cut1.append(cut1)
+    cut_rs = premixed.resample(44100)
+    assert cut_rs.id == premixed.id

--- a/test/dataset/test_cut_transforms.py
+++ b/test/dataset/test_cut_transforms.py
@@ -5,13 +5,16 @@ import pytest
 
 from lhotse import CutSet
 from lhotse.cut import MixedCut
-from lhotse.dataset import CutMix, ExtraPadding
+from lhotse.dataset import CutMix, ExtraPadding, PerturbTempo
 from lhotse.dataset import PerturbSpeed, PerturbVolume
 from lhotse.testing.dummies import DummyManifest
 
 
-def test_perturb_speed():
-    tfnm = PerturbSpeed(factors=[0.9, 1.1], p=0.5, randgen=random.Random(42))
+@pytest.mark.parametrize("preserve_id", [False, True])
+def test_perturb_speed(preserve_id: bool):
+    tfnm = PerturbSpeed(
+        factors=[0.9, 1.1], p=0.5, randgen=random.Random(42), preserve_id=preserve_id
+    )
     cuts = DummyManifest(CutSet, begin_id=0, end_id=10)
     cuts_sp = tfnm(cuts)
 
@@ -23,22 +26,62 @@ def test_perturb_speed():
         for cut in cuts_sp
     )
 
+    if preserve_id:
+        assert all(cut.id == cut_sp.id for cut, cut_sp in zip(cuts, cuts_sp))
+    else:
+        # Note: not using all() because PerturbSpeed has p=0.5
+        assert any(cut.id != cut_sp.id for cut, cut_sp in zip(cuts, cuts_sp))
 
-def test_perturb_volume():
-    tfnm = PerturbVolume(factors=[0.125, 2.], p=0.5, randgen=random.Random(42))
+
+@pytest.mark.parametrize("preserve_id", [False, True])
+def test_perturb_tempo(preserve_id: bool):
+    tfnm = PerturbTempo(
+        factors=[0.9, 1.1], p=0.5, randgen=random.Random(42), preserve_id=preserve_id
+    )
+    cuts = DummyManifest(CutSet, begin_id=0, end_id=10)
+    cuts_tp = tfnm(cuts)
+
+    assert all(
+        # The duration will not be exactly 0.9 and 1.1 because perturb speed
+        # will round to a physically-viable duration based on the sampling_rate
+        # (i.e. round to the nearest sample count).
+        any(isclose(cut.duration, v, abs_tol=0.0125) for v in [0.9, 1.0, 1.1])
+        for cut in cuts_tp
+    )
+
+    if preserve_id:
+        assert all(cut.id == cut_tp.id for cut, cut_tp in zip(cuts, cuts_tp))
+    else:
+        # Note: not using all() because PerturbTempo has p=0.5
+        assert any(cut.id != cut_tp.id for cut, cut_tp in zip(cuts, cuts_tp))
+
+
+@pytest.mark.parametrize("preserve_id", [False, True])
+def test_perturb_volume(preserve_id: bool):
+    tfnm = PerturbVolume(
+        factors=[0.125, 2.0], p=0.5, randgen=random.Random(42), preserve_id=preserve_id
+    )
     cuts = DummyManifest(CutSet, begin_id=0, end_id=10)
     cuts_vp = tfnm(cuts)
 
     assert all(
-        cut.duration == 1. and
-        cut.start == 0. and
-        cut.recording.sampling_rate == 16000 and
-        cut.recording.num_samples == 16000 and
-        cut.recording.duration == 1.0 for cut in cuts_vp
+        cut.duration == 1.0
+        and cut.start == 0.0
+        and cut.recording.sampling_rate == 16000
+        and cut.recording.num_samples == 16000
+        and cut.recording.duration == 1.0
+        for cut in cuts_vp
     )
 
+    if preserve_id:
+        assert all(cut.id == cut_vp.id for cut, cut_vp in zip(cuts, cuts_vp))
+    else:
+        # Note: not using all() because PerturbVolume has p=0.5
+        assert any(cut.id != cut_vp.id for cut, cut_vp in zip(cuts, cuts_vp))
 
-def test_cutmix():
+
+@pytest.mark.parametrize("preserve_id", [False, True])
+def test_cutmix(preserve_id: bool):
     speech_cuts = DummyManifest(CutSet, begin_id=0, end_id=10)
     for c in speech_cuts:
         c.duration = 10.0
@@ -47,7 +90,7 @@ def test_cutmix():
     for c in noise_cuts:
         c.duration = 1.5
 
-    tfnm = CutMix(noise_cuts, snr=None, prob=1.0)
+    tfnm = CutMix(noise_cuts, snr=None, prob=1.0, preserve_id=preserve_id)
 
     tfnm_cuts = tfnm(speech_cuts)
     for c in tfnm_cuts:
@@ -55,13 +98,22 @@ def test_cutmix():
         assert c.tracks[0].cut.duration == 10.0
         assert sum(t.cut.duration for t in c.tracks[1:]) == 10.0
 
+    if preserve_id:
+        assert all(
+            cut.id == cut_noisy.id for cut, cut_noisy in zip(speech_cuts, tfnm_cuts)
+        )
+    else:
+        assert all(
+            cut.id != cut_noisy.id for cut, cut_noisy in zip(speech_cuts, tfnm_cuts)
+        )
 
-@pytest.mark.parametrize('randomized', [False, True])
-def test_extra_padding_frames(randomized):
+
+@pytest.mark.parametrize("randomized", [False, True])
+@pytest.mark.parametrize("preserve_id", [False, True])
+def test_extra_padding_frames(randomized: bool, preserve_id: bool):
     cuts = DummyManifest(CutSet, begin_id=0, end_id=10)
     transform = ExtraPadding(
-        extra_frames=4,
-        randomized=randomized
+        extra_frames=4, randomized=randomized, preserve_id=preserve_id
     )
     padded_cuts = transform(cuts)
 
@@ -81,14 +133,18 @@ def test_extra_padding_frames(randomized):
         nums_frames = [c.num_frames for c in padded_cuts]
         assert len(set(nums_frames)) > 1
 
+    if preserve_id:
+        assert all(cut.id == cut_pad.id for cut, cut_pad in zip(cuts, padded_cuts))
+    else:
+        # Note: using any(), not all(), since some cuts may be unaffected
+        #       as the transform may be randomized.
+        assert any(cut.id != cut_pad.id for cut, cut_pad in zip(cuts, padded_cuts))
 
-@pytest.mark.parametrize('randomized', [False, True])
+
+@pytest.mark.parametrize("randomized", [False, True])
 def test_extra_padding_samples(randomized):
     cuts = DummyManifest(CutSet, begin_id=0, end_id=10)
-    transform = ExtraPadding(
-        extra_samples=320,
-        randomized=randomized
-    )
+    transform = ExtraPadding(extra_samples=320, randomized=randomized)
     padded_cuts = transform(cuts)
 
     # Non-randomized test -- check that all cuts are processed
@@ -108,13 +164,10 @@ def test_extra_padding_samples(randomized):
         assert len(set(nums_samples)) > 1
 
 
-@pytest.mark.parametrize('randomized', [False, True])
+@pytest.mark.parametrize("randomized", [False, True])
 def test_extra_padding_seconds(randomized):
     cuts = DummyManifest(CutSet, begin_id=0, end_id=10)
-    transform = ExtraPadding(
-        extra_seconds=0.04,
-        randomized=randomized
-    )
+    transform = ExtraPadding(extra_seconds=0.04, randomized=randomized)
     padded_cuts = transform(cuts)
 
     # Non-randomized test -- check that all cuts are processed


### PR DESCRIPTION
All relevant cut operations (`.pad()`, `.truncate()`, `.mix()`, `.append()` and transforms (`PerturbSpeed`, `CutMix`, etc.) now have a `preserve_id` option that is set to ``False`` by default. Setting it to ``True`` allows to augment cuts and still match them by IDs.


CC: @csukuangfj 