### PR TITLE
`lhotse split-lazy` and `CutSet.split_lazy()` for memory-efficient splits

### DIFF
--- a/lhotse/audio.py
+++ b/lhotse/audio.py
@@ -54,6 +54,7 @@ from lhotse.utils import (
     index_by_id_and_check,
     perturb_num_samples,
     rich_exception_info,
+    split_manifest_lazy,
     split_sequence,
 )
 
@@ -769,6 +770,25 @@ class RecordingSet(Serializable, Sequence[Recording]):
                 self, num_splits=num_splits, shuffle=shuffle, drop_last=drop_last
             )
         ]
+
+    def split_lazy(self, output_dir: Pathlike, chunk_size: int) -> List["RecordingSet"]:
+        """
+        Splits a manifest (either lazily or eagerly opened) into chunks, each
+        with ``chunk_size`` items (except for the last one, typically).
+
+        In order to be memory efficient, this implementation saves each chunk
+        to disk in a ``.jsonl.gz`` format as the input manifest is sampled.
+
+        .. note:: For lowest memory usage, use ``load_manifest_lazy`` to open the
+            input manifest for this method.
+
+        :param it: any iterable of Lhotse manifests.
+        :param output_dir: directory where the split manifests are saved.
+            Each manifest is saved at: ``{output_dir}/{split_idx}.jsonl.gz``
+        :param chunk_size: the number of items in each chunk.
+        :return: a list of lazily opened chunk manifests.
+        """
+        return split_manifest_lazy(self, output_dir=output_dir, chunk_size=chunk_size)
 
     def subset(
         self, first: Optional[int] = None, last: Optional[int] = None

--- a/lhotse/bin/modes/manipulation.py
+++ b/lhotse/bin/modes/manipulation.py
@@ -229,10 +229,10 @@ def subset(
 @click.argument("output_manifest", type=click.Path())
 def combine(manifests: Pathlike, output_manifest: Pathlike):
     """Load MANIFESTS, combine them into a single one, and write it to OUTPUT_MANIFEST."""
-    from lhotse import load_manifest
+    from lhotse.serialization import load_manifest_lazy_or_eager
     from lhotse.manipulation import combine as combine_manifests
 
-    data_set = combine_manifests(*[load_manifest(m) for m in manifests])
+    data_set = combine_manifests(*[load_manifest_lazy_or_eager(m) for m in manifests])
     data_set.to_file(output_manifest)
 
 

--- a/lhotse/bin/modes/manipulation.py
+++ b/lhotse/bin/modes/manipulation.py
@@ -140,19 +140,41 @@ def copy_feats_worker(
 def split(num_splits: int, manifest: Pathlike, output_dir: Pathlike, shuffle: bool):
     """
     Load MANIFEST, split it into NUM_SPLITS equal parts and save as separate manifests in OUTPUT_DIR.
+
+    When your manifests are very large, prefer to use "lhotse split-lazy" instead.
     """
-    from lhotse import load_manifest
+    from lhotse.serialization import load_manifest_lazy_or_eager
 
     output_dir = Path(output_dir)
     manifest = Path(manifest)
     suffix = "".join(manifest.suffixes)
-    any_set = load_manifest(manifest)
+    any_set = load_manifest_lazy_or_eager(manifest)
     parts = any_set.split(num_splits=num_splits, shuffle=shuffle)
     output_dir.mkdir(parents=True, exist_ok=True)
     num_digits = len(str(num_splits))
     for idx, part in enumerate(parts):
         idx = f"{idx + 1}".zfill(num_digits)
         part.to_file((output_dir / manifest.stem).with_suffix(f".{idx}{suffix}"))
+
+
+@cli.command()
+@click.argument("manifest", type=click.Path(exists=True, dir_okay=False))
+@click.argument("output_dir", type=click.Path())
+@click.argument("chunk_size", type=int)
+def split_lazy(manifest: Pathlike, output_dir: Pathlike, chunk_size: int):
+    """
+    Load MANIFEST (lazily if in JSONL format) and split it into parts,
+    each with CHUNK_SIZE items.
+    The parts are saved to separate files with pattern "{output_dir}/{chunk_idx}.jsonl.gz".
+
+    Prefer this to "lhotse split" when your manifests are very large.
+    """
+    from lhotse.serialization import load_manifest_lazy_or_eager
+
+    output_dir = Path(output_dir)
+    manifest = Path(manifest)
+    any_set = load_manifest_lazy_or_eager(manifest)
+    any_set.split_lazy(output_dir=output_dir, chunk_size=chunk_size)
 
 
 @cli.command()

--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -68,6 +68,7 @@ from lhotse.utils import (
     overspans,
     perturb_num_samples,
     rich_exception_info,
+    split_manifest_lazy,
     split_sequence,
     uuid4,
 )
@@ -3275,6 +3276,25 @@ class CutSet(Serializable, Sequence[Cut]):
                 self, num_splits=num_splits, shuffle=shuffle, drop_last=drop_last
             )
         ]
+
+    def split_lazy(self, output_dir: Pathlike, chunk_size: int) -> List["CutSet"]:
+        """
+        Splits a manifest (either lazily or eagerly opened) into chunks, each
+        with ``chunk_size`` items (except for the last one, typically).
+
+        In order to be memory efficient, this implementation saves each chunk
+        to disk in a ``.jsonl.gz`` format as the input manifest is sampled.
+
+        .. note:: For lowest memory usage, use ``load_manifest_lazy`` to open the
+            input manifest for this method.
+
+        :param it: any iterable of Lhotse manifests.
+        :param output_dir: directory where the split manifests are saved.
+            Each manifest is saved at: ``{output_dir}/{split_idx}.jsonl.gz``
+        :param chunk_size: the number of items in each chunk.
+        :return: a list of lazily opened chunk manifests.
+        """
+        return split_manifest_lazy(self, output_dir=output_dir, chunk_size=chunk_size)
 
     def subset(
         self,

--- a/lhotse/features/base.py
+++ b/lhotse/features/base.py
@@ -26,6 +26,7 @@ from lhotse.utils import (
     exactly_one_not_null,
     fastcopy,
     ifnone,
+    split_manifest_lazy,
     split_sequence,
     uuid4,
 )
@@ -575,6 +576,25 @@ class FeatureSet(Serializable, Sequence[Features]):
                 self, num_splits=num_splits, shuffle=shuffle, drop_last=drop_last
             )
         ]
+
+    def split_lazy(self, output_dir: Pathlike, chunk_size: int) -> List["FeatureSet"]:
+        """
+        Splits a manifest (either lazily or eagerly opened) into chunks, each
+        with ``chunk_size`` items (except for the last one, typically).
+
+        In order to be memory efficient, this implementation saves each chunk
+        to disk in a ``.jsonl.gz`` format as the input manifest is sampled.
+
+        .. note:: For lowest memory usage, use ``load_manifest_lazy`` to open the
+            input manifest for this method.
+
+        :param it: any iterable of Lhotse manifests.
+        :param output_dir: directory where the split manifests are saved.
+            Each manifest is saved at: ``{output_dir}/{split_idx}.jsonl.gz``
+        :param chunk_size: the number of items in each chunk.
+        :return: a list of lazily opened chunk manifests.
+        """
+        return split_manifest_lazy(self, output_dir=output_dir, chunk_size=chunk_size)
 
     def subset(
         self, first: Optional[int] = None, last: Optional[int] = None

--- a/lhotse/supervision.py
+++ b/lhotse/supervision.py
@@ -28,6 +28,7 @@ from lhotse.utils import (
     index_by_id_and_check,
     overspans,
     perturb_num_samples,
+    split_manifest_lazy,
     split_sequence,
 )
 
@@ -606,6 +607,27 @@ class SupervisionSet(Serializable, Sequence[SupervisionSegment]):
                 self, num_splits=num_splits, shuffle=shuffle, drop_last=drop_last
             )
         ]
+
+    def split_lazy(
+        self, output_dir: Pathlike, chunk_size: int
+    ) -> List["SupervisionSet"]:
+        """
+        Splits a manifest (either lazily or eagerly opened) into chunks, each
+        with ``chunk_size`` items (except for the last one, typically).
+
+        In order to be memory efficient, this implementation saves each chunk
+        to disk in a ``.jsonl.gz`` format as the input manifest is sampled.
+
+        .. note:: For lowest memory usage, use ``load_manifest_lazy`` to open the
+            input manifest for this method.
+
+        :param it: any iterable of Lhotse manifests.
+        :param output_dir: directory where the split manifests are saved.
+            Each manifest is saved at: ``{output_dir}/{split_idx}.jsonl.gz``
+        :param chunk_size: the number of items in each chunk.
+        :return: a list of lazily opened chunk manifests.
+        """
+        return split_manifest_lazy(self, output_dir=output_dir, chunk_size=chunk_size)
 
     def subset(
         self, first: Optional[int] = None, last: Optional[int] = None

--- a/lhotse/utils.py
+++ b/lhotse/utils.py
@@ -1,10 +1,10 @@
 import functools
-import logging
 import inspect
-import warnings
+import logging
 import math
 import random
 import uuid
+import warnings
 from contextlib import AbstractContextManager, contextmanager
 from dataclasses import asdict, dataclass
 from decimal import Decimal, ROUND_HALF_DOWN, ROUND_HALF_UP
@@ -264,6 +264,50 @@ def fastcopy(dataclass_obj: T, **kwargs) -> T:
         >>> ts2 = fastcopy(ts1, end=12)
     """
     return type(dataclass_obj)(**{**dataclass_obj.__dict__, **kwargs})
+
+
+def split_manifest_lazy(
+    it: Iterable[Any], output_dir: Pathlike, chunk_size: int
+) -> List:
+    """
+    Splits a manifest (either lazily or eagerly opened) into chunks, each
+    with ``chunk_size`` items (except for the last one, typically).
+
+    In order to be memory efficient, this implementation saves each chunk
+    to disk in a ``.jsonl.gz`` format as the input manifest is sampled.
+
+    .. note:: For lowest memory usage, use ``load_manifest_lazy`` to open the
+        input manifest for this method.
+
+    :param it: any iterable of Lhotse manifests.
+    :param output_dir: directory where the split manifests are saved.
+        Each manifest is saved at: ``{output_dir}/{split_idx}.jsonl.gz``
+    :param chunk_size: the number of items in each chunk.
+    :return: a list of lazily opened chunk manifests.
+    """
+    from lhotse.serialization import SequentialJsonlWriter
+
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    items = iter(it)
+    split_idx = 0
+    splits = []
+    while True:
+        try:
+            written = 0
+            with SequentialJsonlWriter(output_dir / f"{split_idx}.jsonl.gz") as writer:
+                while written < chunk_size:
+                    item = next(items)
+                    writer.write(item)
+                    written += 1
+            split_idx += 1
+        except StopIteration:
+            break
+        finally:
+            splits.append(writer.open_manifest())
+
+    return splits
 
 
 def split_sequence(

--- a/test/test_manipulation.py
+++ b/test/test_manipulation.py
@@ -1,4 +1,5 @@
 import random
+from tempfile import TemporaryDirectory
 
 import pytest
 from pytest import mark
@@ -93,6 +94,23 @@ def test_cannot_split_to_more_chunks_than_items(manifest_type):
     manifest = DummyManifest(manifest_type, begin_id=0, end_id=1)
     with pytest.raises(ValueError):
         manifest.split(num_splits=10)
+
+
+@mark.parametrize("manifest_type", [RecordingSet, SupervisionSet, FeatureSet, CutSet])
+def test_split_lazy_even(manifest_type):
+    with TemporaryDirectory() as d:
+        manifest = DummyManifest(manifest_type, begin_id=0, end_id=100)
+        manifest_subsets = manifest.split_lazy(output_dir=d, chunk_size=49)
+        assert len(manifest_subsets) == 3
+        assert list(manifest_subsets[0]) == list(
+            DummyManifest(manifest_type, begin_id=0, end_id=49)
+        )
+        assert list(manifest_subsets[1]) == list(
+            DummyManifest(manifest_type, begin_id=49, end_id=98)
+        )
+        assert list(manifest_subsets[2]) == list(
+            DummyManifest(manifest_type, begin_id=98, end_id=100)
+        )
 
 
 @mark.parametrize("manifest_type", [RecordingSet, SupervisionSet, FeatureSet, CutSet])


### PR DESCRIPTION
This addresses the issue raised in https://github.com/k2-fsa/icefall/pull/167#issuecomment-1023965523

CC @pkufool 