### PR TITLE
Let kaldifeat handle the device of input waves.

### DIFF
--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -3793,9 +3793,6 @@ class CutSet(Serializable, Sequence[Cut]):
                         augment_fn(w, c.sampling_rate) for c, w in zip(cuts, waves)
                     ]
 
-                # Move the audio data to the right device.
-                waves = [w.to(extractor.device) for w in waves]
-
                 # The actual extraction is here.
                 with torch.no_grad():
                     # Note: chunk_size option limits the memory consumption

--- a/lhotse/features/kaldifeat.py
+++ b/lhotse/features/kaldifeat.py
@@ -155,7 +155,7 @@ class KaldifeatFbankConfig:
     # This is an extra setting compared to kaldifeat FbankOptions:
     # by default, we'll ask kaldifeat to compute the feats in chunks
     # to avoid excessive memory usage.
-    chunk_size: Optional[int] = 100 * 60 * 20 # 20 minutes (assuming 100 frame/s)
+    chunk_size: Optional[int] = 100 * 60 * 20  # 20 minutes (assuming 100 frame/s)
 
     def to_dict(self) -> Dict[str, Any]:
         d = asdict(self)

--- a/lhotse/features/kaldifeat.py
+++ b/lhotse/features/kaldifeat.py
@@ -155,7 +155,7 @@ class KaldifeatFbankConfig:
     # This is an extra setting compared to kaldifeat FbankOptions:
     # by default, we'll ask kaldifeat to compute the feats in chunks
     # to avoid excessive memory usage.
-    chunk_size: Optional[int] = 1000
+    chunk_size: Optional[int] = 100 * 60 * 20 # 20 minutes (assuming 100 frame/s)
 
     def to_dict(self) -> Dict[str, Any]:
         d = asdict(self)


### PR DESCRIPTION
In GigaSpeech, some utterances are more than 20 hours long, which cause CUDA OOM errors if they are moved to GPU for feature extraction.

I have updated kaldifeat (v1.12) to move frames to GPU in a chunk-wise manner. Also, to reduce the number of transfers between CPU and GPU, the default chunk size is changed from 10 seconds to 20 minutes.

See also https://github.com/k2-fsa/icefall/pull/120#issuecomment-983466377