### PR TITLE
More user-friendly default settings

### DIFF
--- a/lhotse/audio.py
+++ b/lhotse/audio.py
@@ -60,7 +60,7 @@ from lhotse.utils import (
 Channels = Union[int, List[int]]
 
 
-_DEFAULT_LHOTSE_AUDIO_DURATION_MISMATCH_TOLERANCE: Seconds = 1e-3
+_DEFAULT_LHOTSE_AUDIO_DURATION_MISMATCH_TOLERANCE: Seconds = 1e-2
 LHOTSE_AUDIO_DURATION_MISMATCH_TOLERANCE: Seconds = (
     _DEFAULT_LHOTSE_AUDIO_DURATION_MISMATCH_TOLERANCE
 )
@@ -1398,8 +1398,7 @@ def assert_and_maybe_fix_num_samples(
         ceil(LHOTSE_AUDIO_DURATION_MISMATCH_TOLERANCE * recording.sampling_rate)
     )
     if 0 < diff <= allowed_diff:
-        # note the extra colon in -1:, which preserves the shape
-        audio = np.append(audio, audio[:, -diff:], axis=1)
+        audio = np.pad(audio, ((0, 0), (0, diff)), mode="reflect")
         return audio
     elif -allowed_diff <= diff < 0:
         audio = audio[:, :diff]

--- a/lhotse/caching.py
+++ b/lhotse/caching.py
@@ -1,7 +1,7 @@
 from functools import lru_cache, wraps
 from typing import Any, Callable
 
-LHOTSE_CACHING_ENABLED = True
+LHOTSE_CACHING_ENABLED = False
 
 # This dict is holding two variants for each registered method:
 # the cached variant, that uses it's own LRU cache,


### PR DESCRIPTION
- turned off audio/feature caching by default (regular users shouldn't pay with unnecessary memory usage)
- increase the tolerance for mismatched num_samples when loading audio from 1e-3 to 1e-2 seconds
- when padding the audio we read in mismatch situations, use mode='reflect' (previously it duplicated the last N samples without reflection)

