### PR TITLE
`DynamicBucketingSampler`: on-the-fly bucketing with restricted memory usage

### DIFF
--- a/lhotse/dataset/sampling/__init__.py
+++ b/lhotse/dataset/sampling/__init__.py
@@ -1,6 +1,7 @@
 from .bucketing import BucketingSampler
 from .cut_pairs import CutPairsSampler
 from .data_source import streaming_shuffle
+from .dynamic_bucketing import DynamicBucketingSampler
 from .single_cut import SingleCutSampler
 from .utils import find_pessimistic_batches
 from .zip import ZipSampler

--- a/lhotse/dataset/sampling/data_source.py
+++ b/lhotse/dataset/sampling/data_source.py
@@ -1,6 +1,6 @@
 import random
 from collections import deque
-from typing import Generator, Iterable, Optional
+from typing import Generator, Iterable, Optional, TypeVar
 
 from lhotse import CutSet
 from lhotse.cut import Cut
@@ -103,11 +103,14 @@ class DataSource:
         return len(self._shuffled_items)
 
 
+T = TypeVar("T")
+
+
 def streaming_shuffle(
-    data: Iterable[Cut],
+    data: Iterable[T],
     bufsize: int = 10000,
     rng: random.Random = random,
-) -> Generator[Cut, None, None]:
+) -> Generator[T, None, None]:
     """
     Shuffle the data in the stream.
 

--- a/lhotse/dataset/sampling/dynamic_bucketing.py
+++ b/lhotse/dataset/sampling/dynamic_bucketing.py
@@ -37,7 +37,9 @@ class DynamicBucketingSampler(CutSampler):
         self.rng = None
 
         if self.shuffle:
-            cuts_for_bins_estimate = streaming_shuffle(cuts, rng=random.Random(seed))
+            cuts_for_bins_estimate = streaming_shuffle(
+                cuts, rng=random.Random(self.seed)
+            )
         else:
             cuts_for_bins_estimate = cuts
         self.duration_bins = estimate_duration_buckets(

--- a/lhotse/dataset/sampling/dynamic_bucketing.py
+++ b/lhotse/dataset/sampling/dynamic_bucketing.py
@@ -3,7 +3,15 @@ import warnings
 from bisect import bisect_right
 from collections import deque
 from itertools import islice
-from typing import Deque, Generator, Iterable, List, Optional
+from typing import (
+    Deque,
+    Generator,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+    Union,
+)
 
 import numpy as np
 
@@ -14,61 +22,152 @@ from lhotse.dataset.sampling.base import CutSampler, SamplingDiagnostics, TimeCo
 
 
 class DynamicBucketingSampler(CutSampler):
+    """
+    A dynamic (streaming) variant of :class:`~lhotse.dataset.sampling.bucketing.BucketingSampler`,
+    that doesn't require reading the whole cut set into memory.
+
+    The basic idea is to sample N (e.g. ~10k) cuts and estimate the boundary durations for buckets.
+    Then, we maintain a buffer of M cuts (stored separately in K buckets) and every time we sample a batch,
+    we consume the input cut iterable for the same amount of cuts.
+    The memory consumption is limited by M at all times.
+
+    For scenarios such as ASR, VAD, Speaker ID, or TTS training, this class supports single CutSet
+    iteration. Example::
+
+        >>> cuts = CutSet(...)
+        >>> sampler = DynamicBucketingSampler(cuts, max_duration=100)
+        >>> for batch in sampler:
+        ...     assert isinstance(batch, CutSet)
+
+    For other scenarios that require pairs (or triplets, etc.) of utterances, this class supports
+    zipping multiple CutSets together. Such scenarios could be voice conversion, speech translation,
+    contrastive self-supervised training, etc. Example::
+
+        >>> source_cuts = CutSet(...)
+        >>> target_cuts = CutSet(...)
+        >>> sampler = DynamicBucketingSampler(source_cuts, target_cuts, max_duration=100)
+        >>> for batch in sampler:
+        ...     assert isinstance(batch, tuple)
+        ...     assert len(batch) == 2
+        ...     assert isinstance(batch[0], CutSet)
+        ...     assert isinstance(batch[1], CutSet)
+
+    .. note:: for cut pairs, triplets, etc. the user is responsible for ensuring that the CutSets
+        are all sorted so that when iterated over sequentially, the items are matched.
+        We take care of preserving the right ordering internally, e.g., when shuffling.
+        By default, we check that the cut IDs are matching, but that can be disabled.
+
+    .. caution:: when using :meth:`DynamicBucketingSampler.filter` to filter some cuts with more than
+        one CutSet to sample from, we sample one cut from every CutSet, and expect that all of the cuts
+        satisfy the predicate -- otherwise, they are all discarded from being sampled.
+    """
+
     def __init__(
         self,
-        cuts: CutSet,
+        *cuts: CutSet,
         max_duration: float,
         num_buckets: int = 10,
         shuffle: bool = False,
         drop_last: bool = False,
-        **kwargs,
+        consistent_ids: bool = True,
+        num_cuts_for_bins_estimate: int = 10000,
+        buffer_size: int = 10000,
+        world_size: Optional[int] = None,
+        rank: Optional[int] = None,
+        seed: int = 0,
     ) -> None:
-        super().__init__(**kwargs)
-        if not cuts.is_lazy:
+        """
+        :param cuts: one or more CutSets (when more than one, will yield tuples of CutSets as mini-batches)
+        :param max_duration: The maximum total recording duration from ``cuts``.
+        :param num_buckets: how many buckets to create.
+        :param shuffle: When ``True``, the cuts will be shuffled dynamically with
+            a reservoir-sampling-based algorithm.
+            Convenient when mini-batch loop is inside an outer epoch-level loop, e.g.:
+            `for epoch in range(10): for batch in dataset: ...` as every epoch will see a
+            different cuts order.
+        :param drop_last: When ``True``, we will drop all incomplete batches.
+            A batch is considered incomplete if it depleted a bucket before
+            hitting the constraint such as max_duration, max_cuts, etc.
+        :param consistent_ids: Only affects processing of multiple CutSets.
+            When ``True``, at each sampling step we check cuts from all CutSets have the same ID
+            (i.e., the first cut from every CutSet should have the same ID, same for the second, third, etc.).
+        :param num_cuts_for_bins_estimate: We will draw this many cuts to estimate the duration bins
+            for creating similar-duration buckets.
+            Larger number means a better estimate to the data distribution, possibly at a longer init cost.
+        :param buffer_size: How many cuts (or cut pairs, triplets) we hold at any time across all
+            of the buckets.
+            Increasing ``max_duration`` (batch_size) or ``num_buckets`` might require increasing this number.
+            It will result in larger memory usage.
+        :param world_size: Total number of distributed nodes. We will try to infer it by default.
+        :param rank: Index of distributed node. We will try to infer it by default.
+        :param seed: Random seed used to consistently shuffle the dataset across different processes.
+        """
+        super().__init__(world_size=world_size, rank=rank, seed=seed)
+        if not all(cs.is_lazy for cs in cuts):
             warnings.warn(
-                "You are using DynamicBucketingSampler with eagerly read CutSet. "
-                "You won't see any benefits with that setup. "
-                "Either use 'CutSet.from_jsonl_lazy' to read the CutSet lazily, or use BucketingSampler instead."
+                "You are using DynamicBucketingSampler with an eagerly read CutSet. "
+                "You won't see any memory/speed benefits with that setup. "
+                "Either use 'CutSet.from_jsonl_lazy' to read the CutSet lazily, or use a BucketingSampler instead."
             )
         self.cuts = cuts
         self.max_duration = max_duration
         self.shuffle = shuffle
         self.drop_last = drop_last
+        self.consistent_ids = consistent_ids
+        self.num_cuts_for_bins_estimate = num_cuts_for_bins_estimate
+        self.buffer_size = buffer_size
         self.rng = None
 
         if self.shuffle:
             cuts_for_bins_estimate = streaming_shuffle(
-                iter(cuts), rng=random.Random(self.seed)
+                iter(self.cuts[0]), rng=random.Random(self.seed)
             )
         else:
-            cuts_for_bins_estimate = cuts
+            cuts_for_bins_estimate = self.cuts[0]
         self.duration_bins = estimate_duration_buckets(
-            islice(cuts_for_bins_estimate, 10000), num_buckets=num_buckets
+            islice(cuts_for_bins_estimate, num_cuts_for_bins_estimate),
+            num_buckets=num_buckets,
         )
 
     def __iter__(self) -> "DynamicBucketingSampler":
         self.rng = random.Random(self.seed + self.epoch)
         # Initiate iteration
-        self.cuts_iter = iter(self.cuts)
+        self.cuts_iter = [iter(cs) for cs in self.cuts]
         # Optionally shuffle
         if self.shuffle:
-            self.cuts_iter = streaming_shuffle(self.cuts_iter, rng=self.rng)
+            self.cuts_iter = [
+                # Important -- every shuffler has a copy of RNG seeded in the same way,
+                # so that they are reproducible.
+                streaming_shuffle(cs, rng=random.Random(self.seed))
+                for cs in self.cuts_iter
+            ]
         # Apply filter predicate
-        self.cuts_iter = filter(self._filter_fn, self.cuts_iter)
+        self.cuts_iter = filter(
+            lambda tpl: all(self._filter_fn(c) for c in tpl), zip(*self.cuts_iter)
+        )
         # Convert Iterable[Cut] -> Iterable[CutSet]
         self.cuts_iter = DynamicBucketer(
-            cuts=self.cuts_iter,
+            self.cuts_iter,
             duration_bins=self.duration_bins,
             max_duration=self.max_duration,
             drop_last=self.drop_last,
-            buffer_size=10000,
+            buffer_size=self.buffer_size,
             rng=self.rng,
         )
         self.cuts_iter = iter(self.cuts_iter)
         return self
 
-    def _next_batch(self) -> CutSet:
-        return next(self.cuts_iter)
+    def _next_batch(self) -> Union[CutSet, Tuple[CutSet]]:
+        batch = next(self.cuts_iter)
+        if self.consistent_ids and isinstance(batch, tuple):
+            for cuts in zip(*batch):
+                expected_id = cuts[0].id
+                assert all(c.id == expected_id for c in cuts[1:]), (
+                    f"The input CutSet are not sorted by cut ID in the same way. "
+                    f"We sampled the following mismatched cut IDs: {', '.join(c.id for c in cuts)}. "
+                    f"If this is expected, pass the argument 'consistent_ids=False' to DynamicBucketingSampler."
+                )
+        return batch
 
     @property
     def remaining_duration(self) -> Optional[float]:
@@ -121,7 +220,7 @@ def estimate_duration_buckets(cuts: Iterable[Cut], num_buckets: int) -> List[Sec
 class DynamicBucketer:
     def __init__(
         self,
-        cuts: Iterable[Cut],
+        cuts: Iterable[Union[Cut, Tuple[Cut]]],
         duration_bins: List[Seconds],
         max_duration: float,
         drop_last: bool = False,
@@ -153,7 +252,9 @@ class DynamicBucketer:
             )
 
         # Init: create empty buckets (note: `num_buckets = len(duration_bins) + 1`).
-        self.buckets = [deque() for _ in range(len(duration_bins) + 1)]
+        self.buckets: List[Deque[Union[Cut, Tuple[Cut]]]] = [
+            deque() for _ in range(len(duration_bins) + 1)
+        ]
 
     def __iter__(self) -> Generator[CutSet, None, None]:
         # Init: sample `buffer_size` cuts and assign them to the right buckets.
@@ -164,7 +265,7 @@ class DynamicBucketer:
         def is_ready(bucket: Deque[Cut]):
             tot = TimeConstraint(max_duration=self.max_duration)
             for c in bucket:
-                tot.add(c)
+                tot.add(c[0] if isinstance(c, tuple) else c)
                 if tot.close_to_exceeding():
                     return True
             return False
@@ -193,7 +294,10 @@ class DynamicBucketer:
                     sampling_bucket, max_duration=self.max_duration
                 )
                 batch = next(iter(batcher))
-                batch_size = len(batch)
+                if isinstance(batch, tuple):
+                    batch_size = len(batch[0])
+                else:
+                    batch_size = len(batch)
                 yield batch
                 # Remove sampled cuts from the bucket.
                 for _ in range(batch_size):
@@ -209,9 +313,12 @@ class DynamicBucketer:
     def _collect_cuts_in_buckets(self, n_cuts: int):
         try:
             for _ in range(n_cuts):
-                cut = next(self.cuts_iter)
-                bucket_idx = bisect_right(self.duration_bins, cut.duration)
-                self.buckets[bucket_idx].append(cut)
+                cuts = next(self.cuts_iter)
+                duration = (
+                    cuts[0].duration if isinstance(cuts, tuple) else cuts.duration
+                )
+                bucket_idx = bisect_right(self.duration_bins, duration)
+                self.buckets[bucket_idx].append(cuts)
         except StopIteration:
             pass
 
@@ -220,7 +327,7 @@ class DynamicBucketer:
 class DurationBatcher:
     def __init__(
         self,
-        datapipe,
+        datapipe: Iterable[Union[Cut, Tuple[Cut]]],
         max_frames: int = None,
         max_samples: int = None,
         max_duration: Seconds = None,
@@ -236,7 +343,7 @@ class DurationBatcher:
             max_duration=max_duration, max_frames=max_frames, max_samples=max_samples
         )
 
-    def __iter__(self) -> Generator[CutSet, None, None]:
+    def __iter__(self) -> Generator[Union[CutSet, Tuple[CutSet]], None, None]:
         self.cuts_iter = iter(self.datapipe)
         try:
             while True:
@@ -245,17 +352,34 @@ class DurationBatcher:
             pass
         self.cuts_iter = None
 
-    def _collect_batch(self) -> CutSet:
+    def _collect_batch(self) -> Union[CutSet, Tuple[CutSet]]:
+        def detuplify(
+            cuts: List[Union[Cut, Tuple[Cut]]]
+        ) -> Union[CutSet, Tuple[CutSet]]:
+            """Helper to do the right thing whether we sampled single cuts or cut tuples."""
+            if isinstance(cuts[0], tuple):
+                if len(cuts[0]) == 1:
+                    cuts = CutSet.from_cuts(cs[0] for cs in cuts)
+                    self.diagnostics.keep(cuts)
+                    return cuts
+                else:
+                    tuple_of_cut_lists = list(zip(*cuts))
+                    self.diagnostics.keep(cuts[0])
+                    return tuple([CutSet.from_cuts(cs) for cs in tuple_of_cut_lists])
+            else:
+                self.diagnostics.keep(cuts)
+                return CutSet.from_cuts(cuts)
+
         self.time_constraint.reset()
         cuts = []
         while True:
             # Check that we have not reached the end of the dataset.
             try:
                 if self.reuse_cuts_buffer:
-                    next_cut = self.reuse_cuts_buffer.popleft()
+                    next_cut_or_tpl = self.reuse_cuts_buffer.popleft()
                 else:
                     # If this doesn't raise (typical case), it's not the end: keep processing.
-                    next_cut = next(self.cuts_iter)
+                    next_cut_or_tpl = next(self.cuts_iter)
             except StopIteration:
                 # No more cuts to sample from: if we have a partial batch,
                 # we may output it, unless the user requested to drop it.
@@ -264,8 +388,7 @@ class DurationBatcher:
                     not self.drop_last or self.time_constraint.close_to_exceeding()
                 ):
                     # We have a partial batch and we can return it.
-                    self.diagnostics.keep(cuts)
-                    return CutSet.from_cuts(cuts)
+                    return detuplify(cuts)
                 else:
                     # There is nothing more to return or it's discarded:
                     # signal the iteration code to stop.
@@ -273,7 +396,11 @@ class DurationBatcher:
                     raise StopIteration()
 
             # Track the duration/frames/etc. constraints.
-            self.time_constraint.add(next_cut)
+            self.time_constraint.add(
+                next_cut_or_tpl[0]
+                if isinstance(next_cut_or_tpl, tuple)
+                else next_cut_or_tpl
+            )
             next_num_cuts = len(cuts) + 1
 
             # Did we exceed the max_frames and max_cuts constraints?
@@ -281,12 +408,12 @@ class DurationBatcher:
                 self.max_cuts is None or next_num_cuts <= self.max_cuts
             ):
                 # No - add the next cut to the batch, and keep trying.
-                cuts.append(next_cut)
+                cuts.append(next_cut_or_tpl)
             else:
                 # Yes. Do we have at least one cut in the batch?
                 if cuts:
                     # Yes. Return the batch, but keep the currently drawn cut for later.
-                    self.reuse_cuts_buffer.append(next_cut)
+                    self.reuse_cuts_buffer.append(next_cut_or_tpl)
                     break
                 else:
                     # No. We'll warn the user that the constrains might be too tight,
@@ -297,7 +424,6 @@ class DurationBatcher:
                         "we'll return it anyway. "
                         "Consider increasing max_frames/max_cuts/max_duration."
                     )
-                    cuts.append(next_cut)
+                    cuts.append(next_cut_or_tpl)
 
-        self.diagnostics.keep(cuts)
-        return CutSet.from_cuts(cuts)
+        return detuplify(cuts)

--- a/lhotse/dataset/sampling/dynamic_bucketing.py
+++ b/lhotse/dataset/sampling/dynamic_bucketing.py
@@ -38,7 +38,7 @@ class DynamicBucketingSampler(CutSampler):
 
         if self.shuffle:
             cuts_for_bins_estimate = streaming_shuffle(
-                cuts, rng=random.Random(self.seed)
+                iter(cuts), rng=random.Random(self.seed)
             )
         else:
             cuts_for_bins_estimate = cuts
@@ -48,8 +48,11 @@ class DynamicBucketingSampler(CutSampler):
 
     def __iter__(self):
         self.rng = random.Random(self.seed + self.epoch)
+        self.cuts_iter = iter(self.cuts)
+        if self.shuffle:
+            self.cuts_iter = streaming_shuffle(self.cuts_iter, rng=self.rng)
         self.cuts_iter = dynamic_bucketing(
-            cuts=self.cuts,
+            cuts=self.cuts_iter,
             duration_bins=self.duration_bins,
             max_duration=self.max_duration,
             drop_last=self.drop_last,

--- a/lhotse/dataset/sampling/dynamic_bucketing.py
+++ b/lhotse/dataset/sampling/dynamic_bucketing.py
@@ -1,0 +1,221 @@
+import random
+import warnings
+from bisect import bisect_right
+from collections import deque
+from typing import Deque, Generator, Iterable, List, Optional
+
+import numpy as np
+
+from lhotse import CutSet, Seconds
+from lhotse.cut import Cut
+from lhotse.dataset.sampling.base import TimeConstraint
+
+
+def estimate_duration_buckets(cuts: Iterable[Cut], num_buckets: int) -> List[Seconds]:
+    """
+    Given an iterable of cuts and a desired number of buckets, select duration values
+    that should start each bucket.
+
+    The returned list, ``bins``, has ``num_buckets - 1`` elements.
+    The first bucket should contain cuts with duration ``0 <= d < bins[0]``;
+    the last bucket should contain cuts with duration ``bins[-1] <= d < float("inf")``,
+    ``i``-th bucket should contain cuts with duration ``bins[i - 1] <= d < bins[i]``.
+
+    :param cuts: an iterable of :class:`lhotse.cut.Cut`.
+    :param num_buckets: desired number of buckets.
+    :return: a list of boundary duration values (floats).
+    """
+    assert num_buckets > 1
+
+    durs = np.array([c.duration for c in cuts])
+    durs.sort()
+    assert num_buckets < durs.shape[0], (
+        f"The number of buckets ({num_buckets}) must be smaller "
+        f"than the number of cuts ({durs.shape[0]})."
+    )
+    bucket_duration = durs.sum() / num_buckets
+
+    bins = []
+    tot = 0.0
+    for dur in durs:
+        if tot > bucket_duration:
+            bins.append(dur)
+            tot = 0.0
+        tot += dur
+
+    return bins
+
+
+def dynamic_bucketing(
+    cuts: Iterable[Cut],
+    duration_bins: List[Seconds],
+    max_duration: float,
+    drop_last: bool = False,
+    buffer_size: int = 10000,
+    rng: random.Random = None,
+) -> Generator[CutSet, None, None]:
+
+    if rng is None:
+        rng = random.Random()
+
+    assert duration_bins == sorted(duration_bins), (
+        f"Argument list for 'duration_bins' is expected to be in "
+        f"sorted order (got: {duration_bins})."
+    )
+
+    # A heuristic diagnostic first, for finding the right settings.
+    mean_duration = np.mean(duration_bins)
+    expected_buffer_duration = buffer_size * mean_duration
+    expected_bucket_duration = expected_buffer_duration / (len(duration_bins) + 1)
+    if expected_bucket_duration < max_duration:
+        warnings.warn(
+            f"Your 'buffer_size' setting of {buffer_size} might be too low to satisfy "
+            f"a 'max_duration' of {max_duration} (given our best guess)."
+        )
+
+    # Init: create empty buckets (note: `num_buckets = len(duration_bins) + 1`).
+    buckets = [deque() for _ in range(len(duration_bins) + 1)]
+
+    # Init: sample `buffer_size` cuts and assign them to the right buckets.
+    cuts_iter = iter(cuts)
+
+    def collect_cuts_in_buckets(n_cuts: int):
+        try:
+            for _ in range(n_cuts):
+                cut = next(cuts_iter)
+                bucket_idx = bisect_right(duration_bins, cut.duration)
+                buckets[bucket_idx].append(cut)
+        except StopIteration:
+            pass
+
+    collect_cuts_in_buckets(buffer_size)
+
+    # Init: determine which buckets are "ready"
+    def is_ready(bucket: Deque[Cut]):
+        tot = TimeConstraint(max_duration=max_duration)
+        for c in bucket:
+            tot.add(c)
+            if tot.close_to_exceeding():
+                return True
+        return False
+
+    assert any(is_ready(bucket) for bucket in buckets)
+
+    # The iteration code starts here.
+    # On each step we're sampling a new batch.
+    try:
+        while True:
+            ready_buckets = [b for b in buckets if is_ready(b)]
+            if not ready_buckets:
+                # No bucket has enough data to yield for the last full batch.
+                non_empty_buckets = [b for b in buckets if b]
+                if drop_last or len(non_empty_buckets) == 0:
+                    # Either the user requested only full batches, or we have nothing left.
+                    raise StopIteration()
+                else:
+                    # Sample from partial batches that are left.
+                    ready_buckets = non_empty_buckets
+            # Choose a bucket to sample from.
+            # We'll only select from the buckets that have a full batch available.
+            sampling_bucket = rng.choice(ready_buckets)
+            # Sample one batch from that bucket and yield it to the caller.
+            batcher = DurationBatcher(sampling_bucket, max_duration=max_duration)
+            batch = next(iter(batcher))
+            batch_size = len(batch)
+            yield batch
+            # Remove sampled cuts from the bucket.
+            for _ in range(batch_size):
+                sampling_bucket.popleft()
+            # Fetch new cuts and add them to appropriate buckets.
+            collect_cuts_in_buckets(batch_size)
+    except StopIteration:
+        pass
+
+
+# Note: this class is a subset of SingleCutSampler and is "datapipes" ready.
+class DurationBatcher:
+    def __init__(
+        self,
+        datapipe,
+        max_frames: int = None,
+        max_samples: int = None,
+        max_duration: Seconds = None,
+        max_cuts: Optional[int] = None,
+        drop_last: bool = False,
+    ):
+        from lhotse.dataset.sampling.base import SamplingDiagnostics, TimeConstraint
+
+        self.datapipe = datapipe
+        self.reuse_cuts_buffer = deque()
+        self.drop_last = drop_last
+        self.max_cuts = max_cuts
+        self.diagnostics = SamplingDiagnostics()
+        self.time_constraint = TimeConstraint(
+            max_duration=max_duration, max_frames=max_frames, max_samples=max_samples
+        )
+
+    def __iter__(self):
+        self.cuts_iter = iter(self.datapipe)
+        try:
+            while True:
+                yield self._collect_batch()
+        except StopIteration:
+            pass
+        self.cuts_iter = None
+
+    def _collect_batch(self):
+        self.time_constraint.reset()
+        cuts = []
+        while True:
+            # Check that we have not reached the end of the dataset.
+            try:
+                if self.reuse_cuts_buffer:
+                    next_cut = self.reuse_cuts_buffer.popleft()
+                else:
+                    # If this doesn't raise (typical case), it's not the end: keep processing.
+                    next_cut = next(self.cuts_iter)
+            except StopIteration:
+                # No more cuts to sample from: if we have a partial batch,
+                # we may output it, unless the user requested to drop it.
+                # We also check if the batch is "almost there" to override drop_last.
+                if cuts and (
+                    not self.drop_last or self.time_constraint.close_to_exceeding()
+                ):
+                    # We have a partial batch and we can return it.
+                    self.diagnostics.keep(cuts)
+                    return CutSet.from_cuts(cuts)
+                else:
+                    # There is nothing more to return or it's discarded:
+                    # signal the iteration code to stop.
+                    self.diagnostics.discard(cuts)
+                    raise StopIteration()
+
+            # Track the duration/frames/etc. constraints.
+            self.time_constraint.add(next_cut)
+            next_num_cuts = len(cuts) + 1
+
+            # Did we exceed the max_frames and max_cuts constraints?
+            if not self.time_constraint.exceeded() and (
+                self.max_cuts is None or next_num_cuts <= self.max_cuts
+            ):
+                # No - add the next cut to the batch, and keep trying.
+                cuts.append(next_cut)
+            else:
+                # Yes. Do we have at least one cut in the batch?
+                if cuts:
+                    # Yes. Return the batch, but keep the currently drawn cut for later.
+                    self.reuse_cuts_buffer.append(next_cut)
+                    break
+                else:
+                    # No. We'll warn the user that the constrains might be too tight,
+                    # and return the cut anyway.
+                    warnings.warn(
+                        "The first cut drawn in batch collection violates "
+                        "the max_frames, max_cuts, or max_duration constraints - "
+                        "we'll return it anyway. "
+                        "Consider increasing max_frames/max_cuts/max_duration."
+                    )
+                    cuts.append(next_cut)
+
+        self.diagnostics.keep(cuts)
+        return CutSet.from_cuts(cuts)

--- a/lhotse/dataset/sampling/dynamic_bucketing.py
+++ b/lhotse/dataset/sampling/dynamic_bucketing.py
@@ -79,6 +79,7 @@ class DynamicBucketingSampler(CutSampler):
         """
         :param cuts: one or more CutSets (when more than one, will yield tuples of CutSets as mini-batches)
         :param max_duration: The maximum total recording duration from ``cuts``.
+            Note: with multiple CutSets, ``max_duration`` constraint applies only to the first CutSet.
         :param num_buckets: how many buckets to create.
         :param shuffle: When ``True``, the cuts will be shuffled dynamically with
             a reservoir-sampling-based algorithm.

--- a/lhotse/serialization.py
+++ b/lhotse/serialization.py
@@ -7,18 +7,31 @@ from typing import Any, Dict, Generator, Iterable, Optional, Type, Union
 
 import yaml
 
-from lhotse.utils import Pathlike
+from lhotse.utils import Pathlike, is_module_available
 
 # TODO: figure out how to use some sort of typing stubs
 #  so that linters/static checkers don't complain
 Manifest = Any  # Union['RecordingSet', 'SupervisionSet', 'FeatureSet', 'CutSet']
 
 
+def open_best(path: Pathlike, mode: str = "r"):
+    if is_module_available("smart_open"):
+        from smart_open import smart_open
+
+        # This will work with JSONL anywhere that smart_open supports, e.g. cloud storage.
+        open_fn = smart_open
+    else:
+        compressed = str(path).endswith(".gz")
+        if compressed and "t" not in mode and "b" not in mode:
+            # Opening as bytes not requested explicitly, use "t" to tell gzip to handle unicode.
+            mode = mode + "t"
+        open_fn = gzip.open if compressed else open
+
+    return open_fn(path, mode)
+
+
 def save_to_yaml(data: Any, path: Pathlike) -> None:
-    compressed = str(path).endswith(".gz")
-    opener = gzip.open if compressed else open
-    mode = "wt" if compressed else "w"
-    with opener(path, mode) as f:
+    with open_best(path, "w") as f:
         try:
             # When pyyaml is installed with C extensions, it can speed up the (de)serialization noticeably
             yaml.dump(data, stream=f, Dumper=yaml.CSafeDumper)
@@ -27,8 +40,7 @@ def save_to_yaml(data: Any, path: Pathlike) -> None:
 
 
 def load_yaml(path: Pathlike) -> dict:
-    opener = gzip.open if str(path).endswith(".gz") else open
-    with opener(path) as f:
+    with open_best(path) as f:
         try:
             # When pyyaml is installed with C extensions, it can speed up the (de)serialization noticeably
             return yaml.load(stream=f, Loader=yaml.CSafeLoader)
@@ -48,17 +60,13 @@ class YamlMixin:
 
 def save_to_json(data: Any, path: Pathlike) -> None:
     """Save the data to a JSON file. Will use GZip to compress it if the path ends with a ``.gz`` extension."""
-    compressed = str(path).endswith(".gz")
-    opener = gzip.open if compressed else open
-    mode = "wt" if compressed else "w"
-    with opener(path, mode) as f:
+    with open_best(path, "w") as f:
         json.dump(data, f, indent=2)
 
 
 def load_json(path: Pathlike) -> Union[dict, list]:
     """Load a JSON file. Also supports compressed JSON with a ``.gz`` extension."""
-    opener = gzip.open if str(path).endswith(".gz") else open
-    with opener(path) as f:
+    with open_best(path) as f:
         return json.load(f)
 
 
@@ -74,18 +82,14 @@ class JsonMixin:
 
 def save_to_jsonl(data: Iterable[Dict[str, Any]], path: Pathlike) -> None:
     """Save the data to a JSON file. Will use GZip to compress it if the path ends with a ``.gz`` extension."""
-    compressed = str(path).endswith(".gz")
-    opener = gzip.open if compressed else open
-    mode = "wt" if compressed else "w"
-    with opener(path, mode) as f:
+    with open_best(path, "w") as f:
         for item in data:
             print(json.dumps(item), file=f)
 
 
 def load_jsonl(path: Pathlike) -> Generator[Dict[str, Any], None, None]:
     """Load a JSON file. Also supports compressed JSON with a ``.gz`` extension."""
-    opener = gzip.open if str(path).endswith(".gz") else open
-    with opener(path) as f:
+    with open_best(path) as f:
         for line in f:
             # The temporary variable helps fail fast
             ret = json.loads(line)
@@ -134,13 +138,11 @@ class SequentialJsonlWriter:
                 f"SequentialJsonlWriter supports only JSONL format (one JSON item per line), "
                 f"but path='{path}'."
             )
-        self.compressed = extension_contains(".gz", self.path)
-        self._open = gzip.open if self.compressed else open
-        self.mode = "wt" if self.compressed else "w"
+        self.mode = "w"
         self.ignore_ids = set()
         if self.path.is_file() and not overwrite:
-            self.mode = "at" if self.compressed else "a"
-            with self._open(self.path) as f:
+            self.mode = "a"
+            with open_best(self.path) as f:
                 self.ignore_ids = {
                     data["id"]
                     for data in (json.loads(line) for line in f)
@@ -148,7 +150,7 @@ class SequentialJsonlWriter:
                 }
 
     def __enter__(self) -> "SequentialJsonlWriter":
-        self.file = self._open(self.path, self.mode)
+        self.file = open_best(self.path, self.mode)
         return self
 
     def __exit__(self, *args, **kwargs) -> None:
@@ -454,8 +456,7 @@ class LazyJsonlIterator:
         assert extension_contains(".jsonl", self.path)
 
     def _reset(self) -> None:
-        opener = gzip.open if str(self.path).endswith(".gz") else open
-        self._file = opener(self.path)
+        self._file = open_best(self.path)
 
     def __getstate__(self):
         """
@@ -606,7 +607,6 @@ def count_newlines_fast(path: Pathlike):
             b = reader(2 ** 16)
 
     path = Path(path)
-    opener = gzip.open if str(path).endswith(".gz") else open
-    with opener(path, "rb") as f:
+    with open_best(path, "rb") as f:
         count = sum(buf.count(b"\n") for buf in _make_gen(f.read))
     return count

--- a/test/dataset/sampling/test_dynamic_bucketing.py
+++ b/test/dataset/sampling/test_dynamic_bucketing.py
@@ -2,7 +2,7 @@ import random
 
 from lhotse import CutSet
 from lhotse.dataset.sampling.dynamic_bucketing import (
-    estimate_duration_buckets,
+    DynamicBucketingSampler, estimate_duration_buckets,
     dynamic_bucketing,
 )
 from lhotse.testing.dummies import DummyManifest
@@ -106,3 +106,38 @@ def test_dynamic_bucketing_drop_last_true():
 
     assert len(batches[2]) == 5
     assert sum(c.duration for c in batches[2]) == 5
+
+
+def test_dynamic_bucketing_sampler():
+    cuts = DummyManifest(CutSet, begin_id=0, end_id=10)
+    for i, c in enumerate(cuts):
+        if i < 5:
+            c.duration = 1
+        else:
+            c.duration = 2
+
+    sampler = DynamicBucketingSampler(cuts, max_duration=5, num_buckets=2, seed=0)
+    batches = [b for b in sampler]
+    sampled_cuts = [c for b in batches for c in b]
+
+    # Invariant: no duplicated cut IDs
+    assert len(set(c.id for b in batches for c in b)) == len(sampled_cuts)
+
+    # Same number of sampled and source cuts.
+    assert len(sampled_cuts) == len(cuts)
+
+    # We sampled 4 batches with this RNG, like the following:
+    assert len(batches) == 4
+
+    assert len(batches[0]) == 2
+    assert sum(c.duration for c in batches[0]) == 4
+
+    assert len(batches[1]) == 2
+    assert sum(c.duration for c in batches[1]) == 4
+
+    assert len(batches[2]) == 5
+    assert sum(c.duration for c in batches[2]) == 5
+
+    assert len(batches[3]) == 1
+    assert sum(c.duration for c in batches[3]) == 2
+

--- a/test/dataset/sampling/test_dynamic_bucketing.py
+++ b/test/dataset/sampling/test_dynamic_bucketing.py
@@ -143,6 +143,39 @@ def test_dynamic_bucketing_sampler():
     assert sum(c.duration for c in batches[3]) == 2
 
 
+def test_dynamic_bucketing_sampler_filter():
+    cuts = DummyManifest(CutSet, begin_id=0, end_id=10)
+    for i, c in enumerate(cuts):
+        if i < 5:
+            c.duration = 1
+        else:
+            c.duration = 2
+
+    sampler = DynamicBucketingSampler(cuts, max_duration=5, num_buckets=2, seed=0)
+    sampler.filter(lambda cut: cut.duration > 1)
+    batches = [b for b in sampler]
+    sampled_cuts = [c for b in batches for c in b]
+
+    # Invariant: no duplicated cut IDs
+    assert len(set(c.id for b in batches for c in b)) == len(sampled_cuts)
+
+    # Same number of sampled and source cuts.
+    assert len(sampled_cuts) < len(cuts)
+    assert len(sampled_cuts) == 5
+
+    # We sampled 4 batches with this RNG, like the following:
+    assert len(batches) == 3
+
+    assert len(batches[0]) == 2
+    assert sum(c.duration for c in batches[0]) == 4
+
+    assert len(batches[1]) == 2
+    assert sum(c.duration for c in batches[1]) == 4
+
+    assert len(batches[2]) == 1
+    assert sum(c.duration for c in batches[2]) == 2
+
+
 def test_dynamic_bucketing_sampler_shuffle():
     cuts = DummyManifest(CutSet, begin_id=0, end_id=10)
     for i, c in enumerate(cuts):

--- a/test/dataset/sampling/test_dynamic_bucketing.py
+++ b/test/dataset/sampling/test_dynamic_bucketing.py
@@ -1,0 +1,108 @@
+import random
+
+from lhotse import CutSet
+from lhotse.dataset.sampling.dynamic_bucketing import (
+    estimate_duration_buckets,
+    dynamic_bucketing,
+)
+from lhotse.testing.dummies import DummyManifest
+
+
+def test_estimate_duration_buckets_2b():
+    cuts = DummyManifest(CutSet, begin_id=0, end_id=10)
+    for i, c in enumerate(cuts):
+        if i < 5:
+            c.duration = 1
+        else:
+            c.duration = 2
+
+    bins = estimate_duration_buckets(cuts, num_buckets=2)
+
+    assert bins == [2]
+
+
+def test_estimate_duration_buckets_4b():
+    cuts = DummyManifest(CutSet, begin_id=0, end_id=20)
+    for i, c in enumerate(cuts):
+        if i < 5:
+            c.duration = 1
+        elif i < 10:
+            c.duration = 2
+        elif i < 15:
+            c.duration = 3
+        elif i < 20:
+            c.duration = 4
+
+    bins = estimate_duration_buckets(cuts, num_buckets=4)
+
+    assert bins == [2, 3, 4]
+
+
+def test_dynamic_bucketing_drop_last_false():
+    cuts = DummyManifest(CutSet, begin_id=0, end_id=10)
+    for i, c in enumerate(cuts):
+        if i < 5:
+            c.duration = 1
+        else:
+            c.duration = 2
+    rng = random.Random(0)
+
+    sampler = dynamic_bucketing(cuts, duration_bins=[2], max_duration=5, rng=rng)
+    batches = [b for b in sampler]
+    sampled_cuts = [c for b in batches for c in b]
+
+    # Invariant: no duplicated cut IDs
+    assert len(set(c.id for b in batches for c in b)) == len(sampled_cuts)
+
+    # Same number of sampled and source cuts.
+    assert len(sampled_cuts) == len(cuts)
+
+    # We sampled 4 batches with this RNG, like the following:
+    assert len(batches) == 4
+
+    assert len(batches[0]) == 2
+    assert sum(c.duration for c in batches[0]) == 4
+
+    assert len(batches[1]) == 2
+    assert sum(c.duration for c in batches[1]) == 4
+
+    assert len(batches[2]) == 5
+    assert sum(c.duration for c in batches[2]) == 5
+
+    assert len(batches[3]) == 1
+    assert sum(c.duration for c in batches[3]) == 2
+
+
+def test_dynamic_bucketing_drop_last_true():
+    cuts = DummyManifest(CutSet, begin_id=0, end_id=10)
+    for i, c in enumerate(cuts):
+        if i < 5:
+            c.duration = 1
+        else:
+            c.duration = 2
+    rng = random.Random(0)
+
+    sampler = dynamic_bucketing(
+        cuts, duration_bins=[2], max_duration=5, rng=rng, drop_last=True
+    )
+    batches = [b for b in sampler]
+    sampled_cuts = [c for b in batches for c in b]
+
+    # Invariant: no duplicated cut IDs.
+    assert len(set(c.id for b in batches for c in b)) == len(sampled_cuts)
+
+    # Some cuts were not sampled due to drop_last.
+    assert len(sampled_cuts) < len(cuts)
+    assert len(sampled_cuts) == 9
+
+    # We sampled 3 batches with this RNG, like the following:
+    assert len(batches) == 3
+
+    assert len(batches[0]) == 2
+    assert sum(c.duration for c in batches[0]) == 4
+
+    assert len(batches[1]) == 2
+    assert sum(c.duration for c in batches[1]) == 4
+
+    assert len(batches[2]) == 5
+    assert sum(c.duration for c in batches[2]) == 5

--- a/test/dataset/sampling/test_dynamic_bucketing.py
+++ b/test/dataset/sampling/test_dynamic_bucketing.py
@@ -350,7 +350,9 @@ def test_dynamic_bucketing_sampler_cut_triplets():
         else:
             c.duration = 2
 
-    sampler = DynamicBucketingSampler(cuts, cuts, cuts, max_duration=5, num_buckets=2, seed=0)
+    sampler = DynamicBucketingSampler(
+        cuts, cuts, cuts, max_duration=5, num_buckets=2, seed=0
+    )
     batches = [b for b in sampler]
     sampled_cut_triplets = [cut_triplet for b in batches for cut_triplet in zip(*b)]
     cuts1 = [c1 for c1, c2, c3 in sampled_cut_triplets]

--- a/test/dataset/sampling/test_dynamic_bucketing.py
+++ b/test/dataset/sampling/test_dynamic_bucketing.py
@@ -2,9 +2,9 @@ import random
 
 from lhotse import CutSet
 from lhotse.dataset.sampling.dynamic_bucketing import (
+    DynamicBucketer,
     DynamicBucketingSampler,
     estimate_duration_buckets,
-    dynamic_bucketing,
 )
 from lhotse.testing.dummies import DummyManifest
 
@@ -48,7 +48,7 @@ def test_dynamic_bucketing_drop_last_false():
             c.duration = 2
     rng = random.Random(0)
 
-    sampler = dynamic_bucketing(cuts, duration_bins=[2], max_duration=5, rng=rng)
+    sampler = DynamicBucketer(cuts, duration_bins=[2], max_duration=5, rng=rng)
     batches = [b for b in sampler]
     sampled_cuts = [c for b in batches for c in b]
 
@@ -83,7 +83,7 @@ def test_dynamic_bucketing_drop_last_true():
             c.duration = 2
     rng = random.Random(0)
 
-    sampler = dynamic_bucketing(
+    sampler = DynamicBucketer(
         cuts, duration_bins=[2], max_duration=5, rng=rng, drop_last=True
     )
     batches = [b for b in sampler]

--- a/test/dataset/sampling/test_dynamic_bucketing.py
+++ b/test/dataset/sampling/test_dynamic_bucketing.py
@@ -205,3 +205,201 @@ def test_dynamic_bucketing_sampler_shuffle():
 
     # Epoch 0 batches are different than epoch 1 batches
     assert epoch_batches[0] != epoch_batches[1]
+
+
+def test_dynamic_bucketing_sampler_cut_pairs():
+    cuts = DummyManifest(CutSet, begin_id=0, end_id=10)
+    for i, c in enumerate(cuts):
+        if i < 5:
+            c.duration = 1
+        else:
+            c.duration = 2
+
+    sampler = DynamicBucketingSampler(cuts, cuts, max_duration=5, num_buckets=2, seed=0)
+    batches = [b for b in sampler]
+    sampled_cut_pairs = [cut_pair for b in batches for cut_pair in zip(*b)]
+    source_cuts = [sc for sc, tc in sampled_cut_pairs]
+    target_cuts = [tc for sc, tc in sampled_cut_pairs]
+
+    # Invariant: no duplicated cut IDs
+    assert len(set(c.id for c in source_cuts)) == len(cuts)
+    assert len(set(c.id for c in target_cuts)) == len(cuts)
+
+    # Same number of sampled and source cuts.
+    assert len(sampled_cut_pairs) == len(cuts)
+
+    # We sampled 4 batches with this RNG, like the following:
+    assert len(batches) == 4
+
+    bidx = 0
+    sc, tc = batches[bidx][0], batches[bidx][1]
+    assert len(sc) == 2
+    assert len(tc) == 2
+    assert sum(c.duration for c in sc) == 4
+    assert sum(c.duration for c in tc) == 4
+
+    bidx = 1
+    sc, tc = batches[bidx][0], batches[bidx][1]
+    assert len(sc) == 2
+    assert len(tc) == 2
+    assert sum(c.duration for c in sc) == 4
+    assert sum(c.duration for c in tc) == 4
+
+    bidx = 2
+    sc, tc = batches[bidx][0], batches[bidx][1]
+    assert len(sc) == 5
+    assert len(tc) == 5
+    assert sum(c.duration for c in sc) == 5
+    assert sum(c.duration for c in tc) == 5
+
+    bidx = 3
+    sc, tc = batches[bidx][0], batches[bidx][1]
+    assert len(sc) == 1
+    assert len(tc) == 1
+    assert sum(c.duration for c in sc) == 2
+    assert sum(c.duration for c in tc) == 2
+
+
+def test_dynamic_bucketing_sampler_cut_pairs_shuffle():
+    cuts = DummyManifest(CutSet, begin_id=0, end_id=10)
+    for i, c in enumerate(cuts):
+        if i < 5:
+            c.duration = 1
+        else:
+            c.duration = 2
+
+    sampler = DynamicBucketingSampler(
+        cuts, cuts, max_duration=5, num_buckets=2, seed=0, shuffle=True
+    )
+
+    epoch_batches = []
+    for epoch in range(2):
+        sampler.set_epoch(epoch)
+
+        batches = [b for b in sampler]
+        sampled_cut_pairs = [cut_pair for b in batches for cut_pair in zip(*b)]
+        source_cuts = [sc for sc, tc in sampled_cut_pairs]
+        target_cuts = [tc for sc, tc in sampled_cut_pairs]
+
+        # Invariant: no duplicated cut IDs
+        assert len(set(c.id for c in source_cuts)) == len(cuts)
+        assert len(set(c.id for c in target_cuts)) == len(cuts)
+
+        # Same number of sampled and source cuts.
+        assert len(sampled_cut_pairs) == len(cuts)
+
+        epoch_batches.append(batches)
+
+    # Epoch 0 batches are different than epoch 1 batches
+    assert epoch_batches[0] != epoch_batches[1]
+
+
+def test_dynamic_bucketing_sampler_cut_pairs_filter():
+    cuts = DummyManifest(CutSet, begin_id=0, end_id=10)
+    for i, c in enumerate(cuts):
+        if i < 5:
+            c.duration = 1
+        else:
+            c.duration = 2
+
+    sampler = DynamicBucketingSampler(cuts, cuts, max_duration=5, num_buckets=2, seed=0)
+    sampler.filter(lambda c: c.duration > 1)
+    batches = [b for b in sampler]
+    sampled_cut_pairs = [cut_pair for b in batches for cut_pair in zip(*b)]
+    source_cuts = [sc for sc, tc in sampled_cut_pairs]
+    target_cuts = [tc for sc, tc in sampled_cut_pairs]
+
+    # Invariant: no duplicated cut IDs (there are 5 unique IDs)
+    assert len(set(c.id for c in source_cuts)) == 5
+    assert len(set(c.id for c in target_cuts)) == 5
+
+    # Smaller number of sampled cuts than the source cuts.
+    assert len(sampled_cut_pairs) < len(cuts)
+    assert len(sampled_cut_pairs) == 5
+
+    # We sampled 3 batches with this RNG, like the following:
+    assert len(batches) == 3
+
+    bidx = 0
+    sc, tc = batches[bidx][0], batches[bidx][1]
+    assert len(sc) == 2
+    assert len(tc) == 2
+    assert sum(c.duration for c in sc) == 4
+    assert sum(c.duration for c in tc) == 4
+
+    bidx = 1
+    sc, tc = batches[bidx][0], batches[bidx][1]
+    assert len(sc) == 2
+    assert len(tc) == 2
+    assert sum(c.duration for c in sc) == 4
+    assert sum(c.duration for c in tc) == 4
+
+    bidx = 2
+    sc, tc = batches[bidx][0], batches[bidx][1]
+    assert len(sc) == 1
+    assert len(tc) == 1
+    assert sum(c.duration for c in sc) == 2
+    assert sum(c.duration for c in tc) == 2
+
+
+def test_dynamic_bucketing_sampler_cut_triplets():
+    cuts = DummyManifest(CutSet, begin_id=0, end_id=10)
+    for i, c in enumerate(cuts):
+        if i < 5:
+            c.duration = 1
+        else:
+            c.duration = 2
+
+    sampler = DynamicBucketingSampler(cuts, cuts, cuts, max_duration=5, num_buckets=2, seed=0)
+    batches = [b for b in sampler]
+    sampled_cut_triplets = [cut_triplet for b in batches for cut_triplet in zip(*b)]
+    cuts1 = [c1 for c1, c2, c3 in sampled_cut_triplets]
+    cuts2 = [c2 for c1, c2, c3 in sampled_cut_triplets]
+    cuts3 = [c3 for c1, c2, c3 in sampled_cut_triplets]
+
+    # Invariant: no duplicated cut IDs
+    assert len(set(c.id for c in cuts1)) == len(cuts)
+    assert len(set(c.id for c in cuts2)) == len(cuts)
+    assert len(set(c.id for c in cuts3)) == len(cuts)
+
+    # Same number of sampled and source cuts.
+    assert len(sampled_cut_triplets) == len(cuts)
+
+    # We sampled 4 batches with this RNG, like the following:
+    assert len(batches) == 4
+
+    bidx = 0
+    c1, c2, c3 = batches[bidx][0], batches[bidx][1], batches[bidx][2]
+    assert len(c1) == 2
+    assert len(c2) == 2
+    assert len(c3) == 2
+    assert sum(c.duration for c in c1) == 4
+    assert sum(c.duration for c in c2) == 4
+    assert sum(c.duration for c in c3) == 4
+
+    bidx = 1
+    c1, c2, c3 = batches[bidx][0], batches[bidx][1], batches[bidx][2]
+    assert len(c1) == 2
+    assert len(c2) == 2
+    assert len(c3) == 2
+    assert sum(c.duration for c in c1) == 4
+    assert sum(c.duration for c in c2) == 4
+    assert sum(c.duration for c in c3) == 4
+
+    bidx = 2
+    c1, c2, c3 = batches[bidx][0], batches[bidx][1], batches[bidx][2]
+    assert len(c1) == 5
+    assert len(c2) == 5
+    assert len(c3) == 5
+    assert sum(c.duration for c in c1) == 5
+    assert sum(c.duration for c in c2) == 5
+    assert sum(c.duration for c in c3) == 5
+
+    bidx = 3
+    c1, c2, c3 = batches[bidx][0], batches[bidx][1], batches[bidx][2]
+    assert len(c1) == 1
+    assert len(c2) == 1
+    assert len(c3) == 1
+    assert sum(c.duration for c in c1) == 2
+    assert sum(c.duration for c in c2) == 2
+    assert sum(c.duration for c in c3) == 2

--- a/test/dataset/sampling/test_dynamic_bucketing.py
+++ b/test/dataset/sampling/test_dynamic_bucketing.py
@@ -2,7 +2,8 @@ import random
 
 from lhotse import CutSet
 from lhotse.dataset.sampling.dynamic_bucketing import (
-    DynamicBucketingSampler, estimate_duration_buckets,
+    DynamicBucketingSampler,
+    estimate_duration_buckets,
     dynamic_bucketing,
 )
 from lhotse.testing.dummies import DummyManifest
@@ -140,4 +141,3 @@ def test_dynamic_bucketing_sampler():
 
     assert len(batches[3]) == 1
     assert sum(c.duration for c in batches[3]) == 2
-

--- a/test/dataset/sampling/test_sampler_restoring.py
+++ b/test/dataset/sampling/test_sampler_restoring.py
@@ -9,6 +9,7 @@ from lhotse import CutSet
 from lhotse.dataset import (
     BucketingSampler,
     CutPairsSampler,
+    DynamicBucketingSampler,
     SingleCutSampler,
     ZipSampler,
 )
@@ -61,6 +62,17 @@ SAMPLERS_TO_TEST = [
         BucketingSampler(CUTS, max_duration=10.0, shuffle=True, drop_last=True, num_buckets=2),
         BucketingSampler(CUTS, num_buckets=2),
     ),
+    # Differently initialized BucketingSampler (using CutPairsSampler) with the same CUTS
+    (
+        BucketingSampler(CUTS, CUTS, max_source_duration=10.0, shuffle=True, drop_last=True, num_buckets=2,
+                         sampler_type=CutPairsSampler),
+        BucketingSampler(CUTS, CUTS, num_buckets=2, sampler_type=CutPairsSampler),
+    ),
+    pytest.param(
+        DynamicBucketingSampler(CUTS, max_duration=10.0, shuffle=True, drop_last=True, num_buckets=2),
+        DynamicBucketingSampler(CUTS, max_duration=10.0, num_buckets=2),
+        marks=pytest.mark.xfail(reason='DynamicBucketingSampler does not support resumption yet.')
+    )
 ]
 # fmt: on
 

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -29,7 +29,7 @@ from lhotse.utils import fastcopy, nullcontext as does_not_raise
         ("test/fixtures/dummy_feats/feature_manifest.json", does_not_raise()),
         ("test/fixtures/libri/cuts.json", does_not_raise()),
         ("test/fixtures/feature_config.yml", pytest.raises(ValueError)),
-        ("no/such/path.xd", pytest.raises(AssertionError)),
+        ("no/such/path.xd", pytest.raises(ValueError)),
     ],
 )
 def test_load_any_lhotse_manifest(path, exception_expectation):
@@ -45,7 +45,7 @@ def test_load_any_lhotse_manifest(path, exception_expectation):
         ("test/fixtures/dummy_feats/feature_manifest.json", does_not_raise()),
         ("test/fixtures/libri/cuts.json", does_not_raise()),
         ("test/fixtures/feature_config.yml", pytest.raises(ValueError)),
-        ("no/such/path.xd", pytest.raises(AssertionError)),
+        ("no/such/path.xd", pytest.raises(ValueError)),
     ],
 )
 def test_load_any_lhotse_manifest_lazy(path, exception_expectation):


### PR DESCRIPTION
This is to start getting early feedback on the design of "streaming" or "dynamic" bucketing that doesn't require reading the whole cut set into memory.

The basic idea is to sample N (e.g. ~10k) cuts and estimate the boundary durations for buckets. Then, we maintain a buffer of M cuts (stored separately in K buckets) and every time we sample a batch, we consume the input cut iterable for the same amount of cuts. The memory consumption is limited by M at all times.

Next steps:
- [x] possibly wrap it as a Sampler/CutSampler
- [x]  make it support everything/most things that other samplers are supporting
- [x] make it work with cut pairs