### PR TITLE
Add dynamic LRU cache for audio and feature I/O

### DIFF
--- a/lhotse/__init__.py
+++ b/lhotse/__init__.py
@@ -1,5 +1,6 @@
 from .audio import AudioSource, Recording, RecordingSet
 from .augmentation import *
+from .caching import is_caching_enabled, set_caching_enabled
 from .cut import CutSet, MonoCut
 from .features import *
 from .kaldi import load_kaldi_data_dir

--- a/lhotse/audio.py
+++ b/lhotse/audio.py
@@ -30,6 +30,7 @@ import numpy as np
 from tqdm.auto import tqdm
 
 from lhotse.augmentation import AudioTransform, Resample, Speed, Tempo, Volume
+from lhotse.caching import dynamic_lru_cache
 from lhotse.serialization import Serializable
 from lhotse.utils import (
     Decibels,
@@ -932,6 +933,7 @@ def audio_energy(audio: np.ndarray) -> float:
 FileObject = Any  # Alias for file-like objects
 
 
+@dynamic_lru_cache
 def read_audio(
     path_or_fd: Union[Pathlike, FileObject],
     offset: Seconds = 0.0,

--- a/lhotse/caching.py
+++ b/lhotse/caching.py
@@ -40,7 +40,8 @@ def dynamic_lru_cache(method: Callable) -> Callable:
         >>> set_caching_enabled(True)   # enable
         >>> set_caching_enabled(False)  # disable
 
-    Currently it hard-codes the cache size at Python's default (128).
+    Currently it hard-codes the cache size at 512 items
+    (regardless of the array size).
 
     Check :meth:`functools.lru_cache` for more details.
     """
@@ -49,7 +50,7 @@ def dynamic_lru_cache(method: Callable) -> Callable:
     global LHOTSE_CACHED_METHOD_REGISTRY
     name = method.__qualname__  # example: "Recording.load_audio()"
     LHOTSE_CACHED_METHOD_REGISTRY["noncached"][name] = method
-    LHOTSE_CACHED_METHOD_REGISTRY["cached"][name] = lru_cache(method)
+    LHOTSE_CACHED_METHOD_REGISTRY["cached"][name] = lru_cache(maxsize=512)(method)
 
     @wraps(method)
     def wrapper(*args, **kwargs) -> Any:

--- a/lhotse/caching.py
+++ b/lhotse/caching.py
@@ -49,6 +49,12 @@ def dynamic_lru_cache(method: Callable) -> Callable:
     # together with the original, noncached method.
     global LHOTSE_CACHED_METHOD_REGISTRY
     name = method.__qualname__  # example: "Recording.load_audio()"
+    if name in LHOTSE_CACHED_METHOD_REGISTRY["cached"]:
+        raise ValueError(
+            f"Method '{name}' is already cached. "
+            f"We don't support caching different methods which have "
+            f"the same __qualname__ attribute (i.e., class name + method name)."
+        )
     LHOTSE_CACHED_METHOD_REGISTRY["noncached"][name] = method
     LHOTSE_CACHED_METHOD_REGISTRY["cached"][name] = lru_cache(maxsize=512)(method)
 

--- a/lhotse/caching.py
+++ b/lhotse/caching.py
@@ -1,0 +1,65 @@
+from functools import lru_cache, wraps
+from typing import Any, Callable
+
+LHOTSE_CACHING_ENABLED = True
+
+# This dict is holding two variants for each registered method:
+# the cached variant, that uses it's own LRU cache,
+# and a noncached variant, that will always be recomputed.
+# This allows the users to enable or disable caching and
+# always get the expected behavior.
+LHOTSE_CACHED_METHOD_REGISTRY = {"cached": {}, "noncached": {}}
+
+
+def set_caching_enabled(enabled: bool) -> None:
+    global LHOTSE_CACHING_ENABLED
+    global LHOTSE_CACHED_METHOD_REGISTRY
+    assert isinstance(enabled, bool)
+    LHOTSE_CACHING_ENABLED = enabled
+    if not enabled:
+        # Caching disabled: purge all caches.
+        for method in LHOTSE_CACHED_METHOD_REGISTRY["cached"].values():
+            method.cache_clear()
+
+
+def is_caching_enabled() -> bool:
+    return LHOTSE_CACHING_ENABLED
+
+
+def dynamic_lru_cache(method: Callable) -> Callable:
+    """
+    Least-recently-used cache decorator.
+
+    It enhances Python's built-in ``lru_cache`` with a dynamic
+    lookup of whether to apply the cached, or noncached variant
+    of the decorated function.
+
+    To disable/enable caching globally in Lhotse, call::
+
+        >>> from lhotse import set_caching_enabled
+        >>> set_caching_enabled(True)   # enable
+        >>> set_caching_enabled(False)  # disable
+
+    Currently it hard-codes the cache size at Python's default (128).
+
+    Check :meth:`functools.lru_cache` for more details.
+    """
+    # Create an LRU cached variant of the method and register it
+    # together with the original, noncached method.
+    global LHOTSE_CACHED_METHOD_REGISTRY
+    name = method.__qualname__  # example: "Recording.load_audio()"
+    LHOTSE_CACHED_METHOD_REGISTRY["noncached"][name] = method
+    LHOTSE_CACHED_METHOD_REGISTRY["cached"][name] = lru_cache(method)
+
+    @wraps(method)
+    def wrapper(*args, **kwargs) -> Any:
+        # Each time the user calls this function, we will
+        # dynamically dispatch the cached or noncached variant
+        # of the wrapped method, depending on the global settings.
+        if is_caching_enabled():
+            m = LHOTSE_CACHED_METHOD_REGISTRY["cached"][name]
+        else:
+            m = LHOTSE_CACHED_METHOD_REGISTRY["noncached"][name]
+        return m(*args, **kwargs)
+
+    return wrapper

--- a/lhotse/features/io.py
+++ b/lhotse/features/io.py
@@ -7,6 +7,7 @@ from typing import List, Optional, Type
 import lilcom
 import numpy as np
 
+from lhotse.caching import dynamic_lru_cache
 from lhotse.utils import Pathlike, SmartOpen, is_module_available
 
 
@@ -181,6 +182,7 @@ class LilcomFilesReader(FeaturesReader):
         super().__init__()
         self.storage_path = Path(storage_path)
 
+    @dynamic_lru_cache
     def read(
         self,
         key: str,
@@ -245,6 +247,7 @@ class NumpyFilesReader(FeaturesReader):
         super().__init__()
         self.storage_path = Path(storage_path)
 
+    @dynamic_lru_cache
     def read(
         self,
         key: str,
@@ -336,6 +339,7 @@ class NumpyHdf5Reader(FeaturesReader):
         super().__init__()
         self.hdf = lookup_cache_or_open(storage_path)
 
+    @dynamic_lru_cache
     def read(
         self,
         key: str,
@@ -414,6 +418,7 @@ class LilcomHdf5Reader(FeaturesReader):
         super().__init__()
         self.hdf = lookup_cache_or_open(storage_path)
 
+    @dynamic_lru_cache
     def read(
         self,
         key: str,
@@ -509,6 +514,7 @@ class ChunkedLilcomHdf5Reader(FeaturesReader):
         super().__init__()
         self.hdf = lookup_cache_or_open(storage_path)
 
+    @dynamic_lru_cache
     def read(
         self,
         key: str,
@@ -650,6 +656,7 @@ class LilcomURLReader(FeaturesReader):
         if self.base_url.endswith("/"):
             self.base_url = self.base_url[:-1]
 
+    @dynamic_lru_cache
     def read(
         self,
         key: str,
@@ -732,6 +739,7 @@ class KaldiReader(FeaturesReader):
         self.storage_path = storage_path
         self.storage = kaldiio.load_scp(str(self.storage_path))
 
+    @dynamic_lru_cache
     def read(
         self,
         key: str,

--- a/test/cut/test_feature_extraction.py
+++ b/test/cut/test_feature_extraction.py
@@ -188,10 +188,15 @@ def test_extract_and_store_features_from_cut_set(
         ),
         pytest.param(
             lambda: LibrosaFbank(LibrosaFbankConfig(sampling_rate=16000)),
-            marks=pytest.mark.skipif(
-                not is_module_available("librosa"),
-                reason="Requires librosa to run.",
-            ),
+            marks=[
+                pytest.mark.skipif(
+                    not is_module_available("librosa"),
+                    reason="Requires librosa to run.",
+                ),
+                pytest.mark.xfail(
+                    reason="Librosa extractors do not work with PyTorch tensors."
+                ),
+            ],
         ),
     ],
 )

--- a/test/test_audio_reads.py
+++ b/test/test_audio_reads.py
@@ -1,5 +1,11 @@
-import pytest
+from tempfile import NamedTemporaryFile
 
+import numpy as np
+import pytest
+import torch
+import torchaudio
+
+import lhotse
 from lhotse import Recording
 
 
@@ -21,3 +27,61 @@ def test_info_and_read_audio_consistency(path):
     recording = Recording.from_file(path)
     audio = recording.load_audio()
     assert audio.shape[1] == recording.num_samples
+
+
+def test_audio_caching_enabled_works():
+    lhotse.set_caching_enabled(True)  # Enable caching.
+
+    np.random.seed(89)  # Reproducibility.
+
+    # Prepare two different waveforms.
+    noise1 = np.random.rand(1, 32000).astype(np.float32)
+    noise2 = np.random.rand(1, 32000).astype(np.float32)
+    # Sanity check -- the noises are different
+    assert np.abs(noise1 - noise2).sum() != 0
+
+    # Save the first waveform in a file.
+    with NamedTemporaryFile(suffix=".wav") as f:
+        torchaudio.save(f.name, torch.from_numpy(noise1), sample_rate=16000)
+        recording = Recording.from_file(f.name)
+
+        # Read the audio -- should be equal to noise1.
+        audio = recording.load_audio()
+        np.testing.assert_almost_equal(audio, noise1)
+
+        # Save noise2 to the same location.
+        torchaudio.save(f.name, torch.from_numpy(noise2), sample_rate=16000)
+
+        # Read the audio -- should *still* be equal to noise1,
+        # because reading from this path was cached before.
+        audio = recording.load_audio()
+        np.testing.assert_almost_equal(audio, noise1)
+
+
+def test_audio_caching_disabled_works():
+    lhotse.set_caching_enabled(False)  # Disable caching.
+
+    np.random.seed(89)  # Reproducibility.
+
+    # Prepare two different waveforms.
+    noise1 = np.random.rand(1, 32000).astype(np.float32)
+    noise2 = np.random.rand(1, 32000).astype(np.float32)
+    # Sanity check -- the noises are different
+    assert np.abs(noise1 - noise2).sum() != 0
+
+    # Save the first waveform in a file.
+    with NamedTemporaryFile(suffix=".wav") as f:
+        torchaudio.save(f.name, torch.from_numpy(noise1), sample_rate=16000)
+        recording = Recording.from_file(f.name)
+
+        # Read the audio -- should be equal to noise1.
+        audio = recording.load_audio()
+        np.testing.assert_almost_equal(audio, noise1)
+
+        # Save noise2 to the same location.
+        torchaudio.save(f.name, torch.from_numpy(noise2), sample_rate=16000)
+
+        # Read the audio -- should be equal to noise2,
+        # and the caching is ignored (doesn't happen).
+        audio = recording.load_audio()
+        np.testing.assert_almost_equal(audio, noise2)


### PR DESCRIPTION
This PR introduces I/O LRU caching to Lhotse. The idea is that when you repeatedly call `cut.load_audio()`, `recording.load_audio()`, or `cut.load_features()` on the same object, you avoid re-reading the data from disk/cloud/elsewhere. 

This comes in handy when: 
- doing data exploration (e.g. Jupyter/Colab notebooks)
- creating batches before and after data augmentation (e.g., #439 CC: @danpovey)

The cache is currently set to 512 elements for each registered method.

Note: *caching is turned on by default,* but can be disabled with `lhotse.set_caching_enabled(False)`. You might want to disable it if you expect that your audio files would be overwritten with new data between calls to `.load_audio()` (for whatever reason that I can't think of).