### PR TITLE
Fix misleading manifest format in the comments

### DIFF
--- a/examples/heroico/heroico.sh
+++ b/examples/heroico/heroico.sh
@@ -29,4 +29,4 @@ for fld in train test devtest; do
   echo "$0:  Create cuts out of features for heroico $fld corpus."
   lhotse cut simple -f $output_dir/feats_${fld}/feature_manifest.json.gz -s $output_dir/supervisions_${fld}.json $output_dir/cuts_${fld}.json.gz
 done
-echo "$0: Processing complete - the resulting YAML manifests can be loaded in Python to create a PyTorch dataset."
+echo "$0: Processing complete - the resulting manifests can be loaded in Python to create a PyTorch dataset."

--- a/examples/librimix/librimix.sh
+++ b/examples/librimix/librimix.sh
@@ -64,4 +64,4 @@ lhotse cut truncate \
   --preserve-id \
   ${OUTPUT_PATH}/cuts_mix_dynamic_noisy.json.gz ${OUTPUT_PATH}/cuts_mix_dynamic_noisy_${DURATION}s.json.gz
 
-# Processing complete - the resulting YAML mixed cut manifests can be loaded in Python to create a PyTorch dataset.
+# Processing complete - the resulting mixed cut manifests can be loaded in Python to create a PyTorch dataset.

--- a/examples/librispeech/mini_librispeech.sh
+++ b/examples/librispeech/mini_librispeech.sh
@@ -29,4 +29,4 @@ for part in ${data_parts}; do
     ${OUTPUT_PATH}/cuts_${part}.json.gz
 done
 
-# Processing complete - the resulting YAML manifests can be loaded in Python to create a PyTorch dataset.
+# Processing complete - the resulting manifests can be loaded in Python to create a PyTorch dataset.


### PR DESCRIPTION
This is fix for outdated comments, about format of manifest files, in the examples scripts. Although it is very small issue, it made me to search for non-existing YAML files and left me a little confused.