### PR TITLE
WIP: Array and TemporalArray manifests (generalization of Features for arbitrary data)

### DIFF
--- a/lhotse/array.py
+++ b/lhotse/array.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 
 import numpy as np
 
+from lhotse import FeaturesWriter
 from lhotse.features.io import get_reader
 from lhotse.utils import Seconds, asdict_nonull, rich_exception_info
 
@@ -29,7 +30,7 @@ class Array:
     shape: List[int]
 
     @property
-    def num_axes(self) -> int:
+    def ndim(self) -> int:
         return len(self.shape)
 
     def to_dict(self) -> dict:
@@ -38,6 +39,16 @@ class Array:
     @classmethod
     def from_dict(cls, data: dict) -> "Array":
         return cls(**data)
+
+    @classmethod
+    def store(cls, key: str, value: np.ndarray, writer: FeaturesWriter) -> "Array":
+        storage_key = writer.write(key, value)
+        return Array(
+            storage_type=writer.name,
+            storage_path=str(writer.storage_path),
+            storage_key=storage_key,
+            shape=list(value.shape),
+        )
 
     @rich_exception_info
     def load(self) -> np.ndarray:
@@ -56,9 +67,9 @@ class TemporalArray:
     # Manifest describing the base array.
     array: Array
 
-    # Indicates which axis (if any) corresponds to the time dimension:
+    # Indicates which dim corresponds to the time dimension:
     # e.g., PCM audio samples indexes, feature frame indexes, chunks indexes, etc.
-    temporal_axis: int
+    temporal_dim: int
 
     # The time interval (in seconds, or fraction of a second) between the start timestamps
     # of consecutive frames. Only defined when ``temporal_axis`` is not ``None``.
@@ -74,12 +85,12 @@ class TemporalArray:
         return self.array.shape
 
     @property
-    def num_axes(self) -> int:
+    def ndim(self) -> int:
         return len(self.shape)
 
     @property
     def duration(self) -> Optional[Seconds]:
-        return self.shape[self.temporal_axis] * self.frame_shift
+        return self.shape[self.temporal_dim] * self.frame_shift
 
     @property
     def end(self) -> Optional[Seconds]:
@@ -90,9 +101,27 @@ class TemporalArray:
 
     @classmethod
     def from_dict(cls, data: dict) -> "TemporalArray":
-        return cls(**data)
+        array = Array.from_dict(data.pop('array'))
+        return cls(array=array, **data)
 
-    @rich_exception_info
+    @classmethod
+    def store(
+        cls,
+        key: str,
+        value: np.ndarray,
+        writer: FeaturesWriter,
+        frame_shift: Seconds,
+        temporal_dim: int = 0,
+        start: Seconds = 0,
+    ) -> "TemporalArray":
+        return TemporalArray(
+            array=Array.store(key=key, value=value, writer=writer),
+            temporal_dim=temporal_dim,
+            frame_shift=frame_shift,
+            start=start
+        )
+
+    # @rich_exception_info
     def load(
         self,
         start: Optional[Seconds] = None,
@@ -116,14 +145,14 @@ class TemporalArray:
             left_offset_frames = seconds_to_frames(
                 start - self.start,
                 frame_shift=self.frame_shift,
-                max_index=self.shape[self.temporal_axis],
+                max_index=self.shape[self.temporal_dim],
             )
         # Right trim
         if duration is not None:
             right_offset_frames = left_offset_frames + seconds_to_frames(
                 duration,
                 frame_shift=self.frame_shift,
-                max_index=self.shape[self.temporal_axis],
+                max_index=self.shape[self.temporal_dim],
             )
 
         # Load and return the features (subset) from the storage
@@ -150,111 +179,3 @@ def seconds_to_frames(duration: Seconds, frame_shift: Seconds, max_index: int) -
         ).quantize(0, rounding=decimal.ROUND_HALF_UP)
     )
     return min(index, max_index)
-
-
-# @dataclass
-# class TemporalArray:
-#     """ """
-#
-#     # Storage type defines which features reader type should be instantiated
-#     # e.g. 'lilcom_files', 'numpy_files', 'lilcom_hdf5'
-#     storage_type: str
-#
-#     # Storage path is either the path to some kind of archive (like HDF5 file) or a path
-#     # to a directory holding files with feature matrices (exact semantics depend on storage_type).
-#     storage_path: str
-#
-#     # Storage key is either the key used to retrieve an array from an archive like HDF5,
-#     # or the name of the file in a directory (exact semantics depend on the storage_type).
-#     storage_key: str
-#
-#     # Shape of the array once loaded into memory.
-#     shape: List[int]
-#
-#     # Indicates which axis (if any) corresponds to the time dimension:
-#     # e.g., PCM audio samples indexes, feature frame indexes, chunks indexes, etc.
-#     temporal_axis: Optional[int] = None
-#
-#     # The time interval (in seconds, or fraction of a second) between the start timestamps
-#     # of consecutive frames. Only defined when ``temporal_axis`` is not ``None``.
-#     frame_shift: Optional[Seconds] = None
-#
-#     # Information about the time range of the features.
-#     start: Optional[Seconds] = None
-#
-#     @property
-#     def num_axes(self) -> int:
-#         return len(self.shape)
-#
-#     @property
-#     def is_temporal(self) -> bool:
-#         return all(
-#             p is not None for p in (self.temporal_axis, self.frame_shift, self.start)
-#         )
-#
-#     @property
-#     def duration(self) -> Optional[Seconds]:
-#         if self.is_temporal:
-#             return self.shape[self.temporal_axis] * self.frame_shift
-#         return None
-#
-#     @property
-#     def end(self) -> Optional[Seconds]:
-#         if self.is_temporal:
-#             return self.start + self.duration
-#         return None
-#
-#     def validate_temporal(self) -> None:
-#         # TODO
-#         pass
-#
-#     def to_dict(self) -> dict:
-#         return asdict_nonull(self)
-#
-#     @classmethod
-#     def from_dict(cls, data: dict) -> "Array":
-#         return cls(**data)
-#
-#     @rich_exception_info
-#     def load(
-#         self,
-#         start: Optional[Seconds] = None,
-#         duration: Optional[Seconds] = None,
-#     ) -> np.ndarray:
-#
-#         if start is not None or duration is not None:
-#             assert (
-#                 self.is_temporal
-#             ), "Arguments start and duration must be set to None for non-temporal Arrays."
-#
-#         # noinspection PyArgumentList
-#         storage = get_reader(self.storage_type)(self.storage_path)
-#         left_offset_frames, right_offset_frames = 0, None
-#
-#         if start is None:
-#             start = self.start
-#         # In case the caller requested only a sub-span of the features, trim them.
-#         # Left trim
-#         if start < self.start - 1e-5:
-#             raise ValueError(
-#                 f"Cannot load array starting from {start}s. "
-#                 f"The available range is ({self.start}, {self.end}) seconds."
-#             )
-#         if not isclose(start, self.start):
-#             left_offset_frames = compute_num_frames(
-#                 start - self.start,
-#                 frame_shift=self.frame_shift,
-#                 sampling_rate=self.sampling_rate,
-#             )
-#         # Right trim
-#         if duration is not None:
-#             right_offset_frames = left_offset_frames + compute_num_frames(
-#                 duration, frame_shift=self.frame_shift, sampling_rate=self.sampling_rate
-#             )
-#
-#         # Load and return the features (subset) from the storage
-#         return storage.read(
-#             self.storage_key,
-#             left_offset_frames=left_offset_frames,
-#             right_offset_frames=right_offset_frames,
-#         )

--- a/lhotse/array.py
+++ b/lhotse/array.py
@@ -1,0 +1,260 @@
+import decimal
+from dataclasses import dataclass
+from math import isclose
+from typing import List, Optional
+
+import numpy as np
+
+from lhotse.features.io import get_reader
+from lhotse.utils import Seconds, asdict_nonull, rich_exception_info
+
+
+@dataclass
+class Array:
+    """ """
+
+    # Storage type defines which features reader type should be instantiated
+    # e.g. 'lilcom_files', 'numpy_files', 'lilcom_hdf5'
+    storage_type: str
+
+    # Storage path is either the path to some kind of archive (like HDF5 file) or a path
+    # to a directory holding files with feature matrices (exact semantics depend on storage_type).
+    storage_path: str
+
+    # Storage key is either the key used to retrieve an array from an archive like HDF5,
+    # or the name of the file in a directory (exact semantics depend on the storage_type).
+    storage_key: str
+
+    # Shape of the array once loaded into memory.
+    shape: List[int]
+
+    @property
+    def num_axes(self) -> int:
+        return len(self.shape)
+
+    def to_dict(self) -> dict:
+        return asdict_nonull(self)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "Array":
+        return cls(**data)
+
+    @rich_exception_info
+    def load(self) -> np.ndarray:
+
+        # noinspection PyArgumentList
+        storage = get_reader(self.storage_type)(self.storage_path)
+
+        # Load and return the array from the storage
+        return storage.read(self.storage_key)
+
+
+@dataclass
+class TemporalArray:
+    """ """
+
+    # Manifest describing the base array.
+    array: Array
+
+    # Indicates which axis (if any) corresponds to the time dimension:
+    # e.g., PCM audio samples indexes, feature frame indexes, chunks indexes, etc.
+    temporal_axis: int
+
+    # The time interval (in seconds, or fraction of a second) between the start timestamps
+    # of consecutive frames. Only defined when ``temporal_axis`` is not ``None``.
+    frame_shift: Seconds
+
+    # Information about the time range of the features.
+    # We only need to specify start, as duration can be computed from
+    # the shape, temporal_axis, and frame_shift.
+    start: Seconds
+
+    @property
+    def shape(self):
+        return self.array.shape
+
+    @property
+    def num_axes(self) -> int:
+        return len(self.shape)
+
+    @property
+    def duration(self) -> Optional[Seconds]:
+        return self.shape[self.temporal_axis] * self.frame_shift
+
+    @property
+    def end(self) -> Optional[Seconds]:
+        return self.start + self.duration
+
+    def to_dict(self) -> dict:
+        return asdict_nonull(self)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "TemporalArray":
+        return cls(**data)
+
+    @rich_exception_info
+    def load(
+        self,
+        start: Optional[Seconds] = None,
+        duration: Optional[Seconds] = None,
+    ) -> np.ndarray:
+
+        # noinspection PyArgumentList
+        storage = get_reader(self.array.storage_type)(self.array.storage_path)
+        left_offset_frames, right_offset_frames = 0, None
+
+        if start is None:
+            start = self.start
+        # In case the caller requested only a sub-span of the features, trim them.
+        # Left trim
+        if start < self.start - 1e-5:
+            raise ValueError(
+                f"Cannot load array starting from {start}s. "
+                f"The available range is ({self.start}, {self.end}) seconds."
+            )
+        if not isclose(start, self.start):
+            left_offset_frames = seconds_to_frames(
+                start - self.start,
+                frame_shift=self.frame_shift,
+                max_index=self.shape[self.temporal_axis],
+            )
+        # Right trim
+        if duration is not None:
+            right_offset_frames = left_offset_frames + seconds_to_frames(
+                duration,
+                frame_shift=self.frame_shift,
+                max_index=self.shape[self.temporal_axis],
+            )
+
+        # Load and return the features (subset) from the storage
+        return storage.read(
+            self.array.storage_key,
+            left_offset_frames=left_offset_frames,
+            right_offset_frames=right_offset_frames,
+        )
+
+
+def seconds_to_frames(duration: Seconds, frame_shift: Seconds, max_index: int) -> int:
+    """
+    Convert time quantity in seconds to a frame index.
+    It takes the shape of the array into account and limits
+    the possible indices values to be compatible with the shape.
+    """
+    assert duration >= 0
+    index = int(
+        decimal.Decimal(
+            # 8 is a good number because cases like 14.49175 still work correctly,
+            # while problematic cases like 14.49999999998 are typically breaking much later than 8th decimal
+            # with double-precision floats.
+            round(duration / frame_shift, ndigits=8)
+        ).quantize(0, rounding=decimal.ROUND_HALF_UP)
+    )
+    return min(index, max_index)
+
+
+# @dataclass
+# class TemporalArray:
+#     """ """
+#
+#     # Storage type defines which features reader type should be instantiated
+#     # e.g. 'lilcom_files', 'numpy_files', 'lilcom_hdf5'
+#     storage_type: str
+#
+#     # Storage path is either the path to some kind of archive (like HDF5 file) or a path
+#     # to a directory holding files with feature matrices (exact semantics depend on storage_type).
+#     storage_path: str
+#
+#     # Storage key is either the key used to retrieve an array from an archive like HDF5,
+#     # or the name of the file in a directory (exact semantics depend on the storage_type).
+#     storage_key: str
+#
+#     # Shape of the array once loaded into memory.
+#     shape: List[int]
+#
+#     # Indicates which axis (if any) corresponds to the time dimension:
+#     # e.g., PCM audio samples indexes, feature frame indexes, chunks indexes, etc.
+#     temporal_axis: Optional[int] = None
+#
+#     # The time interval (in seconds, or fraction of a second) between the start timestamps
+#     # of consecutive frames. Only defined when ``temporal_axis`` is not ``None``.
+#     frame_shift: Optional[Seconds] = None
+#
+#     # Information about the time range of the features.
+#     start: Optional[Seconds] = None
+#
+#     @property
+#     def num_axes(self) -> int:
+#         return len(self.shape)
+#
+#     @property
+#     def is_temporal(self) -> bool:
+#         return all(
+#             p is not None for p in (self.temporal_axis, self.frame_shift, self.start)
+#         )
+#
+#     @property
+#     def duration(self) -> Optional[Seconds]:
+#         if self.is_temporal:
+#             return self.shape[self.temporal_axis] * self.frame_shift
+#         return None
+#
+#     @property
+#     def end(self) -> Optional[Seconds]:
+#         if self.is_temporal:
+#             return self.start + self.duration
+#         return None
+#
+#     def validate_temporal(self) -> None:
+#         # TODO
+#         pass
+#
+#     def to_dict(self) -> dict:
+#         return asdict_nonull(self)
+#
+#     @classmethod
+#     def from_dict(cls, data: dict) -> "Array":
+#         return cls(**data)
+#
+#     @rich_exception_info
+#     def load(
+#         self,
+#         start: Optional[Seconds] = None,
+#         duration: Optional[Seconds] = None,
+#     ) -> np.ndarray:
+#
+#         if start is not None or duration is not None:
+#             assert (
+#                 self.is_temporal
+#             ), "Arguments start and duration must be set to None for non-temporal Arrays."
+#
+#         # noinspection PyArgumentList
+#         storage = get_reader(self.storage_type)(self.storage_path)
+#         left_offset_frames, right_offset_frames = 0, None
+#
+#         if start is None:
+#             start = self.start
+#         # In case the caller requested only a sub-span of the features, trim them.
+#         # Left trim
+#         if start < self.start - 1e-5:
+#             raise ValueError(
+#                 f"Cannot load array starting from {start}s. "
+#                 f"The available range is ({self.start}, {self.end}) seconds."
+#             )
+#         if not isclose(start, self.start):
+#             left_offset_frames = compute_num_frames(
+#                 start - self.start,
+#                 frame_shift=self.frame_shift,
+#                 sampling_rate=self.sampling_rate,
+#             )
+#         # Right trim
+#         if duration is not None:
+#             right_offset_frames = left_offset_frames + compute_num_frames(
+#                 duration, frame_shift=self.frame_shift, sampling_rate=self.sampling_rate
+#             )
+#
+#         # Load and return the features (subset) from the storage
+#         return storage.read(
+#             self.storage_key,
+#             left_offset_frames=left_offset_frames,
+#             right_offset_frames=right_offset_frames,
+#         )

--- a/lhotse/array.py
+++ b/lhotse/array.py
@@ -101,7 +101,7 @@ class TemporalArray:
 
     @classmethod
     def from_dict(cls, data: dict) -> "TemporalArray":
-        array = Array.from_dict(data.pop('array'))
+        array = Array.from_dict(data.pop("array"))
         return cls(array=array, **data)
 
     @classmethod
@@ -118,7 +118,7 @@ class TemporalArray:
             array=Array.store(key=key, value=value, writer=writer),
             temporal_dim=temporal_dim,
             frame_shift=frame_shift,
-            start=start
+            start=start,
         )
 
     # @rich_exception_info

--- a/test/features/test_array.py
+++ b/test/features/test_array.py
@@ -1,0 +1,88 @@
+from tempfile import TemporaryDirectory
+
+import numpy as np
+import pytest
+
+from lhotse import (
+    ChunkedLilcomHdf5Writer,
+    LilcomFilesWriter,
+    LilcomHdf5Writer,
+    NumpyFilesWriter,
+    NumpyHdf5Writer,
+)
+from lhotse.array import Array
+
+
+@pytest.mark.parametrize(
+    "array",
+    [
+        np.arange(20),
+        np.arange(20).reshape(2, 10),
+        np.arange(20).reshape(2, 5, 2),
+        np.arange(20).astype(np.float32),
+        np.arange(20).astype(np.int8),
+    ],
+)
+@pytest.mark.parametrize(
+    "writer_class",
+    [
+        NumpyFilesWriter,
+        NumpyHdf5Writer,
+        pytest.param(
+            LilcomFilesWriter,
+            marks=pytest.mark.xfail(reason="Lilcom changes dtype to float32"),
+        ),
+        pytest.param(
+            LilcomHdf5Writer,
+            marks=pytest.mark.xfail(reason="Lilcom changes dtype to float32"),
+        ),
+        pytest.param(
+            ChunkedLilcomHdf5Writer,
+            marks=pytest.mark.xfail(
+                reason="Lilcom changes dtype to float32 (and Chunked variant works only with shape 2)"
+            ),
+        ),
+    ],
+)
+def test_write_read_array_no_lilcom(array, writer_class):
+    with TemporaryDirectory() as d, writer_class(d) as writer:
+        manifest = Array.store(key="utt1", value=array, writer=writer)
+        restored = manifest.load()
+        assert array.ndim == manifest.ndim
+        assert array.shape == restored.shape
+        assert list(array.shape) == manifest.shape
+        assert array.dtype == restored.dtype
+        np.testing.assert_almost_equal(array, restored)
+
+
+@pytest.mark.parametrize(
+    "writer_class",
+    [
+        LilcomFilesWriter,
+        LilcomHdf5Writer,
+    ],
+)
+def test_write_read_array_lilcom(writer_class):
+    array = np.arange(20).astype(np.float32)
+    with TemporaryDirectory() as d, writer_class(d) as writer:
+        manifest = Array.store(key="utt1", value=array, writer=writer)
+        restored = manifest.load()
+        assert array.ndim == manifest.ndim
+        assert array.shape == restored.shape
+        assert list(array.shape) == manifest.shape
+        assert array.dtype == restored.dtype
+        np.testing.assert_almost_equal(array, restored)
+
+
+def test_array_serialization():
+    # Individual items do not support JSON/etc. serialization;
+    # instead, the XSet (e.g. CutSet) classes convert them to dicts.
+    manifest = Array(
+        storage_type='lilcom_hdf5',
+        storage_path='/tmp/data',
+        storage_key='irrelevant',
+        shape=[300],
+    )
+    serialized = manifest.to_dict()
+    restored = Array.from_dict(serialized)
+    assert manifest == restored

--- a/test/features/test_array.py
+++ b/test/features/test_array.py
@@ -1,4 +1,4 @@
-from tempfile import TemporaryDirectory
+from tempfile import NamedTemporaryFile, TemporaryDirectory
 
 import numpy as np
 import pytest
@@ -7,6 +7,7 @@ from lhotse import (
     ChunkedLilcomHdf5Writer,
     LilcomFilesWriter,
     LilcomHdf5Writer,
+    MonoCut,
     NumpyFilesWriter,
     NumpyHdf5Writer,
 )
@@ -78,9 +79,9 @@ def test_array_serialization():
     # Individual items do not support JSON/etc. serialization;
     # instead, the XSet (e.g. CutSet) classes convert them to dicts.
     manifest = Array(
-        storage_type='lilcom_hdf5',
-        storage_path='/tmp/data',
-        storage_key='irrelevant',
+        storage_type="lilcom_hdf5",
+        storage_path="/tmp/data",
+        storage_key="irrelevant",
         shape=[300],
     )
     serialized = manifest.to_dict()

--- a/test/features/test_temporal_array.py
+++ b/test/features/test_temporal_array.py
@@ -1,0 +1,149 @@
+from tempfile import TemporaryDirectory, NamedTemporaryFile
+
+import numpy as np
+import pytest
+
+from lhotse import (
+    ChunkedLilcomHdf5Writer,
+    LilcomFilesWriter,
+    LilcomHdf5Writer,
+    NumpyFilesWriter,
+    NumpyHdf5Writer,
+)
+from lhotse.array import Array, TemporalArray
+
+
+@pytest.mark.parametrize(
+    "array",
+    [
+        np.arange(20),
+        np.arange(20).reshape(2, 10),
+        np.arange(20).reshape(2, 5, 2),
+        np.arange(20).astype(np.float32),
+        np.arange(20).astype(np.int8),
+    ],
+)
+@pytest.mark.parametrize(
+    "writer_class",
+    [
+        NumpyFilesWriter,
+        NumpyHdf5Writer,
+        pytest.param(
+            LilcomFilesWriter,
+            marks=pytest.mark.xfail(reason="Lilcom changes dtype to float32"),
+        ),
+        pytest.param(
+            LilcomHdf5Writer,
+            marks=pytest.mark.xfail(reason="Lilcom changes dtype to float32"),
+        ),
+        pytest.param(
+            ChunkedLilcomHdf5Writer,
+            marks=pytest.mark.xfail(
+                reason="Lilcom changes dtype to float32 (and Chunked variant works only with shape 2)"
+            ),
+        ),
+    ],
+)
+def test_write_read_temporal_array_no_lilcom(array, writer_class):
+    with TemporaryDirectory() as d, writer_class(d) as writer:
+        manifest = TemporalArray.store(
+            key="utt1",
+            value=array,
+            writer=writer,
+            temporal_dim=0,
+            frame_shift=0.4,
+            start=0.0,
+        )
+        restored = manifest.load()
+        assert array.ndim == manifest.ndim
+        assert array.shape == restored.shape
+        assert list(array.shape) == manifest.shape
+        assert array.dtype == restored.dtype
+        np.testing.assert_almost_equal(array, restored)
+
+
+@pytest.mark.parametrize(
+    "array",
+    [
+        np.arange(20).astype(np.float32),
+        np.arange(20).reshape(2, 10).astype(np.float32),
+        np.arange(20).reshape(2, 5, 2).astype(np.float32),
+    ],
+)
+@pytest.mark.parametrize(
+    "writer_class",
+    [
+        LilcomFilesWriter,
+        LilcomHdf5Writer,
+    ],
+)
+def test_write_read_temporal_array_lilcom(array, writer_class):
+    with TemporaryDirectory() as d, writer_class(d) as writer:
+        manifest = TemporalArray.store(
+            key="utt1",
+            value=array,
+            writer=writer,
+            temporal_dim=0,
+            frame_shift=0.4,
+            start=0.0,
+        )
+        restored = manifest.load()
+        assert array.ndim == manifest.ndim
+        assert array.shape == restored.shape
+        assert list(array.shape) == manifest.shape
+        assert array.dtype == restored.dtype
+        np.testing.assert_almost_equal(array, restored)
+
+
+def test_temporal_array_serialization():
+    # Individual items do not support JSON/etc. serialization;
+    # instead, the XSet (e.g. CutSet) classes convert them to dicts.
+    manifest = TemporalArray(
+        array=Array(
+            storage_type="lilcom_hdf5",
+            storage_path="/tmp/data",
+            storage_key="irrelevant",
+            shape=[300],
+        ),
+        temporal_dim=0,
+        frame_shift=0.3,
+        start=5.0
+    )
+    serialized = manifest.to_dict()
+    restored = TemporalArray.from_dict(serialized)
+    assert manifest == restored
+
+
+def test_temporal_array_partial_read():
+    array = np.arange(30).astype(np.int8)
+
+    with NamedTemporaryFile(suffix='.h5') as f, NumpyHdf5Writer(f.name) as writer:
+        manifest = TemporalArray.store(
+            key="utt1",
+            value=array,
+            writer=writer,
+            temporal_dim=0,
+            frame_shift=0.5,
+            start=0.0,
+        )
+
+        # Read all
+        restored = manifest.load()
+        np.testing.assert_equal(array, restored)
+
+        # Read first 10 frames (0 - 5 seconds)
+        first_10 = manifest.load(duration=5)
+        np.testing.assert_equal(array[:10], first_10)
+
+        # Read last 10 frames (10 - 15 seconds)
+        last_10 = manifest.load(start=10)
+        np.testing.assert_equal(array[-10:], last_10)
+        last_10 = manifest.load(start=10, duration=5)
+        np.testing.assert_equal(array[-10:], last_10)
+
+        # Read middle 10 frames (5 - 10 seconds)
+        mid_10 = manifest.load(start=5, duration=5)
+        np.testing.assert_equal(array[10:20], mid_10)
+
+
+

--- a/test/features/test_temporal_array.py
+++ b/test/features/test_temporal_array.py
@@ -107,7 +107,7 @@ def test_temporal_array_serialization():
         ),
         temporal_dim=0,
         frame_shift=0.3,
-        start=5.0
+        start=5.0,
     )
     serialized = manifest.to_dict()
     restored = TemporalArray.from_dict(serialized)
@@ -117,7 +117,7 @@ def test_temporal_array_serialization():
 def test_temporal_array_partial_read():
     array = np.arange(30).astype(np.int8)
 
-    with NamedTemporaryFile(suffix='.h5') as f, NumpyHdf5Writer(f.name) as writer:
+    with NamedTemporaryFile(suffix=".h5") as f, NumpyHdf5Writer(f.name) as writer:
         manifest = TemporalArray.store(
             key="utt1",
             value=array,
@@ -144,6 +144,3 @@ def test_temporal_array_partial_read():
         # Read middle 10 frames (5 - 10 seconds)
         mid_10 = manifest.load(start=5, duration=5)
         np.testing.assert_equal(array[10:20], mid_10)
-
-
-


### PR DESCRIPTION
This PR adds two new types of manifest called `Array` and `TemporalArray`. Ideally they would replace `Features` manifest, but that may take more work and I don't want to render the codebase unusable as this is highly experimental at this point.

The point of these manifests is to make it more convenient to store any type of data (alignments, embeddings, etc.) that would be later attached to Cut manifests.

For discussion/design/motivation see #453 and #393 