### PR TITLE
Rename `SingleCutSampler` -> `SimpleCutSampler`

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ A short snippet to show how Lhotse can make audio data prepartion quick and easy
 ```python
 from torch.utils.data import DataLoader
 from lhotse import CutSet, Fbank
-from lhotse.dataset import VadDataset, SingleCutSampler
+from lhotse.dataset import VadDataset, SimpleCutSampler
 from lhotse.recipes import prepare_switchboard
 
 # Prepare data manifests from a raw corpus distribution.
@@ -133,7 +133,7 @@ cuts = cuts.compute_and_store_features(
 
 # Construct a Pytorch Dataset class for Voice Activity Detection task:
 dataset = VadDataset(cuts)
-sampler = SingleCutSampler(cuts)
+sampler = SimpleCutSampler(cuts, max_duration=300)
 dataloader = DataLoader(dataset, sampler=sampler, batch_size=None)
 batch = next(iter(dataloader))
 ```

--- a/docs/datasets.rst
+++ b/docs/datasets.rst
@@ -28,7 +28,7 @@ It allows for interesting collation methods - e.g. **padding the speech with noi
 
 The items for mini-batch creation are selected by the ``Sampler``.
 Lhotse defines ``Sampler`` classes that are initialized with :class:`~lhotse.cut.CutSet`'s, so that they can look up specific properties of an utterance to stratify the sampling.
-For example, :class:`~lhotse.dataset.sampling.SingleCutSampler` has a defined ``max_frames`` attribute, and it will keep sampling cuts for a batch until they do not exceed the specified number of frames.
+For example, :class:`~lhotse.dataset.sampling.SimpleCutSampler` has a defined ``max_frames`` attribute, and it will keep sampling cuts for a batch until they do not exceed the specified number of frames.
 Another strategy — used in :class:`~lhotse.dataset.sampling.BucketingSampler` — will first group the cuts of similar durations into buckets, and then randomly select a bucket to draw the whole batch from.
 
 For tasks where both input and output of the model are speech utterances, we can use the :class:`~lhotse.dataset.sampling.CutPairsSampler`, which accepts two :class:`~lhotse.cut.CutSet`'s and will match the cuts in them by their IDs.
@@ -38,11 +38,11 @@ A typical Lhotse's dataset API usage might look like this:
 .. code-block::
 
     from torch.utils.data import DataLoader
-    from lhotse.dataset import SpeechRecognitionDataset, SingleCutSampler
+    from lhotse.dataset import SpeechRecognitionDataset, SimpleCutSampler
 
     cuts = CutSet(...)
     dset = SpeechRecognitionDataset(cuts)
-    sampler = SingleCutSampler(cuts, max_frames=50000)
+    sampler = SimpleCutSampler(cuts, max_frames=50000)
     # Dataset performs batching by itself, so we have to indicate that
     # to the DataLoader with batch_size=None
     dloader = DataLoader(dset, sampler=sampler, batch_size=None, num_workers=1)

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -86,7 +86,7 @@ A short snippet to show how Lhotse can make audio data preparation quick and eas
 
     from torch.utils.data import DataLoader
     from lhotse import CutSet, Fbank
-    from lhotse.dataset import VadDataset, SingleCutSampler
+    from lhotse.dataset import VadDataset, SimpleCutSampler
     from lhotse.recipes import prepare_switchboard
 
     # Prepare data manifests from a raw corpus distribution.
@@ -116,7 +116,7 @@ A short snippet to show how Lhotse can make audio data preparation quick and eas
 
     # Construct a Pytorch Dataset class for Voice Activity Detection task:
     dataset = VadDataset(cuts)
-    sampler = SingleCutSampler(cuts)
+    sampler = SimpleCutSampler(cuts, max_duration=300)
     dataloader = DataLoader(dataset, sampler=sampler, batch_size=None)
     batch = next(iter(dataloader))
 

--- a/examples/ami/ami.ipynb
+++ b/examples/ami/ami.ipynb
@@ -15,7 +15,7 @@
     "from lhotse.recipes.ami import download_ami, prepare_ami\n",
     "from lhotse.features import Fbank, FeatureSetBuilder\n",
     "from lhotse.cut import CutSet\n",
-    "from lhotse.dataset.sampling import SingleCutSampler\n",
+    "from lhotse.dataset.sampling import SimpleCutSampler\n",
     "from lhotse.dataset.speech_recognition import K2SpeechRecognitionDataset\n",
     "from lhotse.dataset.vad import VadDataset"
    ]
@@ -123,7 +123,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sampler = SingleCutSampler(asr_dataset.cuts, shuffle=False, max_cuts=4)\n",
+    "sampler = SimpleCutSampler(asr_dataset.cuts, shuffle=False, max_cuts=4)\n",
     "cut_ids = next(iter(sampler))"
    ]
   },
@@ -206,7 +206,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sampler = SingleCutSampler(vad_dataset.cuts, shuffle=False, max_cuts=4)\n",
+    "sampler = SimpleCutSampler(vad_dataset.cuts, shuffle=False, max_cuts=4)\n",
     "cut_ids = next(iter(sampler))"
    ]
   },

--- a/examples/gigaspeech/gigaspeech.ipynb
+++ b/examples/gigaspeech/gigaspeech.ipynb
@@ -16,7 +16,7 @@
     "from lhotse import CutSet, Fbank, LilcomFilesWriter\n",
     "from lhotse.augmentation import SoxEffectTransform, RandomValue\n",
     "from lhotse.dataset import K2SpeechRecognitionDataset\n",
-    "from lhotse.dataset.sampling import SingleCutSampler\n",
+    "from lhotse.dataset.sampling import SimpleCutSampler\n",
     "from lhotse.recipes.gigaspeech import download_gigaspeech, prepare_gigaspeech"
    ]
   },
@@ -223,7 +223,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sampler = SingleCutSampler(dataset_test.cuts, shuffle=False, max_cuts=4)\n",
+    "sampler = SimpleCutSampler(dataset_test.cuts, shuffle=False, max_cuts=4)\n",
     "cut_id = next(iter(sampler))[0]\n",
     "sample = dataset_test[[cut_id]]"
    ]

--- a/examples/librispeech/librispeech.ipynb
+++ b/examples/librispeech/librispeech.ipynb
@@ -16,7 +16,7 @@
     "from lhotse import CutSet, Fbank, LilcomFilesWriter\n",
     "from lhotse.augmentation import SoxEffectTransform, RandomValue, pitch, reverb, speed\n",
     "from lhotse.dataset import K2SpeechRecognitionDataset\n",
-    "from lhotse.dataset.sampling import SingleCutSampler\n",
+    "from lhotse.dataset.sampling import SimpleCutSampler\n",
     "from lhotse.recipes.librispeech import download_librispeech, prepare_librispeech"
    ]
   },
@@ -198,7 +198,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sampler = SingleCutSampler(dataset_dev.cuts, shuffle=False, max_cuts=4)\n",
+    "sampler = SimpleCutSampler(dataset_dev.cuts, shuffle=False, max_cuts=4)\n",
     "cut_ids = next(iter(sampler))\n",
     "sample = dataset_dev[cut_ids]"
    ]

--- a/lhotse/dataset/sampling/__init__.py
+++ b/lhotse/dataset/sampling/__init__.py
@@ -2,6 +2,6 @@ from .bucketing import BucketingSampler
 from .cut_pairs import CutPairsSampler
 from .data_source import streaming_shuffle
 from .dynamic_bucketing import DynamicBucketingSampler
-from .single_cut import SingleCutSampler
+from .simple import SimpleCutSampler, SingleCutSampler
 from .utils import find_pessimistic_batches
 from .zip import ZipSampler

--- a/lhotse/dataset/sampling/base.py
+++ b/lhotse/dataset/sampling/base.py
@@ -33,7 +33,7 @@ class CutSampler(Sampler):
     Example usage::
 
         >>> dataset = K2SpeechRecognitionDataset(cuts)
-        >>> sampler = SingleCutSampler(cuts, max_duration=200, shuffle=True)
+        >>> sampler = SimpleCutSampler(cuts, max_duration=200, shuffle=True)
         >>> loader = DataLoader(dataset, sampler=sampler, batch_size=None)
         >>> for epoch in range(start_epoch, n_epochs):
         ...     sampler.set_epoch(epoch)
@@ -117,7 +117,7 @@ class CutSampler(Sampler):
 
         Example:
             >>> cuts = CutSet(...)
-            ... sampler = SingleCutSampler(cuts, max_duration=100.0)
+            ... sampler = SimpleCutSampler(cuts, max_duration=100.0)
             ... # Retain only the cuts that have at least 1s and at most 20s duration.
             ... sampler.filter(lambda cut: 1.0 <= cut.duration <= 20.0)
         """

--- a/lhotse/dataset/sampling/bucketing.py
+++ b/lhotse/dataset/sampling/bucketing.py
@@ -12,13 +12,13 @@ from typing_extensions import Literal
 from lhotse import CutSet
 from lhotse.cut import Cut
 from lhotse.dataset.sampling.base import CutSampler
-from lhotse.dataset.sampling.single_cut import SingleCutSampler
+from lhotse.dataset.sampling.simple import SimpleCutSampler
 
 
 class BucketingSampler(CutSampler):
     """
     Sorts the cuts in a :class:`CutSet` by their duration and puts them into similar duration buckets.
-    For each bucket, it instantiates a simpler sampler instance, e.g. :class:`SingleCutSampler`.
+    For each bucket, it instantiates a simpler sampler instance, e.g. :class:`SimpleCutSampler`.
 
     It behaves like an iterable that yields lists of strings (cut IDs).
     During iteration, it randomly selects one of the buckets to yield the batch from,
@@ -31,8 +31,8 @@ class BucketingSampler(CutSampler):
         >>> sampler = BucketingSampler(
         ...    cuts,
         ...    # BucketingSampler specific args
-        ...    sampler_type=SingleCutSampler, num_buckets=20,
-        ...    # Args passed into SingleCutSampler
+        ...    sampler_type=SimpleCutSampler, num_buckets=20,
+        ...    # Args passed into SimpleCutSampler
         ...    max_frames=20000
         ... )
 
@@ -50,7 +50,7 @@ class BucketingSampler(CutSampler):
     def __init__(
         self,
         *cuts: CutSet,
-        sampler_type: Type = SingleCutSampler,
+        sampler_type: Type = SimpleCutSampler,
         num_buckets: int = 10,
         bucket_method: Literal["equal_len", "equal_duration"] = "equal_len",
         drop_last: bool = False,
@@ -190,7 +190,7 @@ class BucketingSampler(CutSampler):
 
         Example:
             >>> cuts = CutSet(...)
-            ... sampler = SingleCutSampler(cuts, max_duration=100.0)
+            ... sampler = SimpleCutSampler(cuts, max_duration=100.0)
             ... # Retain only the cuts that have at least 1s and at most 20s duration.
             ... sampler.filter(lambda cut: 1.0 <= cut.duration <= 20.0)
         """

--- a/lhotse/dataset/sampling/dynamic_bucketing.py
+++ b/lhotse/dataset/sampling/dynamic_bucketing.py
@@ -324,7 +324,7 @@ class DynamicBucketer:
             pass
 
 
-# Note: this class is a subset of SingleCutSampler and is "datapipes" ready.
+# Note: this class is a subset of SimpleCutSampler and is "datapipes" ready.
 class DurationBatcher:
     def __init__(
         self,

--- a/lhotse/dataset/sampling/simple.py
+++ b/lhotse/dataset/sampling/simple.py
@@ -7,7 +7,7 @@ from lhotse.dataset.sampling.data_source import DataSource
 from lhotse.utils import is_none_or_gt
 
 
-class SingleCutSampler(CutSampler):
+class SimpleCutSampler(CutSampler):
     """
     Samples cuts from a CutSet to satisfy the input constraints.
     It behaves like an iterable that yields lists of strings (cut IDs).
@@ -20,7 +20,7 @@ class SingleCutSampler(CutSampler):
     Example usage::
 
         >>> dataset = K2SpeechRecognitionDataset(cuts)
-        >>> sampler = SingleCutSampler(cuts, shuffle=True)
+        >>> sampler = SimpleCutSampler(cuts, shuffle=True)
         >>> loader = DataLoader(dataset, sampler=sampler, batch_size=None)
         >>> for epoch in range(start_epoch, n_epochs):
         ...     sampler.set_epoch(epoch)
@@ -42,7 +42,7 @@ class SingleCutSampler(CutSampler):
         seed: int = 0,
     ):
         """
-        SingleCutSampler's constructor.
+        SimpleCutSampler's constructor.
 
         :param cuts: the ``CutSet`` to sample data from.
         :param max_frames: The maximum total number of feature frames from ``cuts``.
@@ -142,7 +142,7 @@ class SingleCutSampler(CutSampler):
         time_constraint = TimeConstraint(**state_dict.pop("time_constraint"))
         if self.time_constraint != time_constraint:
             warnings.warn(
-                "SingleCutSampler.load_state_dict(): Inconsistent time_constraint:\n"
+                "SimpleCutSampler.load_state_dict(): Inconsistent time_constraint:\n"
                 f"expected {self.time_constraint}\n"
                 f"received {time_constraint}\n"
                 f"We will overwrite the settings with the received state_dict."
@@ -152,7 +152,7 @@ class SingleCutSampler(CutSampler):
         max_cuts = state_dict.pop("max_cuts")
         if self.max_cuts != max_cuts:
             warnings.warn(
-                "SingleCutSampler.load_state_dict(): Inconsistent max_cuts:\n"
+                "SimpleCutSampler.load_state_dict(): Inconsistent max_cuts:\n"
                 f"expected {self.max_cuts}\n"
                 f"received {max_cuts}\n"
                 f"We will overwrite the settings with the received state_dict."
@@ -166,7 +166,7 @@ class SingleCutSampler(CutSampler):
             self.data_source.shuffle(self.seed + self.epoch)
         self.data_source.fast_forward(self.diagnostics.total_cuts)
 
-    def __iter__(self) -> "SingleCutSampler":
+    def __iter__(self) -> "SimpleCutSampler":
         """
         Prepare the dataset for iterating over a new epoch. Will shuffle the data if requested.
         """
@@ -244,3 +244,14 @@ class SingleCutSampler(CutSampler):
 
         self.diagnostics.keep(cuts)
         return CutSet.from_cuts(cuts)
+
+
+class SingleCutSampler(SimpleCutSampler):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        warnings.warn(
+            "SingleCutSampler was renamed to SimpleCutSampler in Lhotse v1.0 to avoid confusion "
+            "(the previous name suggested it sampled a single cut rather than a batch of cuts). "
+            "The alias 'SingleCutSampler' is deprecated and will be removed in Lhotse v1.1",
+            category=DeprecationWarning
+        )

--- a/lhotse/dataset/sampling/utils.py
+++ b/lhotse/dataset/sampling/utils.py
@@ -25,7 +25,7 @@ def find_pessimistic_batches(
     Example of how this function can be used with a PyTorch model
     and a :class:`~lhotse.dataset.K2SpeechRecognitionDataset`::
 
-        sampler = SingleCutSampler(cuts, max_duration=300)
+        sampler = SimpleCutSampler(cuts, max_duration=300)
         dataset = K2SpeechRecognitionDataset()
         batches, scores = find_pessimistic_batches(sampler)
         for reason, cuts in batches.items():

--- a/lhotse/dataset/sampling/zip.py
+++ b/lhotse/dataset/sampling/zip.py
@@ -22,8 +22,8 @@ class ZipSampler(CutSampler):
     Example::
 
         >>> sampler = ZipSampler(
-        ...     SingleCutSampler(cuts_corpusA, max_duration=250, shuffle=True),
-        ...     SingleCutSampler(cuts_corpusB, max_duration=100, shuffle=True),
+        ...     SimpleCutSampler(cuts_corpusA, max_duration=250, shuffle=True),
+        ...     SimpleCutSampler(cuts_corpusB, max_duration=100, shuffle=True),
         ... )
         >>> for cut in sampler:
         ...     pass  # profit
@@ -146,7 +146,7 @@ class ZipSampler(CutSampler):
             # different sources of cuts in any different way.
             #
             # Note: merging batches is tricky because the samplers can be either
-            # SingleCutSampler or CutPairsSampler, and we need to handle them differently.
+            # SimpleCutSampler or CutPairsSampler, and we need to handle them differently.
             cuts: List[Union[CutSet, Tuple[CutSet]]] = []
             for sampler in self.samplers:
                 batch = next(sampler)
@@ -195,7 +195,7 @@ class ZipSampler(CutSampler):
 
         Example:
             >>> cuts = CutSet(...)
-            ... sampler = SingleCutSampler(cuts, max_duration=100.0)
+            ... sampler = SimpleCutSampler(cuts, max_duration=100.0)
             ... # Retain only the cuts that have at least 1s and at most 20s duration.
             ... sampler.filter(lambda cut: 1.0 <= cut.duration <= 20.0)
         """

--- a/lhotse/dataset/speech_recognition.py
+++ b/lhotse/dataset/speech_recognition.py
@@ -18,7 +18,7 @@ class K2SpeechRecognitionDataset(torch.utils.data.Dataset):
     for which it loads features and automatically collates/batches them.
 
     To use it with a PyTorch DataLoader, set ``batch_size=None``
-    and provide a :class:`SingleCutSampler` sampler.
+    and provide a :class:`SimpleCutSampler` sampler.
 
     Each item in this dataset is a dict of:
 

--- a/test/dataset/sampling/test_sampler_pickling.py
+++ b/test/dataset/sampling/test_sampler_pickling.py
@@ -8,7 +8,7 @@ from lhotse.dataset import (
     BucketingSampler,
     CutPairsSampler,
     DynamicBucketingSampler,
-    SingleCutSampler,
+    SimpleCutSampler,
     ZipSampler,
 )
 from lhotse.testing.dummies import DummyManifest
@@ -17,11 +17,11 @@ CUTS = DummyManifest(CutSet, begin_id=0, end_id=100)
 CUTS_MOD = CUTS.modify_ids(lambda cid: cid + "_alt")
 
 SAMPLERS_TO_TEST = [
-    SingleCutSampler(CUTS, max_duration=10.0, shuffle=True, drop_last=True),
+    SimpleCutSampler(CUTS, max_duration=10.0, shuffle=True, drop_last=True),
     CutPairsSampler(CUTS, CUTS, max_source_duration=10.0, shuffle=True, drop_last=True),
     ZipSampler(
-        SingleCutSampler(CUTS, max_duration=10.0, shuffle=True, drop_last=True),
-        SingleCutSampler(CUTS_MOD, max_duration=10.0, shuffle=True, drop_last=True),
+        SimpleCutSampler(CUTS, max_duration=10.0, shuffle=True, drop_last=True),
+        SimpleCutSampler(CUTS_MOD, max_duration=10.0, shuffle=True, drop_last=True),
     ),
     ZipSampler(
         CutPairsSampler(

--- a/test/dataset/test_dataloading.py
+++ b/test/dataset/test_dataloading.py
@@ -4,7 +4,7 @@ import pytest
 from packaging.version import parse as _version
 
 from lhotse.cut import CutSet
-from lhotse.dataset import SingleCutSampler, UnsupervisedDataset
+from lhotse.dataset import SimpleCutSampler, UnsupervisedDataset
 from lhotse.dataset.dataloading import LhotseDataLoader
 
 
@@ -22,7 +22,7 @@ def cuts():
     reason="LhotseDataLoader requires Python 3.7+",
 )
 def test_lhotse_dataloader_runs(cuts):
-    sampler = SingleCutSampler(cuts, max_cuts=2)
+    sampler = SimpleCutSampler(cuts, max_cuts=2)
     dloader = LhotseDataLoader(UnsupervisedDataset(), sampler, num_workers=2)
     batches = list(dloader)
     assert len(batches) == 50

--- a/test/dataset/test_speech_recognition_dataset_randomized.py
+++ b/test/dataset/test_speech_recognition_dataset_randomized.py
@@ -5,7 +5,7 @@ from torch.utils.data import DataLoader
 from lhotse import CutSet
 from lhotse.dataset import K2SpeechRecognitionDataset
 from lhotse.dataset.cut_transforms import CutConcatenate
-from lhotse.dataset.sampling import SingleCutSampler
+from lhotse.dataset.sampling import SimpleCutSampler
 from lhotse.testing.fixtures import RandomCutTestCase
 
 
@@ -57,7 +57,7 @@ class TestCollationRandomized(RandomCutTestCase):
             return_cuts=True,
             cut_transforms=[CutConcatenate(duration_factor=3.0)],
         )
-        sampler = SingleCutSampler(
+        sampler = SimpleCutSampler(
             mixed_cuts,
             shuffle=False,
         )


### PR DESCRIPTION
It was pointed out that the name was confusing, suggesting we only sample a single cut instead of a mini-batch.

The old name is retained as a deprecated alias, to be removed in Lhotse v1.1