### PR TITLE
Rich exception info for I/O in Recording, MonoCut and MixedCut

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -17,4 +17,4 @@ jobs:
       - uses: psf/black@stable
         with:
           options: "--check --diff --color"
-          version: "21.9b0"
+          version: "21.10b0"

--- a/lhotse/audio.py
+++ b/lhotse/audio.py
@@ -1313,20 +1313,24 @@ def read_opus(
 
     :return: a tuple of audio samples and the sampling rate.
     """
-    try:
-        return read_opus_torchaudio(
-            path=path,
-            offset=offset,
-            duration=duration,
-            force_opus_sampling_rate=force_opus_sampling_rate,
-        )
-    except:
-        return read_opus_ffmpeg(
-            path=path,
-            offset=offset,
-            duration=duration,
-            force_opus_sampling_rate=force_opus_sampling_rate,
-        )
+    # TODO: Revisit using torchaudio backend for OPUS
+    #       once it's more thoroughly benchmarked against ffmpeg
+    #       and has a competitive I/O speed.
+    #       See: https://github.com/pytorch/audio/issues/1994
+    # try:
+    #     return read_opus_torchaudio(
+    #         path=path,
+    #         offset=offset,
+    #         duration=duration,
+    #         force_opus_sampling_rate=force_opus_sampling_rate,
+    #     )
+    # except:
+    return read_opus_ffmpeg(
+        path=path,
+        offset=offset,
+        duration=duration,
+        force_opus_sampling_rate=force_opus_sampling_rate,
+    )
 
 
 def read_opus_torchaudio(

--- a/lhotse/audio.py
+++ b/lhotse/audio.py
@@ -1305,6 +1305,62 @@ def read_opus(
     force_opus_sampling_rate: Optional[int] = None,
 ) -> Tuple[np.ndarray, int]:
     """
+    Reads OPUS files either using torchaudio or ffmpeg.
+    Torchaudio is faster, but if unavailable for some reason,
+    we fallback to a slower ffmpeg-based implemention.
+
+    :return: a tuple of audio samples and the sampling rate.
+    """
+    try:
+        return read_opus_torchaudio(
+            path=path,
+            offset=offset,
+            duration=duration,
+            force_opus_sampling_rate=force_opus_sampling_rate,
+        )
+    except:
+        return read_opus_ffmpeg(
+            path=path,
+            offset=offset,
+            duration=duration,
+            force_opus_sampling_rate=force_opus_sampling_rate,
+        )
+
+
+def read_opus_torchaudio(
+    path: Pathlike,
+    offset: Seconds = 0.0,
+    duration: Optional[Seconds] = None,
+    force_opus_sampling_rate: Optional[int] = None,
+) -> Tuple[np.ndarray, int]:
+    """
+    Reads OPUS files using torchaudio.
+    This is just running ``tochaudio.load()``, but we take care of extra resampling if needed.
+
+    :return: a tuple of audio samples and the sampling rate.
+    """
+    audio, sampling_rate = torchaudio_load(
+        path_or_fd=path, offset=offset, duration=duration
+    )
+
+    if force_opus_sampling_rate is None or force_opus_sampling_rate == sampling_rate:
+        return audio, sampling_rate
+
+    resampler = Resample(
+        source_sampling_rate=sampling_rate,
+        target_sampling_rate=force_opus_sampling_rate,
+    )
+    resampled_audio = resampler(audio)
+    return resampled_audio, force_opus_sampling_rate
+
+
+def read_opus_ffmpeg(
+    path: Pathlike,
+    offset: Seconds = 0.0,
+    duration: Optional[Seconds] = None,
+    force_opus_sampling_rate: Optional[int] = None,
+) -> Tuple[np.ndarray, int]:
+    """
     Reads OPUS files using ffmpeg in a shell subprocess.
     Unlike audioread, correctly supports offsets and durations for reading short chunks.
     Optionally, we can force ffmpeg to resample to the true sampling rate (if we know it up-front).
@@ -1333,17 +1389,22 @@ def read_opus(
     raw_audio = proc.stdout
     audio = np.frombuffer(raw_audio, dtype=np.float32)
     # Determine if the recording is mono or stereo and decode accordingly.
-    channel_string = parse_channel_from_ffmpeg_output(proc.stderr)
-    if channel_string == "stereo":
-        new_audio = np.empty((2, audio.shape[0] // 2), dtype=np.float32)
-        new_audio[0, :] = audio[::2]
-        new_audio[1, :] = audio[1::2]
-        audio = new_audio
-    elif channel_string == "mono":
-        audio = audio.reshape(1, -1)
-    else:
-        raise NotImplementedError(
-            f"Unknown channel description from ffmpeg: {channel_string}"
+    try:
+        channel_string = parse_channel_from_ffmpeg_output(proc.stderr)
+        if channel_string == "stereo":
+            new_audio = np.empty((2, audio.shape[0] // 2), dtype=np.float32)
+            new_audio[0, :] = audio[::2]
+            new_audio[1, :] = audio[1::2]
+            audio = new_audio
+        elif channel_string == "mono":
+            audio = audio.reshape(1, -1)
+        else:
+            raise NotImplementedError(
+                f"Unknown channel description from ffmpeg: {channel_string}"
+            )
+    except ValueError as e:
+        raise ValueError(
+            f"{e}\nThe ffmpeg command for which the program failed is: '{cmd}'"
         )
     return audio, sampling_rate
 

--- a/lhotse/audio.py
+++ b/lhotse/audio.py
@@ -46,7 +46,7 @@ from lhotse.utils import (
     ifnone,
     index_by_id_and_check,
     perturb_num_samples,
-    split_sequence,
+    rich_exception_info, split_sequence,
 )
 
 Channels = Union[int, List[int]]
@@ -295,6 +295,7 @@ class Recording:
     def channel_ids(self):
         return sorted(cid for source in self.sources for cid in source.channels)
 
+    @rich_exception_info
     def load_audio(
         self,
         channels: Optional[Channels] = None,

--- a/lhotse/audio.py
+++ b/lhotse/audio.py
@@ -46,7 +46,8 @@ from lhotse.utils import (
     ifnone,
     index_by_id_and_check,
     perturb_num_samples,
-    rich_exception_info, split_sequence,
+    rich_exception_info,
+    split_sequence,
 )
 
 Channels = Union[int, List[int]]

--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -61,7 +61,7 @@ from lhotse.utils import (
     overlaps,
     overspans,
     perturb_num_samples,
-    split_sequence,
+    rich_exception_info, split_sequence,
     uuid4,
 )
 
@@ -815,6 +815,7 @@ class MonoCut(Cut):
             else self.recording.sampling_rate
         )
 
+    @rich_exception_info
     def load_features(self) -> Optional[np.ndarray]:
         """
         Load the features from the underlying storage and cut them to the relevant
@@ -833,6 +834,7 @@ class MonoCut(Cut):
             return feats
         return None
 
+    @rich_exception_info
     def load_audio(self) -> Optional[np.ndarray]:
         """
         Load the audio by locating the appropriate recording in the supplied RecordingSet.
@@ -1916,6 +1918,7 @@ class MixedCut(Cut):
             ],
         )
 
+    @rich_exception_info
     def load_features(self, mixed: bool = True) -> Optional[np.ndarray]:
         """
         Loads the features of the source cuts and mixes them on-the-fly.
@@ -1983,6 +1986,7 @@ class MixedCut(Cut):
         else:
             return mixer.unmixed_feats
 
+    @rich_exception_info
     def load_audio(self, mixed: bool = True) -> Optional[np.ndarray]:
         """
         Loads the audios of the source cuts and mix them on-the-fly.

--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -61,7 +61,8 @@ from lhotse.utils import (
     overlaps,
     overspans,
     perturb_num_samples,
-    rich_exception_info, split_sequence,
+    rich_exception_info,
+    split_sequence,
     uuid4,
 )
 

--- a/lhotse/utils.py
+++ b/lhotse/utils.py
@@ -582,7 +582,10 @@ def rich_exception_info(fn):
         try:
             return fn(*args, **kwargs)
         except Exception as e:
-            raise type(e)(f"{e}\n[extra info] When calling: {fn.__qualname__}(args={args} kwargs={kwargs})")
+            raise type(e)(
+                f"{e}\n[extra info] When calling: {fn.__qualname__}(args={args} kwargs={kwargs})"
+            )
+
     return wrapper
 
 

--- a/lhotse/utils.py
+++ b/lhotse/utils.py
@@ -1,3 +1,4 @@
+import functools
 import logging
 import math
 import random
@@ -573,6 +574,16 @@ def lens_to_mask(lens: torch.IntTensor) -> torch.Tensor:
     for i, num in enumerate(lens):
         mask[i, :num] = 1.0
     return mask
+
+
+def rich_exception_info(fn):
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        try:
+            return fn(*args, **kwargs)
+        except Exception as e:
+            raise type(e)(f"{e}\n[extra info] When calling: {fn.__qualname__}(args={args} kwargs={kwargs})")
+    return wrapper
 
 
 class NonPositiveEnergyError(ValueError):

--- a/test/test_audio_reads.py
+++ b/test/test_audio_reads.py
@@ -57,15 +57,22 @@ def test_opus_torchaudio_vs_ffmpeg(path):
     ],
 )
 @pytest.mark.parametrize(
-    "force_opus_sampling_rate", [
-        pytest.param(8000, marks=pytest.mark.xfail(reason="Mismatch in shape by one sample.")),
+    "force_opus_sampling_rate",
+    [
+        pytest.param(
+            8000, marks=pytest.mark.xfail(reason="Mismatch in shape by one sample.")
+        ),
         16000,
-        pytest.param(22050, marks=pytest.mark.xfail(reason="Mismatch in shape by one sample.")),
+        pytest.param(
+            22050, marks=pytest.mark.xfail(reason="Mismatch in shape by one sample.")
+        ),
         24000,
-        pytest.param(32000, marks=pytest.mark.xfail(reason="Mismatch in shape by one sample.")),
+        pytest.param(
+            32000, marks=pytest.mark.xfail(reason="Mismatch in shape by one sample.")
+        ),
         44100,
-        48000
-    ]
+        48000,
+    ],
 )
 def test_opus_torchaudio_vs_ffmpeg_with_resampling(path, force_opus_sampling_rate):
     audio_ta, sr_ta = read_opus_torchaudio(

--- a/test/test_audio_reads.py
+++ b/test/test_audio_reads.py
@@ -7,6 +7,7 @@ import torchaudio
 
 import lhotse
 from lhotse import Recording
+from lhotse.audio import read_opus_ffmpeg, read_opus_torchaudio
 
 
 @pytest.mark.parametrize(
@@ -27,6 +28,61 @@ def test_info_and_read_audio_consistency(path):
     recording = Recording.from_file(path)
     audio = recording.load_audio()
     assert audio.shape[1] == recording.num_samples
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "test/fixtures/mono_c0.opus",
+        "test/fixtures/stereo.opus",
+    ],
+)
+def test_opus_torchaudio_vs_ffmpeg(path):
+    audio_ta, sr_ta = read_opus_torchaudio(path)
+    audio_ff, sr_ff = read_opus_ffmpeg(path)
+    assert sr_ta == sr_ff
+    assert audio_ta.shape == audio_ff.shape
+    # Apparently FFMPEG and SOX (torchaudio) apply different decoders
+    # and/or resampling algorithms for reading OPUS, so they yield
+    # different results up to 3rd decimal place (for 16bit PCM,
+    # this is affecting around 6 least significant bits)
+    np.testing.assert_almost_equal(audio_ta, audio_ff, decimal=3)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "test/fixtures/mono_c0.opus",
+        "test/fixtures/stereo.opus",
+    ],
+)
+@pytest.mark.parametrize(
+    "force_opus_sampling_rate", [
+        pytest.param(8000, marks=pytest.mark.xfail(reason="Mismatch in shape by one sample.")),
+        16000,
+        pytest.param(22050, marks=pytest.mark.xfail(reason="Mismatch in shape by one sample.")),
+        24000,
+        pytest.param(32000, marks=pytest.mark.xfail(reason="Mismatch in shape by one sample.")),
+        44100,
+        48000
+    ]
+)
+def test_opus_torchaudio_vs_ffmpeg_with_resampling(path, force_opus_sampling_rate):
+    audio_ta, sr_ta = read_opus_torchaudio(
+        path, force_opus_sampling_rate=force_opus_sampling_rate
+    )
+    audio_ff, sr_ff = read_opus_ffmpeg(
+        path, force_opus_sampling_rate=force_opus_sampling_rate
+    )
+    assert sr_ta == sr_ff
+    # Note: for some resampling rates, there will be mismatch by one
+    # sample. Recording.load_audio() will fix these cases.
+    assert audio_ta.shape == audio_ff.shape
+    # Note: when we resample, for a very small number of samples,
+    # there are typically discrepancies up to second decimal place
+    # between the two implementations.
+    # I won't fight the audio codec world -- it is what it is.
+    np.testing.assert_almost_equal(audio_ta, audio_ff, decimal=1)
 
 
 def test_audio_caching_enabled_works():

--- a/test/test_recording_set.py
+++ b/test/test_recording_set.py
@@ -433,12 +433,12 @@ def test_opus_recording_from_file_force_sampling_rate():
     path = "test/fixtures/mono_c0.opus"
     recording = Recording.from_file(path, force_opus_sampling_rate=8000)
     assert recording.sampling_rate == 8000
-    assert isclose(recording.duration, 0.505375)
+    assert isclose(recording.duration, 0.5055)
     samples = recording.load_audio()
     num_channels, num_samples = samples.shape
     assert num_channels == recording.num_channels
     assert num_samples == recording.num_samples
-    assert num_samples == 4043
+    assert num_samples == 4044
 
 
 @pytest.mark.skipif(
@@ -452,12 +452,12 @@ def test_opus_stereo_recording_from_file_force_sampling_rate():
     path = "test/fixtures/stereo.opus"
     recording = Recording.from_file(path, force_opus_sampling_rate=8000)
     assert recording.sampling_rate == 8000
-    assert isclose(recording.duration, 1.005375)
+    assert isclose(recording.duration, 1.0055)
     samples = recording.load_audio()
     num_channels, num_samples = samples.shape
     assert num_channels == recording.num_channels
     assert num_samples == recording.num_samples
-    assert num_samples == 8043
+    assert num_samples == 8044
 
 
 @pytest.mark.skipif(
@@ -471,7 +471,7 @@ def test_opus_stereo_recording_from_file_force_sampling_rate_read_chunk():
     path = "test/fixtures/stereo.opus"
     recording = Recording.from_file(path, force_opus_sampling_rate=8000)
     assert recording.sampling_rate == 8000
-    assert isclose(recording.duration, 1.005375)
+    assert isclose(recording.duration, 1.0055)
     all_samples = recording.load_audio()
     samples = recording.load_audio(offset=0.5, duration=0.25)
     num_channels, num_samples = samples.shape

--- a/test/test_recording_set.py
+++ b/test/test_recording_set.py
@@ -433,12 +433,12 @@ def test_opus_recording_from_file_force_sampling_rate():
     path = "test/fixtures/mono_c0.opus"
     recording = Recording.from_file(path, force_opus_sampling_rate=8000)
     assert recording.sampling_rate == 8000
-    assert isclose(recording.duration, 0.50375)
+    assert isclose(recording.duration, 0.505375)
     samples = recording.load_audio()
     num_channels, num_samples = samples.shape
     assert num_channels == recording.num_channels
     assert num_samples == recording.num_samples
-    assert num_samples == 4044
+    assert num_samples == 4043
 
 
 @pytest.mark.skipif(
@@ -457,7 +457,7 @@ def test_opus_stereo_recording_from_file_force_sampling_rate():
     num_channels, num_samples = samples.shape
     assert num_channels == recording.num_channels
     assert num_samples == recording.num_samples
-    assert num_samples == 8044
+    assert num_samples == 8043
 
 
 @pytest.mark.skipif(

--- a/test/test_recording_set.py
+++ b/test/test_recording_set.py
@@ -433,7 +433,7 @@ def test_opus_recording_from_file_force_sampling_rate():
     path = "test/fixtures/mono_c0.opus"
     recording = Recording.from_file(path, force_opus_sampling_rate=8000)
     assert recording.sampling_rate == 8000
-    assert isclose(recording.duration, 0.5055)
+    assert isclose(recording.duration, 0.50375)
     samples = recording.load_audio()
     num_channels, num_samples = samples.shape
     assert num_channels == recording.num_channels
@@ -452,7 +452,7 @@ def test_opus_stereo_recording_from_file_force_sampling_rate():
     path = "test/fixtures/stereo.opus"
     recording = Recording.from_file(path, force_opus_sampling_rate=8000)
     assert recording.sampling_rate == 8000
-    assert isclose(recording.duration, 1.0055)
+    assert isclose(recording.duration, 1.005375)
     samples = recording.load_audio()
     num_channels, num_samples = samples.shape
     assert num_channels == recording.num_channels
@@ -471,7 +471,7 @@ def test_opus_stereo_recording_from_file_force_sampling_rate_read_chunk():
     path = "test/fixtures/stereo.opus"
     recording = Recording.from_file(path, force_opus_sampling_rate=8000)
     assert recording.sampling_rate == 8000
-    assert isclose(recording.duration, 1.0055)
+    assert isclose(recording.duration, 1.005375)
     all_samples = recording.load_audio()
     samples = recording.load_audio(offset=0.5, duration=0.25)
     num_channels, num_samples = samples.shape


### PR DESCRIPTION
This attempts to use torchaudio if available to read OPUS (should be faster as it doesn't spawn extra subprocesses, but I didn't benchmark it in any way yet).

It also tries to provide extra info when loading audio or features raises exceptions -- sometimes these methods are deep in the stack and it's not straightforward to see for which cut/recording it failed. Now many exceptions are enhanced with suffix in the message like this:

```
... stack trace ...
AssertionError: Requested to load audio from a channel that does not exist in the recording: (recording channels: frozenset({0}) -- requested channels: frozenset({1}))
[extra info] When calling: Recording.load_audio(args=(Recording(id='mono_c0', sources=[AudioSource(type='file', channels=[0], source='test/fixtures/mono_c0.wav')], sampling_rate=8000, num_samples=4000, duration=0.5, transforms=None),) kwargs={'channels': 1, 'offset': 0, 'duration': 0.5})
[extra info] When calling: MonoCut.load_audio(args=(MonoCut(id='test-cut', start=0, duration=0.5, channel=1, supervisions=[], features=None, recording=Recording(id='mono_c0', sources=[AudioSource(type='file', channels=[0], source='test/fixtures/mono_c0.wav')], sampling_rate=8000, num_samples=4000, duration=0.5, transforms=None)),) kwargs={})
```

CC: @glynpu