### PR TITLE
Change the default Fbank and Mfcc feature extractors implementation

### DIFF
--- a/lhotse/features/__init__.py
+++ b/lhotse/features/__init__.py
@@ -5,7 +5,7 @@ from .base import (
     Features,
     create_default_feature_extractor,
 )
-from .fbank import Fbank, FbankConfig
+from .fbank import TorchaudioFbank, TorchaudioFbankConfig
 from .io import (
     ChunkedLilcomHdf5Reader,
     ChunkedLilcomHdf5Writer,
@@ -25,7 +25,7 @@ from .io import (
     available_storage_backends,
     close_cached_file_handles,
 )
-from .kaldi.extractors import KaldiFbank, KaldiFbankConfig, KaldiMfcc, KaldiMfccConfig
+from .kaldi.extractors import Fbank, FbankConfig, Mfcc, MfccConfig
 from .kaldifeat import (
     KaldifeatFbank,
     KaldifeatFbankConfig,
@@ -34,6 +34,6 @@ from .kaldifeat import (
 )
 from .librosa_fbank import LibrosaFbank, LibrosaFbankConfig
 from .opensmile import OpenSmileExtractor, OpenSmileConfig
-from .mfcc import Mfcc, MfccConfig
+from .mfcc import TorchaudioMfcc, TorchaudioMfccConfig
 from .mixer import FeatureMixer
 from .spectrogram import Spectrogram, SpectrogramConfig

--- a/lhotse/features/fbank.py
+++ b/lhotse/features/fbank.py
@@ -8,7 +8,7 @@ from lhotse.utils import EPSILON, Seconds
 
 
 @dataclass
-class FbankConfig:
+class TorchaudioFbankConfig:
     # Spectogram-related part
     dither: float = 0.0
     window_type: str = "povey"
@@ -35,16 +35,16 @@ class FbankConfig:
         return asdict(self)
 
     @staticmethod
-    def from_dict(data: Dict[str, Any]) -> "FbankConfig":
-        return FbankConfig(**data)
+    def from_dict(data: Dict[str, Any]) -> "TorchaudioFbankConfig":
+        return TorchaudioFbankConfig(**data)
 
 
 @register_extractor
-class Fbank(TorchaudioFeatureExtractor):
+class TorchaudioFbank(TorchaudioFeatureExtractor):
     """Log Mel energy filter bank feature extractor based on ``torchaudio.compliance.kaldi.fbank`` function."""
 
     name = "fbank"
-    config_type = FbankConfig
+    config_type = TorchaudioFbankConfig
 
     def _feature_fn(self, *args, **kwargs):
         from torchaudio.compliance.kaldi import fbank

--- a/lhotse/features/kaldi/__init__.py
+++ b/lhotse/features/kaldi/__init__.py
@@ -1,2 +1,2 @@
-from .extractors import KaldiFbank, KaldiFbankConfig, KaldiMfcc, KaldiMfccConfig
+from .extractors import Fbank, FbankConfig, Mfcc, MfccConfig
 from .layers import Wav2FFT, Wav2LogFilterBank, Wav2LogSpec, Wav2MFCC, Wav2Spec, Wav2Win

--- a/lhotse/features/kaldi/extractors.py
+++ b/lhotse/features/kaldi/extractors.py
@@ -53,7 +53,7 @@ class Fbank(FeatureExtractor):
 
     def __init__(self, config: Optional[FbankConfig] = None):
         super().__init__(config=config)
-        self.extractor = Wav2LogFilterBank(**self.config.to_dict())
+        self.extractor = Wav2LogFilterBank(**self.config.to_dict()).eval()
 
     @property
     def frame_shift(self) -> Seconds:
@@ -148,7 +148,7 @@ class Mfcc(FeatureExtractor):
 
     def __init__(self, config: Optional[MfccConfig] = None):
         super().__init__(config=config)
-        self.extractor = torch.jit.script(Wav2MFCC(**self.config.to_dict()))
+        self.extractor = Wav2MFCC(**self.config.to_dict()).eval()
 
     @property
     def frame_shift(self) -> Seconds:

--- a/lhotse/features/kaldi/extractors.py
+++ b/lhotse/features/kaldi/extractors.py
@@ -53,7 +53,7 @@ class Fbank(FeatureExtractor):
 
     def __init__(self, config: Optional[FbankConfig] = None):
         super().__init__(config=config)
-        self.extractor = torch.jit.script(Wav2LogFilterBank(**self.config.to_dict()))
+        self.extractor = Wav2LogFilterBank(**self.config.to_dict())
 
     @property
     def frame_shift(self) -> Seconds:

--- a/lhotse/features/kaldi/extractors.py
+++ b/lhotse/features/kaldi/extractors.py
@@ -1,5 +1,4 @@
-import warnings
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from typing import Any, Dict, Optional, Union
 
 import numpy as np
@@ -66,7 +65,7 @@ class Fbank(FeatureExtractor):
         self, samples: Union[np.ndarray, torch.Tensor], sampling_rate: int
     ) -> Union[np.ndarray, torch.Tensor]:
         assert sampling_rate == self.config.sampling_rate, (
-            f"KaldiFbank was instantiated for sampling_rate "
+            f"Fbank was instantiated for sampling_rate "
             f"{self.config.sampling_rate}, but "
             f"sampling_rate={sampling_rate} was passed to extract()."
         )
@@ -161,7 +160,7 @@ class Mfcc(FeatureExtractor):
         self, samples: Union[np.ndarray, torch.Tensor], sampling_rate: int
     ) -> Union[np.ndarray, torch.Tensor]:
         assert sampling_rate == self.config.sampling_rate, (
-            f"KaldiMfcc was instantiated for sampling_rate "
+            f"Mfcc was instantiated for sampling_rate "
             f"{self.config.sampling_rate}, but "
             f"sampling_rate={sampling_rate} was passed to extract()."
         )

--- a/lhotse/features/kaldi/layers.py
+++ b/lhotse/features/kaldi/layers.py
@@ -779,7 +779,7 @@ def _get_strided_batch(
         if npad_right >= 0:
             pad_right = torch.flip(waveform[:, -npad_right:], (1,))
         else:
-            pad_right = torch.tensor([], dtype=waveform.dtype)
+            pad_right = torch.zeros(0, dtype=waveform.dtype)
         waveform = torch.cat((pad_left, waveform, pad_right), dim=1)
 
     strides = (

--- a/lhotse/features/kaldi/layers.py
+++ b/lhotse/features/kaldi/layers.py
@@ -252,7 +252,7 @@ class Wav2FFT(nn.Module):
         sampling_rate: int = 16000,
         frame_length: Seconds = 0.025,
         frame_shift: Seconds = 0.01,
-        fft_length: int = 512,
+        round_to_power_of_two: bool = True,
         remove_dc_offset: bool = True,
         preemph_coeff: float = 0.97,
         window_type: str = "povey",
@@ -263,17 +263,14 @@ class Wav2FFT(nn.Module):
         use_energy: bool = True,
     ) -> None:
         super().__init__()
-
+        self.use_energy = use_energy
         N = int(math.floor(frame_length * sampling_rate))
-        if N > fft_length:
-            k = math.ceil(math.log(N) / math.log(2))
-            self.fft_length = int(2 ** k)
-
+        self.fft_length = next_power_of_2(N) if round_to_power_of_two else N
         self.wav2win = Wav2Win(
             sampling_rate,
             frame_length,
             frame_shift,
-            pad_length=fft_length,
+            pad_length=self.fft_length,
             remove_dc_offset=remove_dc_offset,
             preemph_coeff=preemph_coeff,
             window_type=window_type,
@@ -283,9 +280,6 @@ class Wav2FFT(nn.Module):
             raw_energy=raw_energy,
             return_log_energy=use_energy,
         )
-
-        self.fft_length = fft_length
-        self.use_energy = use_energy
 
     @property
     def sampling_rate(self) -> int:
@@ -367,7 +361,7 @@ class Wav2Spec(Wav2FFT):
         sampling_rate: int = 16000,
         frame_length: Seconds = 0.025,
         frame_shift: Seconds = 0.01,
-        fft_length: int = 512,
+        round_to_power_of_two: bool = True,
         remove_dc_offset: bool = True,
         preemph_coeff: float = 0.97,
         window_type: str = "povey",
@@ -382,7 +376,7 @@ class Wav2Spec(Wav2FFT):
             sampling_rate,
             frame_length,
             frame_shift,
-            fft_length,
+            round_to_power_of_two=round_to_power_of_two,
             remove_dc_offset=remove_dc_offset,
             preemph_coeff=preemph_coeff,
             window_type=window_type,
@@ -436,7 +430,7 @@ class Wav2LogSpec(Wav2FFT):
         sampling_rate: int = 16000,
         frame_length: Seconds = 0.025,
         frame_shift: Seconds = 0.01,
-        fft_length: int = 512,
+        round_to_power_of_two: bool = True,
         remove_dc_offset: bool = True,
         preemph_coeff: float = 0.97,
         window_type: str = "povey",
@@ -451,7 +445,7 @@ class Wav2LogSpec(Wav2FFT):
             sampling_rate,
             frame_length,
             frame_shift,
-            fft_length,
+            round_to_power_of_two=round_to_power_of_two,
             remove_dc_offset=remove_dc_offset,
             preemph_coeff=preemph_coeff,
             window_type=window_type,
@@ -505,7 +499,7 @@ class Wav2LogFilterBank(Wav2FFT):
         sampling_rate: int = 16000,
         frame_length: Seconds = 0.025,
         frame_shift: Seconds = 0.01,
-        fft_length: int = 512,
+        round_to_power_of_two: bool = True,
         remove_dc_offset: bool = True,
         preemph_coeff: float = 0.97,
         window_type: str = "povey",
@@ -526,7 +520,7 @@ class Wav2LogFilterBank(Wav2FFT):
             sampling_rate,
             frame_length,
             frame_shift,
-            fft_length,
+            round_to_power_of_two=round_to_power_of_two,
             remove_dc_offset=remove_dc_offset,
             preemph_coeff=preemph_coeff,
             window_type=window_type,
@@ -557,7 +551,7 @@ class Wav2LogFilterBank(Wav2FFT):
             # see torchaudio.compliance.kaldi.fbank, lines #581-587 for the original usage
             fb, _ = get_mel_banks(
                 num_bins=num_filters,
-                window_length_padded=fft_length,
+                window_length_padded=self.fft_length,
                 sample_freq=sampling_rate,
                 low_freq=low_freq,
                 high_freq=high_freq,
@@ -571,15 +565,13 @@ class Wav2LogFilterBank(Wav2FFT):
         else:
             fb = create_mel_scale(
                 num_filters=num_filters,
-                fft_length=fft_length,
+                fft_length=self.fft_length,
                 sampling_rate=sampling_rate,
                 low_freq=low_freq,
                 high_freq=high_freq,
                 norm_filters=norm_filters,
             )
-        self._fb = nn.Parameter(
-            torch.tensor(fb, dtype=torch.get_default_dtype()), requires_grad=False
-        )
+        self._fb = nn.Parameter(fb, requires_grad=False)
 
     def _forward_strided(
         self, x_strided: torch.Tensor, log_e: Optional[torch.Tensor]
@@ -620,7 +612,7 @@ class Wav2MFCC(Wav2FFT):
         sampling_rate: int = 16000,
         frame_length: Seconds = 0.025,
         frame_shift: Seconds = 0.01,
-        fft_length: int = 512,
+        round_to_power_of_two: bool = True,
         remove_dc_offset: bool = True,
         preemph_coeff: float = 0.97,
         window_type: str = "povey",
@@ -643,7 +635,7 @@ class Wav2MFCC(Wav2FFT):
             sampling_rate,
             frame_length,
             frame_shift,
-            fft_length,
+            round_to_power_of_two=round_to_power_of_two,
             remove_dc_offset=remove_dc_offset,
             preemph_coeff=preemph_coeff,
             window_type=window_type,
@@ -676,7 +668,7 @@ class Wav2MFCC(Wav2FFT):
             # see torchaudio.compliance.kaldi.fbank, lines #581-587 for the original usage
             fb, _ = get_mel_banks(
                 num_bins=num_filters,
-                window_length_padded=fft_length,
+                window_length_padded=self.fft_length,
                 sample_freq=sampling_rate,
                 low_freq=low_freq,
                 high_freq=high_freq,
@@ -690,15 +682,13 @@ class Wav2MFCC(Wav2FFT):
         else:
             fb = create_mel_scale(
                 num_filters=num_filters,
-                fft_length=fft_length,
+                fft_length=self.fft_length,
                 sampling_rate=sampling_rate,
                 low_freq=low_freq,
                 high_freq=high_freq,
                 norm_filters=norm_filters,
             )
-        self._fb = nn.Parameter(
-            torch.tensor(fb, dtype=torch.get_default_dtype()), requires_grad=False
-        )
+        self._fb = nn.Parameter(fb, requires_grad=False)
 
         self._dct = nn.Parameter(
             self.make_dct_matrix(self.num_ceps, self.num_filters), requires_grad=False
@@ -898,7 +888,7 @@ def create_mel_scale(
     low_freq: float = 0,
     high_freq: Optional[float] = None,
     norm_filters: bool = True,
-):
+) -> torch.Tensor:
     if high_freq is None or high_freq == 0:
         high_freq = sampling_rate / 2
     if high_freq < 0:
@@ -925,7 +915,7 @@ def create_mel_scale(
     if norm_filters:
         B = B / np.sum(B, axis=0, keepdims=True)
 
-    return B
+    return torch.from_numpy(B)
 
 
 def available_windows() -> List[str]:
@@ -967,3 +957,12 @@ def lin2mel(x):
 
 def mel2lin(x):
     return 700 * (np.exp(x / 1127.0) - 1)
+
+
+def next_power_of_2(x: int) -> int:
+    """
+    Returns the smallest power of 2 that is greater than x.
+
+    Original source: TorchAudio (torchaudio/compliance/kaldi.py)
+    """
+    return 1 if x == 0 else 2 ** (x - 1).bit_length()

--- a/lhotse/features/mfcc.py
+++ b/lhotse/features/mfcc.py
@@ -6,7 +6,7 @@ from lhotse.utils import EPSILON, Seconds
 
 
 @dataclass
-class MfccConfig:
+class TorchaudioMfccConfig:
     # Spectogram-related part
     dither: float = 0.0
     window_type: str = "povey"
@@ -35,16 +35,16 @@ class MfccConfig:
         return asdict(self)
 
     @staticmethod
-    def from_dict(data: Dict[str, Any]) -> "MfccConfig":
-        return MfccConfig(**data)
+    def from_dict(data: Dict[str, Any]) -> "TorchaudioMfccConfig":
+        return TorchaudioMfccConfig(**data)
 
 
 @register_extractor
-class Mfcc(TorchaudioFeatureExtractor):
+class TorchaudioMfcc(TorchaudioFeatureExtractor):
     """MFCC feature extractor based on ``torchaudio.compliance.kaldi.mfcc`` function."""
 
     name = "mfcc"
-    config_type = MfccConfig
+    config_type = TorchaudioMfccConfig
 
     def _feature_fn(self, *args, **kwargs):
         from torchaudio.compliance.kaldi import mfcc

--- a/lhotse/testing/fixtures.py
+++ b/lhotse/testing/fixtures.py
@@ -93,7 +93,9 @@ class RandomCutTestCase:
             ),
         )
         if features:
-            cut = self._with_features(cut, frame_shift=frame_shift)
+            cut = self._with_features(
+                cut, frame_shift=frame_shift, sampling_rate=sampling_rate
+            )
         if supervision:
             cut.supervisions.append(
                 SupervisionSegment(
@@ -111,10 +113,14 @@ class RandomCutTestCase:
             self._with_custom_temporal_array(cut=cut, frame_shift=frame_shift)
         return cut
 
-    def _with_features(self, cut: MonoCut, frame_shift: Seconds) -> MonoCut:
+    def _with_features(
+        self, cut: MonoCut, frame_shift: Seconds, sampling_rate: int
+    ) -> MonoCut:
         d = TemporaryDirectory()
         self.dirs.append(d)
-        extractor = Fbank(config=FbankConfig(frame_shift=frame_shift))
+        extractor = Fbank(
+            config=FbankConfig(sampling_rate=sampling_rate, frame_shift=frame_shift)
+        )
         with LilcomHdf5Writer(d.name) as storage:
             return cut.compute_and_store_features(extractor, storage=storage)
 

--- a/test/cut/test_feature_extraction.py
+++ b/test/cut/test_feature_extraction.py
@@ -12,8 +12,9 @@ import lhotse
 from lhotse import (
     CutSet,
     Fbank,
-    KaldiFbank,
-    KaldiMfcc,
+    FbankConfig,
+    TorchaudioFbank,
+    TorchaudioMfcc,
     KaldifeatFbank,
     KaldifeatMfcc,
     LibrosaFbank,
@@ -52,14 +53,14 @@ def cut(recording):
 
 
 def test_extract_features(cut):
-    extractor = Fbank()
+    extractor = Fbank(FbankConfig(sampling_rate=8000))
     arr = cut.compute_features(extractor=extractor)
     assert arr.shape[0] == 100
     assert arr.shape[1] == extractor.feature_dim(cut.sampling_rate)
 
 
 def test_extract_and_store_features(cut):
-    extractor = Fbank()
+    extractor = Fbank(FbankConfig(sampling_rate=8000))
     with TemporaryDirectory() as tmpdir, LilcomFilesWriter(tmpdir) as storage:
         cut_with_feats = cut.compute_and_store_features(
             extractor=extractor, storage=storage
@@ -72,7 +73,7 @@ def test_extract_and_store_features(cut):
 @pytest.mark.parametrize("mix_eagerly", [False, True])
 def test_extract_and_store_features_from_mixed_cut(cut, mix_eagerly):
     mixed_cut = cut.append(cut)
-    extractor = Fbank()
+    extractor = Fbank(FbankConfig(sampling_rate=8000))
     with TemporaryDirectory() as tmpdir, LilcomFilesWriter(tmpdir) as storage:
         cut_with_feats = mixed_cut.compute_and_store_features(
             extractor=extractor, storage=storage, mix_eagerly=mix_eagerly
@@ -136,7 +137,7 @@ def is_dask_availabe():
 def test_extract_and_store_features_from_cut_set(
     cut_set, executor, num_jobs, storage_type, mix_eagerly
 ):
-    extractor = Fbank()
+    extractor = Fbank(FbankConfig(sampling_rate=8000))
     with TemporaryDirectory() as tmpdir:
         cut_set_with_feats = cut_set.compute_and_store_features(
             extractor=extractor,
@@ -175,8 +176,8 @@ def test_extract_and_store_features_from_cut_set(
     [
         Fbank,
         Mfcc,
-        KaldiFbank,
-        KaldiMfcc,
+        TorchaudioFbank,
+        TorchaudioMfcc,
         pytest.param(
             KaldifeatFbank,
             marks=pytest.mark.skipif(
@@ -278,8 +279,8 @@ def test_cut_set_batch_feature_extraction_resume(cut_set, overwrite):
     [
         Fbank,
         Mfcc,
-        KaldiFbank,
-        KaldiMfcc,
+        TorchaudioFbank,
+        TorchaudioMfcc,
         pytest.param(
             KaldifeatFbank,
             marks=pytest.mark.skipif(

--- a/test/features/test_kaldi_features.py
+++ b/test/features/test_kaldi_features.py
@@ -1,9 +1,9 @@
 import pytest
 import torch
 
-from lhotse import Fbank, Mfcc
+from lhotse import TorchaudioFbank, TorchaudioMfcc
 from lhotse.audio import Recording
-from lhotse.features.kaldi.extractors import KaldiFbank, KaldiMfcc
+from lhotse.features.kaldi.extractors import Fbank, Mfcc
 from lhotse.features.kaldi.layers import Wav2LogFilterBank, Wav2MFCC
 
 
@@ -55,30 +55,30 @@ def test_kaldi_mfcc_layer(recording):
 
 
 def test_kaldi_fbank_extractor(recording):
-    fbank = KaldiFbank()
+    fbank = Fbank()
     feats = fbank.extract(recording.load_audio(), recording.sampling_rate)
     assert feats.shape == (1604, 80)
 
 
 def test_kaldi_fbank_extractor_vs_torchaudio(recording):
     audio = recording.load_audio()
-    fbank = KaldiFbank()
-    fbank_ta = Fbank()
+    fbank = Fbank()
+    fbank_ta = TorchaudioFbank()
     feats = fbank.extract(audio, recording.sampling_rate)
     feats_ta = fbank_ta.extract(audio, recording.sampling_rate)
     torch.testing.assert_allclose(feats, feats_ta)
 
 
 def test_kaldi_mfcc_extractor(recording):
-    mfcc = KaldiMfcc()
+    mfcc = Mfcc()
     feats = mfcc.extract(recording.load_audio(), recording.sampling_rate)
     assert feats.shape == (1604, 13)
 
 
 def test_kaldi_mfcc_extractor_vs_torchaudio(recording):
     audio = recording.load_audio()
-    fbank = KaldiMfcc()
-    fbank_ta = Mfcc()
+    fbank = Mfcc()
+    fbank_ta = TorchaudioMfcc()
     feats = fbank.extract(audio, recording.sampling_rate)
     feats_ta = fbank_ta.extract(audio, recording.sampling_rate)
     torch.testing.assert_allclose(feats, feats_ta)


### PR DESCRIPTION
From the user's point of view, there is only one change -- the default feature extractor now requires the audio sampling rate to be matched. 

I renamed `Fbank` to `TorchaudioFbank` and `KaldiFbank` to `Fbank` (same for MFCC). Since our Fbank and Mfcc have the same numerical results as torchaudio, it makes sense to simply use them as the default ones. For some reason the current implementation is 10-15% faster than torchaudio's on CPU when running examples one-by-one (I think it's because it doesn't recompute the mel filter bands each time). It could be even a bit faster with TorchScript but that breaks the ability to pickle (and use multiprocessing for feature extraction) -- likely not worth the effort to accomodate.