### PR TITLE
fix typo of np.stack

### DIFF
--- a/lhotse/features/base.py
+++ b/lhotse/features/base.py
@@ -169,7 +169,7 @@ class FeatureExtractor(metaclass=ABCMeta):
             else:
                 return result[0]
         elif all(item.shape == result[0].shape for item in result[1:]):
-            return np.stack(result, dim=0)
+            return np.stack(result, axis=0)
         else:
             return result
 


### PR DESCRIPTION
It maybe a typo.
Accoring to numpy document, the second argument's name of np.stack is **axis** not **dim**.
https://numpy.org/doc/stable/reference/generated/numpy.stack.html

Actually, it triggered an error when I used this function today.

```
  File "prepare_gigaspeech.py", line 285, in main
    CutSet.from_manifests(
  File "/ceph-ly/open-source/giga_librispeech/lhotse/lhotse/cut.py", line 3446, in compute_and_store_features_batch
    features = extractor.extract_batch(
  File "/ceph-ly/open-source/giga_librispeech/lhotse/lhotse/features/base.py", line 172, in extract_batch
    return np.stack(result, dim=0)
  File "<__array_function__ internals>", line 4, in stack
TypeError: _stack_dispatcher() got an unexpected keyword argument 'dim'
```