### PR TITLE
Custom binary feature storage format

### DIFF
--- a/lhotse/bin/modes/manipulation.py
+++ b/lhotse/bin/modes/manipulation.py
@@ -1,5 +1,7 @@
 import json
 import os
+from concurrent.futures import ProcessPoolExecutor, as_completed
+from itertools import groupby
 from pathlib import Path
 from typing import Optional
 
@@ -43,11 +45,22 @@ def copy(input_manifest, output_manifest):
     default="lilcom_chunky",
     help="Which storage backend should we use for writing the copied features.",
 )
+@click.option(
+    "-j",
+    "--max-jobs",
+    default=-1,
+    type=int,
+    help="Maximum number of parallel copying processes. "
+    "By default, one process is spawned for every existing feature file in the "
+    "INPUT_MANIFEST (e.g., if the features were extracted with 20 jobs, "
+    "there will typically be 20 files).",
+)
 def copy_feats(
     input_manifest: Pathlike,
     output_manifest: Pathlike,
     storage_path: str,
     storage_type: str,
+    max_jobs: int,
 ) -> None:
     """
     Load INPUT_MANIFEST of type :class:`lhotse.FeatureSet` or `lhotse.CutSet`,
@@ -55,21 +68,63 @@ def copy_feats(
     save them in STORAGE_PATH and save the updated manifest to OUTPUT_MANIFEST.
     """
     from lhotse.serialization import load_manifest_lazy_or_eager
+    from lhotse.manipulation import combine as combine_manifests
 
     manifests = load_manifest_lazy_or_eager(input_manifest)
+
     if isinstance(manifests, FeatureSet):
         with get_writer(storage_type)(storage_path) as w:
             # FeatureSet is copied in-memory and written (TODO: make it incremental if needed)
             manifests = manifests.copy_feats(writer=w)
             manifests.to_file(output_manifest)
+
     elif isinstance(manifests, CutSet):
-        with get_writer(storage_type)(storage_path) as w:
-            # CutSet has an incremental reading API
-            manifests.copy_feats(writer=w, output_path=output_manifest)
+        # Group cuts by their underlying feature files.
+        manifests = sorted(manifests, key=lambda cut: cut.features.storage_path)
+        subsets = groupby(manifests, lambda cut: cut.features.storage_path)
+        unique_storage_paths, subsets = zip(
+            *[(k, CutSet.from_cuts(grp)) for k, grp in subsets]
+        )
+
+        # Create paths for new feature files and subset cutsets.
+        tot_items = len(unique_storage_paths)
+        new_storage_paths = [f"{storage_path}/feats-{i}" for i in range(tot_items)]
+        partial_manifest_paths = [
+            f"{storage_path}/cuts-{i}.jsonl.gz" for i in range(tot_items)
+        ]
+
+        num_jobs = len(unique_storage_paths)
+        if max_jobs > 0:
+            num_jobs = min(num_jobs, max_jobs)
+
+        # Create directory if needed (storage_path might be an URL)
+        if Path(storage_path).parent.is_dir():
+            Path(storage_path).mkdir(exist_ok=True)
+
+        # Copy each partition in parallel and combine lazily opened manifests.
+        with ProcessPoolExecutor(num_jobs) as ex:
+            futures = []
+            for cs, nsp, pmp in zip(subsets, new_storage_paths, partial_manifest_paths):
+                futures.append(ex.submit(copy_feats_worker, cs, nsp, storage_type, pmp))
+
+            all_cuts = combine_manifests((f.result() for f in as_completed(futures)))
+
+        # Combine and save subset cutsets into the final file.
+        with CutSet.open_writer(output_manifest) as w:
+            for c in all_cuts:
+                w.write(c)
     else:
         raise ValueError(
             f"Unsupported manifest type ({type(manifests)}) at: {input_manifest}"
         )
+
+
+def copy_feats_worker(
+    cuts: CutSet, storage_path: Pathlike, storage_type: str, output_manifest: Path
+) -> CutSet:
+    with get_writer(storage_type)(storage_path) as w:
+        # CutSet has an incremental reading API
+        return cuts.copy_feats(writer=w, output_path=output_manifest)
 
 
 @cli.command()

--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -41,7 +41,7 @@ from lhotse.features import (
     create_default_feature_extractor,
 )
 from lhotse.features.base import compute_global_stats
-from lhotse.features.io import FeaturesWriter, LilcomFilesWriter, LilcomHdf5Writer
+from lhotse.features.io import FeaturesWriter, LilcomChunkyWriter, LilcomFilesWriter
 from lhotse.serialization import Serializable
 from lhotse.supervision import SupervisionSegment, SupervisionSet
 from lhotse.utils import (
@@ -147,8 +147,8 @@ class Cut:
     It is also possible to use a :class:`~lhotse.features.io.FeaturesWriter` to store the features and attach
     their manifest to a copy of the cut::
 
-        >>> from lhotse import LilcomHdf5Writer
-        >>> with LilcomHdf5Writer('feats.h5') as storage:
+        >>> from lhotse import LilcomChunkyWriter
+        >>> with LilcomChunkyWriter('feats.lca') as storage:
         ...     cut_with_feats = cut.compute_and_store_features(
         ...         extractor=Fbank(),
         ...         storage=storage
@@ -3836,7 +3836,7 @@ class CutSet(Serializable, Sequence[Cut]):
         storage_path: Pathlike,
         num_jobs: Optional[int] = None,
         augment_fn: Optional[AugmentFn] = None,
-        storage_type: Type[FW] = LilcomHdf5Writer,
+        storage_type: Type[FW] = LilcomChunkyWriter,
         executor: Optional[Executor] = None,
         mix_eagerly: bool = True,
         progress_bar: bool = True,
@@ -3848,7 +3848,7 @@ class CutSet(Serializable, Sequence[Cut]):
         Examples:
 
             Extract fbank features on one machine using 8 processes,
-            store arrays partitioned in 8 HDF5 files with lilcom compression:
+            store arrays partitioned in 8 archive files with lilcom compression:
 
             >>> cuts = CutSet(...)
             ... cuts.compute_and_store_features(
@@ -3870,7 +3870,7 @@ class CutSet(Serializable, Sequence[Cut]):
 
             Extract fbank features on multiple machines using a Dask cluster
             with 80 jobs,
-            store arrays partitioned in 80 HDF5 files with lilcom compression:
+            store arrays partitioned in 80 archive files with lilcom compression:
 
             >>> from distributed import Client
             ... cuts = CutSet(...)
@@ -4015,7 +4015,7 @@ class CutSet(Serializable, Sequence[Cut]):
         batch_duration: Seconds = 600.0,
         num_workers: int = 4,
         augment_fn: Optional[AugmentFn] = None,
-        storage_type: Type[FW] = LilcomHdf5Writer,
+        storage_type: Type[FW] = LilcomChunkyWriter,
         overwrite: bool = False,
     ) -> "CutSet":
         """
@@ -4030,7 +4030,7 @@ class CutSet(Serializable, Sequence[Cut]):
         Otherwise, the speed will be comparable to single-threaded extraction.
 
         Example: extract fbank features on one GPU, using 4 dataloading workers
-        for reading audio, and store the arrays in an HDF5 file with
+        for reading audio, and store the arrays in an archive file with
         lilcom compression::
 
             >>> from lhotse import KaldifeatFbank, KaldifeatFbankConfig

--- a/lhotse/features/__init__.py
+++ b/lhotse/features/__init__.py
@@ -12,6 +12,8 @@ from .io import (
     FeaturesReader,
     FeaturesWriter,
     KaldiReader,
+    LilcomChunkyReader,
+    LilcomChunkyWriter,
     LilcomFilesReader,
     LilcomFilesWriter,
     LilcomHdf5Reader,
@@ -33,7 +35,7 @@ from .kaldifeat import (
     KaldifeatMfccConfig,
 )
 from .librosa_fbank import LibrosaFbank, LibrosaFbankConfig
-from .opensmile import OpenSmileExtractor, OpenSmileConfig
 from .mfcc import Mfcc, MfccConfig
 from .mixer import FeatureMixer
+from .opensmile import OpenSmileConfig, OpenSmileExtractor
 from .spectrogram import Spectrogram, SpectrogramConfig

--- a/lhotse/features/base.py
+++ b/lhotse/features/base.py
@@ -482,7 +482,7 @@ class Features:
     def to_dict(self) -> dict:
         return asdict_nonull(self)
 
-    def copy_feats(self, writer: FeaturesWriter) -> 'Features':
+    def copy_feats(self, writer: FeaturesWriter) -> "Features":
         """
         Read the referenced feature array and save it using ``writer``.
         Returns a copy of the manifest with updated fields related to the feature storage.
@@ -698,7 +698,7 @@ class FeatureSet(Serializable, Sequence[Features]):
         features = feature_info.load(start=start, duration=duration)
         return features
 
-    def copy_feats(self, writer: FeaturesWriter) -> 'FeatureSet':
+    def copy_feats(self, writer: FeaturesWriter) -> "FeatureSet":
         """
         For each manifest in this FeatureSet,
         read the referenced feature array and save it using ``writer``.

--- a/lhotse/features/base.py
+++ b/lhotse/features/base.py
@@ -482,6 +482,21 @@ class Features:
     def to_dict(self) -> dict:
         return asdict_nonull(self)
 
+    def copy_feats(self, writer: FeaturesWriter) -> 'Features':
+        """
+        Read the referenced feature array and save it using ``writer``.
+        Returns a copy of the manifest with updated fields related to the feature storage.
+        """
+        feats = self.load()
+        new_key = writer.write(self.storage_key, feats)
+        item = fastcopy(
+            self,
+            storage_type=writer.name,
+            storage_path=writer.storage_path,
+            storage_key=new_key,
+        )
+        return item
+
     @staticmethod
     def from_dict(data: dict) -> "Features":
         # The "storage_type" check is to ensure that the "data" dict actually contains
@@ -682,6 +697,14 @@ class FeatureSet(Serializable, Sequence[Features]):
         )
         features = feature_info.load(start=start, duration=duration)
         return features
+
+    def copy_feats(self, writer: FeaturesWriter) -> 'FeatureSet':
+        """
+        For each manifest in this FeatureSet,
+        read the referenced feature array and save it using ``writer``.
+        Returns a copy of the manifest with updated fields related to the feature storage.
+        """
+        return FeatureSet.from_features(f.copy_feats(writer=writer) for f in self)
 
     def compute_global_stats(
         self, storage_path: Optional[Pathlike] = None

--- a/lhotse/features/compression.py
+++ b/lhotse/features/compression.py
@@ -5,9 +5,14 @@ import numpy as np
 
 
 def lilcom_compress_chunked(
-    data: np.ndarray, tick_power: int = -5, do_regression=True, chunk_size: int = 100
+    data: np.ndarray,
+    tick_power: int = -5,
+    do_regression=True,
+    chunk_size: int = 100,
+    temporal_dim: int = 0,
 ) -> List[bytes]:
-    num_frames, num_feats = data.shape
+    assert temporal_dim < data.ndim
+    num_frames = data.shape[temporal_dim]
     compressed = []
     for begin in range(0, num_frames, chunk_size):
         compressed.append(

--- a/lhotse/features/io.py
+++ b/lhotse/features/io.py
@@ -816,16 +816,19 @@ class LilcomChunkyWriter(FeaturesWriter):
         :param chunk_size: How many frames to store per chunk.
             Too low a number will require many reads for long feature matrices,
             too high a number will require to read more redundant data.
-        :param mode: Modes, one of: "wb"
+        :param mode: Modes, one of: "w" (write) or "a" (append); can be "wb" and "ab", "b" is implicit
         """
         super().__init__()
 
-        assert mode == "wb"
+        if "b" not in mode:
+            mode = mode + "b"
+        assert mode == "wb" or "ab"
 
-        self.storage_path_ = Path(storage_path).with_suffix(".lf")
+        # ".lca" -> "lilcom chunky archive"
+        self.storage_path_ = Path(storage_path).with_suffix(".lca")
         self.tick_power = tick_power
         self.file = open(self.storage_path, mode=mode)
-        self.curr_offset = 0
+        self.curr_offset = self.file.tell()
 
     @property
     def storage_path(self) -> str:

--- a/test/features/test_copy_feats.py
+++ b/test/features/test_copy_feats.py
@@ -1,0 +1,95 @@
+from tempfile import NamedTemporaryFile, TemporaryDirectory
+
+import numpy as np
+import pytest
+
+from lhotse import CutSet, FeatureSet, NumpyFilesWriter
+from lhotse.utils import fastcopy
+
+
+@pytest.fixture
+def cuts():
+    return CutSet.from_file("test/fixtures/libri/cuts.json")
+
+
+def test_features_copy_feats(cuts):
+    features = cuts[0].features
+    with TemporaryDirectory() as d, NumpyFilesWriter(d) as w:
+        cpy = features.copy_feats(writer=w)
+        data = cpy.load()
+        assert isinstance(data, np.ndarray)
+        ref_data = features.load()
+        np.testing.assert_almost_equal(data, ref_data)
+
+
+def test_feature_set_copy_feats(cuts):
+    feature_set = FeatureSet.from_features([cuts[0].features])
+    with TemporaryDirectory() as d, NumpyFilesWriter(d) as w:
+        cpy = feature_set.copy_feats(writer=w)
+        data = cpy[0].load()
+        assert isinstance(data, np.ndarray)
+        ref_data = feature_set[0].load()
+        np.testing.assert_almost_equal(data, ref_data)
+
+
+def test_cut_set_copy_feats(cuts):
+    # Make a CutSet with MonoCut, PaddingCut, and MixedCut
+    cuts = CutSet.from_cuts(
+        [
+            # MonoCut
+            cuts[0],
+            # MonoCut without feats
+            fastcopy(cuts[0], id="cut-no-feats").drop_features(),
+        ]
+    )
+    with TemporaryDirectory() as d, NumpyFilesWriter(d) as w:
+        cpy = cuts.copy_feats(writer=w)
+        assert len(cpy) == len(cuts)
+        for cut, orig in zip(cpy, cuts):
+            if not orig.has_features:
+                continue
+            data = cut.load_features()
+            assert isinstance(data, np.ndarray)
+            ref_data = orig.load_features()
+            np.testing.assert_almost_equal(data, ref_data)
+
+
+def test_cut_set_copy_feats_output_path(cuts):
+    # Make a CutSet with MonoCut, PaddingCut, and MixedCut
+    cuts = CutSet.from_cuts(
+        [
+            # MonoCut
+            cuts[0],
+            # MonoCut without feats
+            fastcopy(cuts[0], id="cut-no-feats").drop_features(),
+        ]
+    )
+    with NamedTemporaryFile(
+        suffix=".jsonl"
+    ) as f, TemporaryDirectory() as d, NumpyFilesWriter(d) as w:
+        cpy = cuts.copy_feats(writer=w, output_path=f.name)
+        assert len(cpy) == len(cuts)
+        assert list(cpy.ids) == list(cuts.ids)
+        for cut, orig in zip(cpy, cuts):
+            assert (
+                not orig.has_features
+                or (cut.load_features() == orig.load_features()).all()
+            )
+
+
+def test_cut_set_mixed_cut_copy_feats(cuts):
+    # Make a CutSet with MonoCut, PaddingCut, and MixedCut
+    cuts = CutSet.from_cuts(
+        [
+            # MixedCut
+            cuts[0].pad(duration=30)
+        ]
+    )
+    with TemporaryDirectory() as d, NumpyFilesWriter(d) as w:
+        cpy = cuts.copy_feats(writer=w)
+        assert len(cpy) == len(cuts)
+        for cut, orig in zip(cpy, cuts):
+            data = cut.load_features()
+            assert isinstance(data, np.ndarray)
+            ref_data = orig.load_features()
+            np.testing.assert_almost_equal(data, ref_data)

--- a/test/features/test_writer_append.py
+++ b/test/features/test_writer_append.py
@@ -1,0 +1,77 @@
+from tempfile import TemporaryDirectory
+
+import numpy as np
+import pytest
+
+from lhotse import CutSet, LilcomChunkyReader, LilcomChunkyWriter
+
+
+@pytest.fixture
+def cuts():
+    return CutSet.from_file("test/fixtures/libri/cuts.json")
+
+
+def test_writer_overwrite(cuts):
+    data = cuts[0].load_features()
+    dataplus1 = data + 1
+    with TemporaryDirectory() as d:
+
+        with LilcomChunkyWriter(d) as w:
+            key1 = w.write('key1', data)
+            storage_path = w.storage_path
+
+        with LilcomChunkyWriter(storage_path) as w:
+            key2 = w.write('key2', dataplus1)
+
+        r = LilcomChunkyReader(storage_path)
+
+        # key1 is corrupted as it was overwritten
+        with pytest.raises(ValueError):
+            r.read(key1)
+
+        restored = r.read(key2)
+        # decimal=1 because of lilcom compression, see:
+        # E           AssertionError:
+        # E           Arrays are not almost equal to 7 decimals
+        # E
+        # E           Mismatched elements: 39997 / 40000 (100%)
+        # E           Max absolute difference: 0.015625
+        # E           Max relative difference: 54.764027
+        np.testing.assert_almost_equal(restored, dataplus1, decimal=1)
+
+
+def test_writer_append(cuts):
+    data = cuts[0].load_features()
+    dataplus1 = data + 1
+    with TemporaryDirectory() as d:
+
+        with LilcomChunkyWriter(d) as w:
+            key1 = w.write('key1', data)
+            storage_path = w.storage_path
+
+        with LilcomChunkyWriter(storage_path, mode='ab') as w:
+            key2 = w.write('key2', dataplus1)
+
+        r = LilcomChunkyReader(storage_path)
+
+        restored = r.read(key1)
+        np.testing.assert_almost_equal(restored, data, decimal=1)
+        # decimal=1 because of lilcom compression, see:
+        # E           AssertionError:
+        # E           Arrays are not almost equal to 7 decimals
+        # E
+        # E           Mismatched elements: 39499 / 40000 (98.7%)
+        # E           Max absolute difference: 0.015625
+        # E           Max relative difference: 4.2855635
+
+        restored = r.read(key2)
+        # decimal=1 because of lilcom compression, see:
+        # E           AssertionError:
+        # E           Arrays are not almost equal to 7 decimals
+        # E
+        # E           Mismatched elements: 39997 / 40000 (100%)
+        # E           Max absolute difference: 0.015625
+        # E           Max relative difference: 54.764027
+        np.testing.assert_almost_equal(restored, dataplus1, decimal=1)
+
+

--- a/test/features/test_writer_append.py
+++ b/test/features/test_writer_append.py
@@ -17,11 +17,11 @@ def test_writer_overwrite(cuts):
     with TemporaryDirectory() as d:
 
         with LilcomChunkyWriter(d) as w:
-            key1 = w.write('key1', data)
+            key1 = w.write("key1", data)
             storage_path = w.storage_path
 
         with LilcomChunkyWriter(storage_path) as w:
-            key2 = w.write('key2', dataplus1)
+            key2 = w.write("key2", dataplus1)
 
         r = LilcomChunkyReader(storage_path)
 
@@ -46,11 +46,11 @@ def test_writer_append(cuts):
     with TemporaryDirectory() as d:
 
         with LilcomChunkyWriter(d) as w:
-            key1 = w.write('key1', data)
+            key1 = w.write("key1", data)
             storage_path = w.storage_path
 
-        with LilcomChunkyWriter(storage_path, mode='ab') as w:
-            key2 = w.write('key2', dataplus1)
+        with LilcomChunkyWriter(storage_path, mode="ab") as w:
+            key2 = w.write("key2", dataplus1)
 
         r = LilcomChunkyReader(storage_path)
 
@@ -73,5 +73,3 @@ def test_writer_append(cuts):
         # E           Max absolute difference: 0.015625
         # E           Max relative difference: 54.764027
         np.testing.assert_almost_equal(restored, dataplus1, decimal=1)
-
-

--- a/test/test_feature_set.py
+++ b/test/test_feature_set.py
@@ -20,7 +20,8 @@ from lhotse.features import (
 from lhotse.features.io import (
     ChunkedLilcomHdf5Writer,
     KaldiWriter,
-    LilcomFastWriter, LilcomFilesWriter,
+    LilcomChunkyWriter,
+    LilcomFilesWriter,
     LilcomHdf5Writer,
     NumpyFilesWriter,
     NumpyHdf5Writer,
@@ -126,7 +127,7 @@ def test_compute_global_stats():
         lambda: LilcomFilesWriter(TemporaryDirectory().name),
         lambda: LilcomHdf5Writer(NamedTemporaryFile().name),
         lambda: ChunkedLilcomHdf5Writer(NamedTemporaryFile().name),
-        lambda: LilcomFastWriter(NamedTemporaryFile().name),
+        lambda: LilcomChunkyWriter(NamedTemporaryFile().name),
         lambda: NumpyFilesWriter(TemporaryDirectory().name),
         lambda: NumpyHdf5Writer(NamedTemporaryFile().name),
         pytest.param(

--- a/test/test_feature_set.py
+++ b/test/test_feature_set.py
@@ -20,7 +20,7 @@ from lhotse.features import (
 from lhotse.features.io import (
     ChunkedLilcomHdf5Writer,
     KaldiWriter,
-    LilcomFilesWriter,
+    LilcomFastWriter, LilcomFilesWriter,
     LilcomHdf5Writer,
     NumpyFilesWriter,
     NumpyHdf5Writer,
@@ -126,6 +126,7 @@ def test_compute_global_stats():
         lambda: LilcomFilesWriter(TemporaryDirectory().name),
         lambda: LilcomHdf5Writer(NamedTemporaryFile().name),
         lambda: ChunkedLilcomHdf5Writer(NamedTemporaryFile().name),
+        lambda: LilcomFastWriter(NamedTemporaryFile().name),
         lambda: NumpyFilesWriter(TemporaryDirectory().name),
         lambda: NumpyHdf5Writer(NamedTemporaryFile().name),
         pytest.param(


### PR DESCRIPTION
Since HDF5 might not be the best choice for this project (we'll see how the discussion proceeds in #518), here is an alternative that doesn't use it. 

It's a copy of `ChunkedLilcomHdf5Writer` that uses a plain binary file and stores the compressed array chunks next to each other. The `storage_key` keeps the global file offset for each array followed by a list of chunk relative offsets. 

Seems to work on par with HDF5 storage we had so far: practically identical file sizes, seems to have roughly the same iteration speed when reading shuffled feats. 

@danpovey you have experience with building formats like these in Kaldi (`ark`), any thoughts here?