### PR TITLE
make the callhome asr utterances following specific format for QOL

### DIFF
--- a/lhotse/recipes/callhome_english.py
+++ b/lhotse/recipes/callhome_english.py
@@ -191,12 +191,12 @@ def prepare_callhome_english_asr(
                 start = float(start)
                 supervisions.append(
                     SupervisionSegment(
-                        id=f"{recording_id}_{idx}",
                         recording_id=recording_id,
                         start=start,
                         duration=duration,
-                        speaker=f"{recording_id}_{spk}",
                         channel=ord(spk[0]) - ord("A"),
+                        speaker=f"{recording_id}_{spk:0>2s}",
+                        id=f"{recording_id}_{spk:0>2s}_{idx:0>5d}",
                         text=text,
                     )
                 )


### PR DESCRIPTION
make the callhome asr utterances following specific format for ease of export to kaldi (quality of life change)

specifically, quality of my life :)
but shouldn't be a problem to anyone, callhome english ASR is very new in lhotse
y.

