### PR TITLE
Skipping problematic audios - continued

### DIFF
--- a/lhotse/audio.py
+++ b/lhotse/audio.py
@@ -40,9 +40,7 @@ from lhotse.augmentation import (
 from lhotse.caching import dynamic_lru_cache
 from lhotse.serialization import Serializable
 from lhotse.utils import (
-    AudioLoadingError,
     Decibels,
-    DurationMismatchError,
     NonPositiveEnergyError,
     Pathlike,
     Seconds,
@@ -60,7 +58,6 @@ from lhotse.utils import (
 )
 
 Channels = Union[int, List[int]]
-
 
 _DEFAULT_LHOTSE_AUDIO_DURATION_MISMATCH_TOLERANCE: Seconds = 1e-3
 LHOTSE_AUDIO_DURATION_MISMATCH_TOLERANCE: Seconds = (
@@ -1609,3 +1606,11 @@ def read_sph(
         audio = audio.reshape(1, -1) if sf_desc.channels == 1 else audio.T
 
     return audio, sampling_rate
+
+
+class AudioLoadingError(Exception):
+    pass
+
+
+class DurationMismatchError(Exception):
+    pass

--- a/lhotse/audio.py
+++ b/lhotse/audio.py
@@ -40,7 +40,9 @@ from lhotse.augmentation import (
 from lhotse.caching import dynamic_lru_cache
 from lhotse.serialization import Serializable
 from lhotse.utils import (
+    AudioLoadingError,
     Decibels,
+    DurationMismatchError,
     NonPositiveEnergyError,
     Pathlike,
     Seconds,
@@ -196,7 +198,7 @@ class AudioSource:
             if (
                 available_duration < duration - LHOTSE_AUDIO_DURATION_MISMATCH_TOLERANCE
             ):  # set the allowance as 1ms to avoid float error
-                raise ValueError(
+                raise DurationMismatchError(
                     f"Requested more audio ({duration}s) than available ({available_duration}s)"
                 )
 
@@ -1526,8 +1528,8 @@ def read_opus_ffmpeg(
                 f"Unknown channel description from ffmpeg: {channel_string}"
             )
     except ValueError as e:
-        raise ValueError(
-            f"{e}\nThe ffmpeg command for which the program failed is: '{cmd}'"
+        raise AudioLoadingError(
+            f"{e}\nThe ffmpeg command for which the program failed is: '{cmd}', error code: {proc.returncode}"
         )
     return audio, sampling_rate
 

--- a/lhotse/dataset/input_strategies.py
+++ b/lhotse/dataset/input_strategies.py
@@ -103,7 +103,10 @@ class PrecomputedFeatures(BatchIO):
     :class:`InputStrategy` that reads pre-computed features, whose manifests
     are attached to cuts, from disk.
 
-    It pads the feature matrices, if needed.
+    It automatically pads the feature matrices so that every example has the same number
+    of frames as the longest cut in a mini-batch.
+    This is needed to put all examples into a single tensor.
+    The padding value is a low log-energy, around log(1e-10).
 
     .. automethod:: __call__
     """
@@ -175,7 +178,9 @@ class AudioSamples(BatchIO):
     :class:`InputStrategy` that reads single-channel recordings, whose manifests
     are attached to cuts, from disk (or other audio source).
 
-    It pads the recordings, if needed.
+    It automatically zero-pads the recordings so that every example has the same number
+    of audio samples as the longest cut in a mini-batch.
+    This is needed to put all examples into a single tensor.
 
     .. automethod:: __call__
     """
@@ -276,7 +281,10 @@ class OnTheFlyFeatures(BatchIO):
     are attached to cuts, from disk (or other audio source).
     Then, it uses a :class:`FeatureExtractor` to compute their features on-the-fly.
 
-    It pads the recordings, if needed.
+    It automatically pads the feature matrices so that every example has the same number
+    of frames as the longest cut in a mini-batch.
+    This is needed to put all examples into a single tensor.
+    The padding value is a low log-energy, around log(1e-10).
 
     .. note:
         The batch feature extraction performed here is not as efficient as it could be,

--- a/lhotse/dataset/speech_recognition.py
+++ b/lhotse/dataset/speech_recognition.py
@@ -110,7 +110,14 @@ class K2SpeechRecognitionDataset(torch.utils.data.Dataset):
 
         # Get a tensor with batched feature matrices, shape (B, T, F)
         # Collation performs auto-padding, if necessary.
-        inputs, _ = self.input_strategy(cuts)
+        input_tpl = self.input_strategy(cuts)
+        if len(input_tpl) == 3:
+            # An input strategy with fault tolerant audio reading mode.
+            # "cuts" may be a subset of the original "cuts" variable,
+            # that only has cuts for which we succesfully read the audio.
+            inputs, _, cuts = input_tpl
+        else:
+            inputs, _ = input_tpl
 
         # Get a dict of tensors that encode the positional information about supervisions
         # in the batch of feature matrices. The tensors are named "sequence_idx",

--- a/lhotse/dataset/unsupervised.py
+++ b/lhotse/dataset/unsupervised.py
@@ -22,6 +22,7 @@ class UnsupervisedDataset(torch.utils.data.Dataset):
             'features_lens': (B, ) tensor
         }
     """
+
     def __init__(self) -> None:
         super().__init__()
 
@@ -54,6 +55,7 @@ class UnsupervisedWaveformDataset(UnsupervisedDataset):
             'audio_lens': (B, ) int tensor
         }
     """
+
     def __init__(self, collate: bool = True) -> None:
         super().__init__()
         self.collate = collate
@@ -83,10 +85,7 @@ class UnsupervisedWaveformDataset(UnsupervisedDataset):
                         f"DurationMismatchError for {c} \nError messages: {e} \nSkipping this cut."
                     )
                     continue
-            return {
-                "cuts": CutSet.from_cuts(remain_cuts),
-                "audio": remain_audios
-            }
+            return {"cuts": CutSet.from_cuts(remain_cuts), "audio": remain_audios}
 
     def _validate(self, cuts: CutSet) -> None:
         validate(cuts)
@@ -102,6 +101,7 @@ class DynamicUnsupervisedDataset(UnsupervisedDataset):
     and ``UnsupervisedDataset`` does that in the feature domain.
     Cuts that are not mixed will yield identical results in both dataset classes.
     """
+
     def __init__(
         self,
         feature_extractor: FeatureExtractor,

--- a/lhotse/utils.py
+++ b/lhotse/utils.py
@@ -639,18 +639,21 @@ class suppress_and_warn:
     After the exception is suppressed, execution proceeds with the next
     statement following the with statement.
 
-         with warn_and_suppress(FileNotFoundError):
-             os.remove(somefile)
-         # Execution still resumes here if the file was already removed
+         >>> with suppress_and_warn(FileNotFoundError):
+         ...     os.remove(somefile)
+         >>> # Execution still resumes here if the file was already removed
     """
 
-    def __init__(self, *exceptions):
+    def __init__(self, *exceptions, enabled: bool = True):
+        self._enabled = enabled
         self._exceptions = exceptions
 
     def __enter__(self):
         pass
 
     def __exit__(self, exctype, excinst, exctb):
+        if not self._enabled:
+            return
         # Returning True from __exit__ in a context manager tells Python
         # to suppress an exception.
         should_suppress = exctype is not None and issubclass(exctype, self._exceptions)

--- a/lhotse/utils.py
+++ b/lhotse/utils.py
@@ -632,3 +632,11 @@ def deprecated(message):
         return wrapper
 
     return decorator
+
+
+class AudioLoadingError(Exception):
+    pass
+
+
+class DurationMismatchError(Exception):
+    pass

--- a/test/dataset/test_collation.py
+++ b/test/dataset/test_collation.py
@@ -61,6 +61,18 @@ def test_collate_audio_padding():
     assert max(audio_lens).item() == correct_pad
 
 
+def test_collate_audio_padding_fault_tolerant_return_vals():
+    cuts = CutSet.from_json("test/fixtures/ljspeech/cuts.json")
+    assert len(set(cut.num_samples for cut in cuts)) > 1
+
+    correct_pad = max(cut.num_samples for cut in cuts)
+    audio, audio_lens, cuts_ok = collate_audio(cuts, fault_tolerant=True)
+
+    assert len(cuts) == len(cuts_ok)
+    assert audio.shape[-1] == correct_pad
+    assert max(audio_lens).item() == correct_pad
+
+
 def test_collate_feature_padding():
     cuts = CutSet.from_json("test/fixtures/ljspeech/cuts.json")
     assert len(set(cut.num_frames for cut in cuts)) > 1

--- a/test/dataset/test_speech_recognition_dataset.py
+++ b/test/dataset/test_speech_recognition_dataset.py
@@ -162,13 +162,16 @@ def test_extra_padding_transform(k2_cut_set):
 
 
 @pytest.mark.parametrize("use_batch_extract", [True, False])
+@pytest.mark.parametrize("fault_tolerant", [True, False])
 def test_k2_speech_recognition_on_the_fly_feature_extraction(
-    k2_cut_set, use_batch_extract
+    k2_cut_set, use_batch_extract, fault_tolerant
 ):
     precomputed_dataset = K2SpeechRecognitionDataset()
     on_the_fly_dataset = K2SpeechRecognitionDataset(
         input_strategy=OnTheFlyFeatures(
-            Fbank(FbankConfig(num_mel_bins=40)), use_batch_extract=use_batch_extract
+            Fbank(FbankConfig(num_mel_bins=40)),
+            use_batch_extract=use_batch_extract,
+            fault_tolerant=fault_tolerant,
         )
     )
     sampler = SingleCutSampler(k2_cut_set, shuffle=False, max_cuts=1)

--- a/test/test_recording_set.py
+++ b/test/test_recording_set.py
@@ -6,7 +6,13 @@ import numpy as np
 import pytest
 from pytest import mark, raises
 
-from lhotse.audio import AudioMixer, AudioSource, Recording, RecordingSet
+from lhotse.audio import (
+    AudioMixer,
+    AudioSource,
+    Recording,
+    RecordingSet,
+    DurationMismatchError,
+)
 from lhotse.testing.dummies import DummyManifest
 from lhotse.utils import INT16MAX
 from lhotse.utils import fastcopy, nullcontext as does_not_raise
@@ -111,7 +117,7 @@ def test_get_audio_multichannel(
             10.0,
             "irrelevant",
             "irrelevant",
-            raises(ValueError),
+            raises(DurationMismatchError),
         ),  # requested more audio than available
     ],
 )


### PR DESCRIPTION
Hey @pkufool,

it took me a while to get back to this, but I finally found a way to fully support what you started building in #513. I set up a new PR based on your branch + some modifications from me. 

The core idea is to allow `read_audio_from_cuts`, `collate_audio`, `AudioSamples`, and `OnTheFlyFeatures` to return a reduced CutSet in addition to the collated tensors. Since this change is possibly breaking to other users, I added a flag `fault_tolerant` that controls whether this additional CutSet is returned or not. It's `False` by default, so existing users will not observe any change, but if you flip it to `True`, `K2SpeechRecognitionDataset` will do the right thing. It is a bit messy but I did not see a more elegant way to integrate that change.

LMK if this helps.