### PR TITLE
Add early reverb option for RIR-based augmentation

### DIFF
--- a/lhotse/audio.py
+++ b/lhotse/audio.py
@@ -517,7 +517,7 @@ class Recording:
 
         :param rir_recording: The impulse response to be used.
         :param normalize_output: When true, output will be normalized to have energy as input.
-        :param early_only: When true, only the early reflections will be used.
+        :param early_only: When true, only the early reflections (first 50 ms) will be used.
         :param affix_id: When true, we will modify the ``Recording.id`` field
             by affixing it with "_rvb".
         :return: the perturbed ``Recording``.
@@ -882,7 +882,7 @@ class RecordingSet(Serializable, Sequence[Recording]):
 
         :param rir_recordings: The impulse responses to be used.
         :param normalize_output: When true, output will be normalized to have energy as input.
-        :param early_only: When true, only the early reflections will be used.
+        :param early_only: When true, only the early reflections (first 50 ms) will be used.
         :param affix_id: When true, we will modify the ``Recording.id`` field
             by affixing it with "_rvb".
         :return: a ``RecordingSet`` containing the perturbed ``Recording`` objects.

--- a/lhotse/audio.py
+++ b/lhotse/audio.py
@@ -508,6 +508,7 @@ class Recording:
         self,
         rir_recording: "Recording",
         normalize_output: bool = True,
+        early_only: bool = False,
         affix_id: bool = True,
     ) -> "Recording":
         """
@@ -516,6 +517,7 @@ class Recording:
 
         :param rir_recording: The impulse response to be used.
         :param normalize_output: When true, output will be normalized to have energy as input.
+        :param early_only: When true, only the early reflections will be used.
         :param affix_id: When true, we will modify the ``Recording.id`` field
             by affixing it with "_rvb".
         :return: the perturbed ``Recording``.
@@ -525,6 +527,7 @@ class Recording:
             ReverbWithImpulseResponse(
                 rir_recording,
                 normalize_output=normalize_output,
+                early_only=early_only,
             ).to_dict()
         )
         return fastcopy(
@@ -870,6 +873,7 @@ class RecordingSet(Serializable, Sequence[Recording]):
         self,
         rir_recordings: "RecordingSet",
         normalize_output: bool = True,
+        early_only: bool = False,
         affix_id: bool = True,
     ) -> "RecordingSet":
         """
@@ -878,6 +882,7 @@ class RecordingSet(Serializable, Sequence[Recording]):
 
         :param rir_recordings: The impulse responses to be used.
         :param normalize_output: When true, output will be normalized to have energy as input.
+        :param early_only: When true, only the early reflections will be used.
         :param affix_id: When true, we will modify the ``Recording.id`` field
             by affixing it with "_rvb".
         :return: a ``RecordingSet`` containing the perturbed ``Recording`` objects.
@@ -887,6 +892,7 @@ class RecordingSet(Serializable, Sequence[Recording]):
             r.reverb_rir(
                 rir_recording=random.choice(rir_recordings),
                 normalize_output=normalize_output,
+                early_only=early_only,
                 affix_id=affix_id,
             )
             for r in self

--- a/lhotse/augmentation/torchaudio.py
+++ b/lhotse/augmentation/torchaudio.py
@@ -382,6 +382,7 @@ class ReverbWithImpulseResponse(AudioTransform):
 
     rir: dict
     normalize_output: bool = True
+    early_only: bool = False
 
     RIR_SCALING_FACTOR: float = 0.5 ** 15
 
@@ -404,7 +405,11 @@ class ReverbWithImpulseResponse(AudioTransform):
         assert samples.shape[0] == 1, "The input audio must be single-channel."
         sampling_rate = int(sampling_rate)  # paranoia mode
 
-        rir_ = self.rir.load_audio()
+        rir_ = (
+            self.rir.load_audio()
+            if not self.early_only
+            else self.rir.load_audio(duration=0.05)
+        )
 
         # Determine output length.
         _, N_in = samples.shape

--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -1355,7 +1355,7 @@ class MonoCut(Cut):
 
         :param rir_recording: The impulse response to use for convolving.
         :param normalize_output: When true, output will be normalized to have energy as input.
-        :param early_only: When true, only the early reflections will be used.
+        :param early_only: When true, only the early reflections (first 50 ms) will be used.
         :param affix_id: When true, we will modify the ``MonoCut.id`` field
             by affixing it with "_rvb".
         :return: a modified copy of the current ``MonoCut``.
@@ -1750,7 +1750,7 @@ class PaddingCut(Cut):
 
         :param rir_recording: The impulse response to use for convolving.
         :param normalize_output: When true, output will be normalized to have energy as input.
-        :param early_only: When true, only the early reflections will be used.
+        :param early_only: When true, only the early reflections (first 50 ms) will be used.
         :param affix_id: When true, we will modify the ``PaddingCut.id`` field
             by affixing it with "_rvb".
         :return: a modified copy of the current ``PaddingCut``.
@@ -2350,7 +2350,7 @@ class MixedCut(Cut):
 
         :param rir_recording: The impulse response to use for convolving.
         :param normalize_output: When true, output will be normalized to have energy as input.
-        :param early_only: When true, only the early reflections will be used.
+        :param early_only: When true, only the early reflections (first 50 ms) will be used.
         :param affix_id: When true, we will modify the ``MixedCut.id`` field
             by affixing it with "_rvb".
         :return: a modified copy of the current ``MixedCut``.
@@ -3725,7 +3725,7 @@ class CutSet(Serializable, Sequence[Cut]):
 
         :param rir_recordings: RecordingSet containing the room impulse responses.
         :param normalize_output: When true, output will be normalized to have energy as input.
-        :param early_only: When true, only the early reflections will be used.
+        :param early_only: When true, only the early reflections (first 50 ms) will be used.
         :param affix_id: Should we modify the ID (useful if both versions of the same
             cut are going to be present in a single manifest).
         :return: a modified copy of the ``CutSet``.

--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -1347,6 +1347,7 @@ class MonoCut(Cut):
         self,
         rir_recording: "Recording",
         normalize_output: bool = True,
+        early_only: bool = False,
         affix_id: bool = True,
     ) -> "MonoCut":
         """
@@ -1354,6 +1355,7 @@ class MonoCut(Cut):
 
         :param rir_recording: The impulse response to use for convolving.
         :param normalize_output: When true, output will be normalized to have energy as input.
+        :param early_only: When true, only the early reflections will be used.
         :param affix_id: When true, we will modify the ``MonoCut.id`` field
             by affixing it with "_rvb".
         :return: a modified copy of the current ``MonoCut``.
@@ -1373,6 +1375,7 @@ class MonoCut(Cut):
         recording_rvb = self.recording.reverb_rir(
             rir_recording=rir_recording,
             normalize_output=normalize_output,
+            early_only=early_only,
             affix_id=affix_id,
         )
         # Match the supervision's id (and it's underlying recording id).
@@ -1738,6 +1741,7 @@ class PaddingCut(Cut):
         self,
         rir_recording: "Recording",
         normalize_output: bool = True,
+        early_only: bool = False,
         affix_id: bool = True,
     ) -> "PaddingCut":
         """
@@ -1746,6 +1750,7 @@ class PaddingCut(Cut):
 
         :param rir_recording: The impulse response to use for convolving.
         :param normalize_output: When true, output will be normalized to have energy as input.
+        :param early_only: When true, only the early reflections will be used.
         :param affix_id: When true, we will modify the ``PaddingCut.id`` field
             by affixing it with "_rvb".
         :return: a modified copy of the current ``PaddingCut``.
@@ -2337,6 +2342,7 @@ class MixedCut(Cut):
         self,
         rir_recording: "Recording",
         normalize_output: bool = True,
+        early_only: bool = False,
         affix_id: bool = True,
     ) -> "MixedCut":
         """
@@ -2344,6 +2350,7 @@ class MixedCut(Cut):
 
         :param rir_recording: The impulse response to use for convolving.
         :param normalize_output: When true, output will be normalized to have energy as input.
+        :param early_only: When true, only the early reflections will be used.
         :param affix_id: When true, we will modify the ``MixedCut.id`` field
             by affixing it with "_rvb".
         :return: a modified copy of the current ``MixedCut``.
@@ -2366,6 +2373,7 @@ class MixedCut(Cut):
                     cut=track.cut.reverb_rir(
                         rir_recording=rir_recording,
                         normalize_output=normalize_output,
+                        early_only=early_only,
                         affix_id=affix_id,
                     ),
                 )
@@ -3706,6 +3714,7 @@ class CutSet(Serializable, Sequence[Cut]):
         self,
         rir_recordings: "RecordingSet",
         normalize_output: bool = True,
+        early_only: bool = False,
         affix_id: bool = True,
     ) -> "CutSet":
         """
@@ -3716,6 +3725,7 @@ class CutSet(Serializable, Sequence[Cut]):
 
         :param rir_recordings: RecordingSet containing the room impulse responses.
         :param normalize_output: When true, output will be normalized to have energy as input.
+        :param early_only: When true, only the early reflections will be used.
         :param affix_id: Should we modify the ID (useful if both versions of the same
             cut are going to be present in a single manifest).
         :return: a modified copy of the ``CutSet``.
@@ -3726,6 +3736,7 @@ class CutSet(Serializable, Sequence[Cut]):
                 cut.reverb_rir(
                     rir_recording=random.choice(rir_recordings),
                     normalize_output=normalize_output,
+                    early_only=early_only,
                     affix_id=affix_id,
                 )
                 for cut in self

--- a/lhotse/dataset/cut_transforms/reverberate.py
+++ b/lhotse/dataset/cut_transforms/reverberate.py
@@ -7,7 +7,8 @@ class ReverbWithImpulseResponse:
     """
     A transform on batch of cuts (``CutSet``) that convolves each cut with an impulse
     response with some probability :attr:`p`. The impulse response is chosen randomly from
-    a specified CutSet of RIRs :attr:`rir_cuts`.
+    a specified CutSet of RIRs :attr:`rir_cuts`. If `early_only` is set to True, convolution
+    is performed only with the first 50ms of the impulse response.
     """
 
     def __init__(
@@ -17,12 +18,14 @@ class ReverbWithImpulseResponse:
         normalize_output: bool = True,
         randgen: random.Random = None,
         preserve_id: bool = False,
+        early_only: bool = False,
     ) -> None:
         self.rir_recordings = list(rir_recordings)
         self.p = p
         self.normalize_output = normalize_output
         self.random = randgen
         self.preserve_id = preserve_id
+        self.early_only = early_only
 
     def __call__(self, cuts: CutSet) -> CutSet:
         if self.random is None:
@@ -31,6 +34,7 @@ class ReverbWithImpulseResponse:
             cut.reverb_rir(
                 rir_recording=self.random.choice(self.rir_recordings),
                 normalize_output=self.normalize_output,
+                early_only=self.early_only,
                 affix_id=not self.preserve_id,
             )
             if self.random.random() >= self.p

--- a/test/augmentation/test_torchaudio.py
+++ b/test/augmentation/test_torchaudio.py
@@ -76,16 +76,20 @@ def test_volume_does_not_change_num_samples(audio):
         assert augmented_audio != audio
 
 
-def test_reverb_does_not_change_num_samples(audio, rir):
-    augment_fn = ReverbWithImpulseResponse(rir=rir)
+@pytest.mark.parametrize("early_only", [True, False])
+def test_reverb_does_not_change_num_samples(audio, rir, early_only):
+    augment_fn = ReverbWithImpulseResponse(rir=rir, early_only=early_only)
     for _ in range(10):
         augmented_audio = augment_fn(audio, sampling_rate=SAMPLING_RATE)
         assert augmented_audio.shape == (1, 16000)
 
 
 @pytest.mark.parametrize("normalize_output", [True, False])
-def test_reverb_normalize_output(audio, rir, normalize_output):
-    augment_fn = ReverbWithImpulseResponse(rir=rir, normalize_output=normalize_output)
+@pytest.mark.parametrize("early_only", [True, False])
+def test_reverb_normalize_output(audio, rir, normalize_output, early_only):
+    augment_fn = ReverbWithImpulseResponse(
+        rir=rir, normalize_output=normalize_output, early_only=early_only
+    )
     orig_energy = np.sum(np.abs(audio) ** 2) / audio.shape[1]
     for _ in range(10):
         augmented_audio = augment_fn(audio, sampling_rate=SAMPLING_RATE)


### PR DESCRIPTION
When this option is set to `true`, the audio is convolved with only the first 50ms of the impulse response.