### PR TITLE
Option to create a CutSet lazily when everything is sorted on recording IDs

### DIFF
--- a/lhotse/__init__.py
+++ b/lhotse/__init__.py
@@ -1,7 +1,7 @@
 from .audio import AudioSource, Recording, RecordingSet
 from .augmentation import *
 from .caching import is_caching_enabled, set_caching_enabled
-from .cut import CutSet, MonoCut
+from .cut import CutSet, MonoCut, create_cut_set_eager, create_cut_set_lazy
 from .features import *
 from .kaldi import load_kaldi_data_dir
 from .manipulation import combine, split_parallelize_combine, to_manifest

--- a/lhotse/features/base.py
+++ b/lhotse/features/base.py
@@ -513,6 +513,15 @@ class FeatureSet(Serializable, Sequence[Features]):
     def __eq__(self, other: "FeatureSet") -> bool:
         return self.features == other.features
 
+    @property
+    def is_lazy(self) -> bool:
+        """
+        Indicates whether this manifest was opened in lazy (read-on-the-fly) mode or not.
+        """
+        from lhotse.serialization import LazyJsonlIterator
+
+        return isinstance(self.features, LazyJsonlIterator)
+
     @staticmethod
     def from_features(features: Iterable[Features]) -> "FeatureSet":
         return FeatureSet(list(features))  # just for consistency with other *Sets


### PR DESCRIPTION
This is the first of a bunch of PRs I'm going to add to make Lhotse less memory-hungry when working on ~10k hours sized corpora like GigaSpeech. Most of the changes in these PRs will boil down to using these two methods (`CutSet` can be replaced with any other set class):
- for reads `CutSet.from_jsonl_lazy()`
- for writes `with CutSet.open_writer() as writer:`

I want the PRs to be separate for better changes visibility.

This one shows how to create a large CutSet practically not touching the memory. The users have to open recordings, supervisions, etc. lazily and the cuts are saved and freed one-by-one.