### PR TITLE
A change for tedlium.py

### DIFF
--- a/lhotse/recipes/tedlium.py
+++ b/lhotse/recipes/tedlium.py
@@ -133,7 +133,7 @@ def prepare_tedlium(
         validate_recordings_and_supervisions(**corpus[split])
 
         if output_dir is not None:
-            recordings.to_json(output_dir / f"{split}_recordings.json")
-            supervisions.to_json(output_dir / f"{split}_supervisions.json")
+            recordings.to_json(output_dir / f"recordings_{split}.json")
+            supervisions.to_json(output_dir / f"supervisions_{split}.json")
 
     return corpus


### PR DESCRIPTION
I just change `{split}_supervisions.json` to `supervisions_{split}.json`,  `{split}_recordings.json` to `recordings_{split}.json`. After changing, the function `read_manifests_if_cached` in lhotse.recipes.utils can load the json files in `manifests.`
https://github.com/lhotse-speech/lhotse/blob/7c1e3bd33f3b1ef23b67ee3c2e70443bf302e655/lhotse/recipes/utils.py#L39-L41
