### PR TITLE
Reduce memory usage when writing GigaSpeech manifests

### DIFF
--- a/lhotse/parallel.py
+++ b/lhotse/parallel.py
@@ -1,0 +1,57 @@
+import threading
+import queue
+from concurrent.futures import ProcessPoolExecutor
+
+
+def parallel_map(fn, *iterables, num_jobs: int = 1, queue_size: int = 5000):
+    thread = SubmitterThread(fn, *iterables, num_jobs=num_jobs, queue_size=queue_size)
+    thread.start()
+    q = thread.queue
+
+    while thread.is_alive() or not q.empty():
+        try:
+            yield q.get(block=True, timeout=0.1).result()
+        except queue.Empty:
+            # Hit the timeout but thread is still running, try again.
+            # This is needed to avoid hanging at the end when nothing else
+            # shows up in the queue, but the thread didn't shutdown yet.
+            continue
+
+    thread.join()
+
+
+class SubmitterThread(threading.Thread):
+    def __init__(
+        self, fn, *iterables, num_jobs: int = 1, queue_size: int = 5000
+    ) -> None:
+        super().__init__()
+        self.fn = fn
+        self.num_jobs = num_jobs
+        self.iterables = iterables
+        self.queue = queue.Queue(maxsize=queue_size)
+
+    def run(self) -> None:
+        with ProcessPoolExecutor(self.num_jobs) as ex:
+            for args in zip(*self.iterables):
+                future = ex.submit(self.fn, *args)
+                self.queue.put(future, block=True)
+
+
+def foo(*iz):
+    ret = "item"
+    for i in iz:
+        ret = ret + f'_{i}'
+    return ret
+
+
+def it():
+    from time import sleep
+
+    for i in range(100):
+        yield i
+        sleep(0.01)
+
+
+if __name__ == "__main__":
+    for x in parallel_map(foo, it(), it(), num_jobs=3):
+        print(x)

--- a/lhotse/parallel.py
+++ b/lhotse/parallel.py
@@ -19,6 +19,11 @@ def parallel_map(
     The current thread becomes a consumer thread and this generator yields items from the queue
     to the caller, as they become available.
 
+    Example::
+
+        >>> for root in parallel_map(math.sqrt, range(1000), num_jobs=4):
+        ...     print(root)
+
     :param fn: function/callable to execute on each element.
     :param iterables: one of more iterables (one for each parameter of ``fn``).
     :param num_jobs: the number of parallel jobs.

--- a/lhotse/parallel.py
+++ b/lhotse/parallel.py
@@ -33,7 +33,9 @@ def parallel_map(
     :param threads: whether to use threads instead of processes for producers (false by default).
     :return: a generator over results from ``fn`` applied to each item of ``iterables``.
     """
-    thread = SubmitterThread(fn, *iterables, num_jobs=num_jobs, queue_size=queue_size, threads=threads)
+    thread = SubmitterThread(
+        fn, *iterables, num_jobs=num_jobs, queue_size=queue_size, threads=threads
+    )
     thread.start()
     q = thread.queue
 

--- a/lhotse/parallel.py
+++ b/lhotse/parallel.py
@@ -1,18 +1,16 @@
 import threading
 import queue
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
-from typing import Any, Callable, Generator, TypeVar
-
-T = TypeVar("T")
+from typing import Callable, Generator, Iterable
 
 
 def parallel_map(
-    fn: Callable[[Any, ...], T],
-    *iterables,
+    fn: Callable,
+    *iterables: Iterable,
     num_jobs: int = 1,
     queue_size: int = 5000,
     threads: bool = False,
-) -> Generator[T, None, None]:
+) -> Generator:
     """
     Works like Python's ``map``, but parallelizes the execution of ``fn`` over ``num_jobs``
     subprocesses or threads.

--- a/lhotse/recipes/gigaspeech.py
+++ b/lhotse/recipes/gigaspeech.py
@@ -82,6 +82,7 @@ def prepare_gigaspeech(
             output_dir=output_dir,
             prefix="gigaspeech",
             suffix="jsonl.gz",
+            lazy=True,
         )
 
     with ProcessPoolExecutor(num_jobs) as ex:

--- a/lhotse/recipes/gigaspeech.py
+++ b/lhotse/recipes/gigaspeech.py
@@ -71,19 +71,16 @@ def prepare_gigaspeech(
     corpus_dir = Path(corpus_dir)
     gigaspeech = GigaSpeech(corpus_dir)
 
-    manifests = defaultdict(dict)
-
-    if output_dir is not None:
-        output_dir = Path(output_dir)
-        output_dir.mkdir(parents=True, exist_ok=True)
-        # Maybe some manifests already exist: we can read them and save a bit of preparation time.
-        manifests = read_manifests_if_cached(
-            dataset_parts=dataset_parts,
-            output_dir=output_dir,
-            prefix="gigaspeech",
-            suffix="jsonl.gz",
-            lazy=True,
-        )
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    # Maybe some manifests already exist: we can read them and save a bit of preparation time.
+    manifests = read_manifests_if_cached(
+        dataset_parts=dataset_parts,
+        output_dir=output_dir,
+        prefix="gigaspeech",
+        suffix="jsonl.gz",
+        lazy=True,
+    )
 
     with ProcessPoolExecutor(num_jobs) as ex:
         for part in subsets:

--- a/lhotse/recipes/gigaspeech.py
+++ b/lhotse/recipes/gigaspeech.py
@@ -15,7 +15,8 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 from tqdm.auto import tqdm
 
 from lhotse import (
-    CutSet, compute_num_samples,
+    CutSet,
+    compute_num_samples,
     fix_manifests,
     validate_recordings_and_supervisions,
 )
@@ -117,7 +118,9 @@ def prepare_gigaspeech(
                     )
                     # Create the cut since most users will need it anyway.
                     # There will be exactly one cut since there's exactly one recording.
-                    cuts = CutSet.from_manifests(recordings=recordings, supervisions=segments)
+                    cuts = CutSet.from_manifests(
+                        recordings=recordings, supervisions=segments
+                    )
                     # Write the manifests
                     rec_writer.write(recordings[0])
                     for s in segments:

--- a/lhotse/recipes/utils.py
+++ b/lhotse/recipes/utils.py
@@ -1,12 +1,19 @@
 from collections import defaultdict
 from typing import Dict, Iterable, Optional, Sequence, Union
 
-from lhotse import load_manifest
+from lhotse import CutSet, FeatureSet, load_manifest
 from lhotse.audio import RecordingSet
 from lhotse.supervision import SupervisionSet
 from lhotse.utils import Pathlike
 
 DEFAULT_DETECTED_MANIFEST_TYPES = ("recordings", "supervisions")
+
+TYPES_TO_CLASSES = {
+    "recordings": RecordingSet,
+    "supervisions": SupervisionSet,
+    "features": FeatureSet,
+    "cuts": CutSet,
+}
 
 
 def read_manifests_if_cached(
@@ -15,6 +22,7 @@ def read_manifests_if_cached(
     prefix: str = "",
     suffix: Optional[str] = "json",
     types: Iterable[str] = DEFAULT_DETECTED_MANIFEST_TYPES,
+    lazy: bool = False,
 ) -> Dict[str, Dict[str, Union[RecordingSet, SupervisionSet]]]:
     """
     Loads manifests from the disk, or a subset of them if only some exist.
@@ -35,13 +43,18 @@ def read_manifests_if_cached(
         prefix = f"{prefix}_"
     if suffix.startswith("."):
         suffix = suffix[1:]
+    if lazy and not suffix.startswith('jsonl'):
+        raise ValueError(f"Only JSONL manifests can be opened lazily (got suffix: '{suffix}')")
     manifests = defaultdict(dict)
     for part in dataset_parts:
         for manifest in types:
             path = output_dir / f"{prefix}{manifest}_{part}.{suffix}"
             if not path.is_file():
                 continue
-            manifests[part][manifest] = load_manifest(path)
+            if lazy:
+                manifests[part][manifest] = TYPES_TO_CLASSES[manifest].from_jsonl_lazy(path)
+            else:
+                manifests[part][manifest] = load_manifest(path)
     return dict(manifests)
 
 

--- a/lhotse/recipes/utils.py
+++ b/lhotse/recipes/utils.py
@@ -43,8 +43,10 @@ def read_manifests_if_cached(
         prefix = f"{prefix}_"
     if suffix.startswith("."):
         suffix = suffix[1:]
-    if lazy and not suffix.startswith('jsonl'):
-        raise ValueError(f"Only JSONL manifests can be opened lazily (got suffix: '{suffix}')")
+    if lazy and not suffix.startswith("jsonl"):
+        raise ValueError(
+            f"Only JSONL manifests can be opened lazily (got suffix: '{suffix}')"
+        )
     manifests = defaultdict(dict)
     for part in dataset_parts:
         for manifest in types:
@@ -52,7 +54,9 @@ def read_manifests_if_cached(
             if not path.is_file():
                 continue
             if lazy:
-                manifests[part][manifest] = TYPES_TO_CLASSES[manifest].from_jsonl_lazy(path)
+                manifests[part][manifest] = TYPES_TO_CLASSES[manifest].from_jsonl_lazy(
+                    path
+                )
             else:
                 manifests[part][manifest] = load_manifest(path)
     return dict(manifests)

--- a/test/test_parallel.py
+++ b/test/test_parallel.py
@@ -1,0 +1,30 @@
+import pytest
+
+from lhotse.parallel import parallel_map
+
+
+def pow2(x):
+    return x ** 2
+
+
+def mul(x, y):
+    return x * y
+
+
+@pytest.mark.parametrize("num_jobs", [1, 2])
+def test_parallel_map_num_jobs(num_jobs):
+    squares = list(map(pow2, range(100)))
+    squares_parallel = list(parallel_map(pow2, range(100), num_jobs=num_jobs))
+    assert squares == squares_parallel
+
+
+def test_parallel_map_threads():
+    squares = list(map(pow2, range(100)))
+    squares_parallel = list(parallel_map(pow2, range(100), num_jobs=2, threads=True))
+    assert squares == squares_parallel
+
+
+def test_parallel_map_two_iterables():
+    squares = list(map(mul, range(100), range(100)))
+    squares_parallel = list(parallel_map(mul, range(100), range(100), num_jobs=2))
+    assert squares == squares_parallel


### PR DESCRIPTION
The GigaSpeech recipe is now an example of how to write Lhotse manifests iteratively. The total memory usage at any point in time is between 3-4GB. 

I also added a function called `parallel_map` which I had ready for some other stuff, I might replace some usages of ProcessPoolExecutor in several places with it later. It enables parallel execution with a limit on how much memory is used and almost instantly generates return values (no need to wait until everything is submitted to consume).