### PR TITLE
set the channel info correctly

### DIFF
--- a/lhotse/recipes/callhome_english.py
+++ b/lhotse/recipes/callhome_english.py
@@ -196,6 +196,7 @@ def prepare_callhome_english_asr(
                         start=start,
                         duration=duration,
                         speaker=f"{recording_id}_{spk}",
+                        channel=ord(spk[0]) - ord("A"),
                         text=text,
                     )
                 )


### PR DESCRIPTION
Properly set the channel to either 0 or 1 depending on the speaker. Callhome English has the speakers in individual/separated channels
