### PR TITLE
Streaming Kaldi feature extractors

### DIFF
--- a/lhotse/features/kaldi/layers.py
+++ b/lhotse/features/kaldi/layers.py
@@ -680,7 +680,10 @@ def _get_strided_batch(waveform, window_length, window_shift, snip_edges):
         npad_right = npad - npad_left
         # waveform = nn.functional.pad(waveform, (npad_left, npad_right), mode='reflect')
         pad_left = torch.flip(waveform[:, 1 : npad_left + 1], (1,))
-        pad_right = torch.flip(waveform[:, -npad_right - 1 : -1], (1,))
+        if npad_right >= 0:
+            pad_right = torch.flip(waveform[:, -npad_right - 1 : -1], (1,))
+        else:
+            pad_right = torch.tensor([], dtype=waveform.dtype)
         waveform = torch.cat((pad_left, waveform, pad_right), dim=1)
 
     strides = (

--- a/lhotse/features/kaldi/layers.py
+++ b/lhotse/features/kaldi/layers.py
@@ -817,7 +817,7 @@ def _get_strided_batch_streaming(
     num_samples = waveform.size(-1)
 
     window_remainder = window_length - window_shift
-    num_frames = (num_samples - (window_remainder)) // window_shift
+    num_frames = (num_samples - window_remainder) // window_shift
 
     remainder = waveform[:, num_frames * window_shift :]
 

--- a/lhotse/features/kaldi/layers.py
+++ b/lhotse/features/kaldi/layers.py
@@ -164,7 +164,7 @@ class Wav2Win(nn.Module):
 
         # preemphasis
         if self.preemph_coeff != 0.0:
-            x_offset = torch.nn.functional.pad(x_strided, (0, 1), mode="replicate")
+            x_offset = torch.nn.functional.pad(x_strided, (1, 0), mode="replicate")
             x_strided = x_strided - self.preemph_coeff * x_offset[:, :, :-1]
 
         # Apply window_function to each frame

--- a/test/features/test_kaldi_features.py
+++ b/test/features/test_kaldi_features.py
@@ -1,6 +1,7 @@
 import pytest
 import torch
 
+from lhotse import Fbank, Mfcc
 from lhotse.audio import Recording
 from lhotse.features.kaldi.extractors import KaldiFbank, KaldiMfcc
 from lhotse.features.kaldi.layers import Wav2LogFilterBank, Wav2MFCC
@@ -59,7 +60,25 @@ def test_kaldi_fbank_extractor(recording):
     assert feats.shape == (1604, 80)
 
 
+def test_kaldi_fbank_extractor_vs_torchaudio(recording):
+    audio = recording.load_audio()
+    fbank = KaldiFbank()
+    fbank_ta = Fbank()
+    feats = fbank.extract(audio, recording.sampling_rate)
+    feats_ta = fbank_ta.extract(audio, recording.sampling_rate)
+    torch.testing.assert_allclose(feats, feats_ta)
+
+
 def test_kaldi_mfcc_extractor(recording):
     mfcc = KaldiMfcc()
     feats = mfcc.extract(recording.load_audio(), recording.sampling_rate)
     assert feats.shape == (1604, 13)
+
+
+def test_kaldi_mfcc_extractor_vs_torchaudio(recording):
+    audio = recording.load_audio()
+    fbank = KaldiMfcc()
+    fbank_ta = Mfcc()
+    feats = fbank.extract(audio, recording.sampling_rate)
+    feats_ta = fbank_ta.extract(audio, recording.sampling_rate)
+    torch.testing.assert_allclose(feats, feats_ta)

--- a/test/features/test_kaldi_layers.py
+++ b/test/features/test_kaldi_layers.py
@@ -141,7 +141,7 @@ def test_strided_waveform_batch_streaming():
 
     # one last extra iteration to pump out the frames that the offline version gets due to padding
     # note that our implementation will flip the last N samples so we do the same for identical results
-    x_chunk = torch.flip(x[:, -(window_shift + 1) : -1], dims=(1,))
+    x_chunk = torch.flip(x[:, -window_shift:], dims=(1,))
     y_chunk, remainder = _get_strided_batch_streaming(
         x_chunk,
         window_length=window_length,
@@ -180,7 +180,7 @@ def test_wav2win_streaming():
         frames.append(y_chunk)
 
     # one last extra iteration to pump out the frames that the offline version gets due to padding
-    x_chunk = torch.flip(x[:, -(window_shift + 1) : -1], dims=(1,))
+    x_chunk = torch.flip(x[:, -window_shift:], dims=(1,))
     (y_chunk, _), remainder = t.online_inference(x_chunk, context=remainder)
     frames.append(y_chunk)
 
@@ -224,7 +224,7 @@ def test_wav2logfilterbank_streaming(layer_type, feat_dim):
         frames.append(y_chunk)
 
     # one last extra iteration to pump out the frames that the offline version gets due to padding
-    x_chunk = torch.flip(x[:, -(window_shift + 1) : -1], dims=(1,))
+    x_chunk = torch.flip(x[:, -window_shift:], dims=(1,))
     y_chunk, remainder = t.online_inference(x_chunk, context=remainder)
     frames.append(y_chunk)
 

--- a/test/features/test_kaldi_layers.py
+++ b/test/features/test_kaldi_layers.py
@@ -1,3 +1,6 @@
+import math
+
+import pytest
 import torch
 
 from lhotse.features.kaldi import (
@@ -7,6 +10,10 @@ from lhotse.features.kaldi import (
     Wav2MFCC,
     Wav2Spec,
     Wav2Win,
+)
+from lhotse.features.kaldi.layers import (
+    _get_strided_batch,
+    _get_strided_batch_streaming,
 )
 
 
@@ -104,3 +111,125 @@ def test_wav2mfcc_is_torchscriptable():
     y = t(x)
     assert y.shape == torch.Size([1, 100, 13])
     assert y.dtype == torch.float32
+
+
+def test_strided_waveform_batch_streaming():
+    x = torch.arange(16000).unsqueeze(0)
+    window_length = 400
+    window_shift = 160
+
+    # reference offline forward pass
+    y = _get_strided_batch(
+        waveform=x,
+        window_length=window_length,
+        window_shift=window_shift,
+        snip_edges=False,
+    )
+    assert y.shape == torch.Size([1, 100, window_length])
+
+    # online pass under test
+    frames = []
+    chunk_size = 1200
+    num_chunks = math.ceil(x.size(1) / chunk_size)
+    remainder = None
+    for i in range(num_chunks):
+        x_chunk = x[:, i * chunk_size : (i + 1) * chunk_size]
+        y_chunk, remainder = _get_strided_batch_streaming(
+            x_chunk, window_length=400, window_shift=160, prev_remainder=remainder
+        )
+        frames.append(y_chunk)
+
+    # one last extra iteration to pump out the frames that the offline version gets due to padding
+    # note that our implementation will flip the last N samples so we do the same for identical results
+    x_chunk = torch.flip(x[:, -(window_shift + 1) : -1], dims=(1,))
+    y_chunk, remainder = _get_strided_batch_streaming(
+        x_chunk,
+        window_length=window_length,
+        window_shift=window_shift,
+        prev_remainder=remainder,
+    )
+    frames.append(y_chunk)
+
+    y_online = torch.cat(frames, dim=1)
+
+    assert y.shape == y_online.shape
+
+    torch.testing.assert_allclose(y_online, y)
+
+
+def test_wav2win_streaming():
+    x = torch.randn(1, 16000, dtype=torch.float32)
+    t = Wav2Win()
+    window_length = 400
+    window_shift = 160
+    assert t._length == window_length
+    assert t._shift == window_shift
+
+    # reference offline forward pass
+    y, _ = t(x)
+    assert y.shape == torch.Size([1, 100, window_length])
+
+    # online pass under test
+    frames = []
+    chunk_size = 1200
+    num_chunks = math.ceil(x.size(1) / chunk_size)
+    remainder = None
+    for i in range(num_chunks):
+        x_chunk = x[:, i * chunk_size : (i + 1) * chunk_size]
+        (y_chunk, _), remainder = t.online_inference(x_chunk, context=remainder)
+        frames.append(y_chunk)
+
+    # one last extra iteration to pump out the frames that the offline version gets due to padding
+    x_chunk = torch.flip(x[:, -(window_shift + 1) : -1], dims=(1,))
+    (y_chunk, _), remainder = t.online_inference(x_chunk, context=remainder)
+    frames.append(y_chunk)
+
+    y_online = torch.cat(frames, dim=1)
+
+    assert y.shape == y_online.shape
+
+    torch.testing.assert_allclose(y_online, y)
+
+
+@pytest.mark.parametrize(
+    ["layer_type", "feat_dim"],
+    [
+        (Wav2FFT, 257),
+        (Wav2Spec, 257),
+        (Wav2LogSpec, 257),
+        (Wav2LogFilterBank, 80),
+        (Wav2MFCC, 13),
+    ],
+)
+def test_wav2logfilterbank_streaming(layer_type, feat_dim):
+    x = torch.randn(1, 16000, dtype=torch.float32)
+    t = layer_type()
+    window_length = 400
+    window_shift = 160
+    assert t.wav2win._length == window_length
+    assert t.wav2win._shift == window_shift
+
+    # reference offline forward pass
+    y = t(x)
+    assert y.shape == torch.Size([1, 100, feat_dim])
+
+    # online pass under test
+    frames = []
+    chunk_size = 1200
+    num_chunks = math.ceil(x.size(1) / chunk_size)
+    remainder = None
+    for i in range(num_chunks):
+        x_chunk = x[:, i * chunk_size : (i + 1) * chunk_size]
+        y_chunk, remainder = t.online_inference(x_chunk, context=remainder)
+        frames.append(y_chunk)
+
+    # one last extra iteration to pump out the frames that the offline version gets due to padding
+    x_chunk = torch.flip(x[:, -(window_shift + 1) : -1], dims=(1,))
+    y_chunk, remainder = t.online_inference(x_chunk, context=remainder)
+    frames.append(y_chunk)
+
+    y_online = torch.cat(frames, dim=1)
+
+    assert y.shape == y_online.shape
+
+    torch.testing.assert_allclose(y_online, y)


### PR DESCRIPTION
This updates the Kaldi-like feature extractor layers with a new function `online_inference`. It accepts an extra argument which is the remainder of the previous waveform (or `None`) and it returns the remainder from the currently processed audio chunk. It works basically the same like Kaldi's online feature extraction, except it has a stateless API which plays better with TorchScript and other runtimes. The callers should manage the state themselves.