### PR TITLE
Sampler reports for how much padding is typically used

### DIFF
--- a/lhotse/dataset/sampling/__init__.py
+++ b/lhotse/dataset/sampling/__init__.py
@@ -3,5 +3,5 @@ from .cut_pairs import CutPairsSampler
 from .data_source import streaming_shuffle
 from .dynamic_bucketing import DynamicBucketingSampler
 from .simple import SimpleCutSampler, SingleCutSampler
-from .utils import find_pessimistic_batches
+from .utils import find_pessimistic_batches, report_padding_ratio_estimate
 from .zip import ZipSampler

--- a/lhotse/dataset/sampling/utils.py
+++ b/lhotse/dataset/sampling/utils.py
@@ -109,7 +109,11 @@ def report_padding_ratio_estimate(sampler: CutSampler, n_samples: int = 1000) ->
             break
 
         if not isinstance(batch, CutSet):
-            raise NotImplemented
+            warnings.warn(
+                "The sampler returned a mini-batch with multiple CutSets: "
+                "we will only report the padding estimate for the first CutSet in each mini-batch."
+            )
+            batch = batch[0]
 
         batch = batch.sort_by_duration(ascending=False)
 

--- a/lhotse/dataset/sampling/utils.py
+++ b/lhotse/dataset/sampling/utils.py
@@ -159,5 +159,5 @@ def report_padding_ratio_estimate(sampler: CutSampler, n_samples: int = 1000) ->
 
     return f"""An average CUT has {m_supervised:.1f}s (std={np.std(supervised):.1f}s) of supervisions vs. {m_total:.1f}s (std={np.std(total):.1f}s) of total duration. Average padding is {m_gaps:.1f}s (std={np.std(gaps):.1f}s), i.e. {m_gaps / m_total:.1%}.
 An average BATCH has {m_batch_supervised:.1f}s (std={np.std(batch_supervised):.1f}s) of combined supervised duration vs. {m_batch_total:.1f}s (std={np.std(batch_total):.1f}s) of combined total duration. Average padding is {m_batch_gaps:.1f}s (std={np.std(batch_gaps):.1f}s), i.e. {m_batch_gaps / m_batch_total:.1%}.
-Expected variability of cut durations within a single batch is +/-{np.mean(mean_dur_diffs):.1%} (min={np.mean(min_dur_diffs):.1%} max={np.mean(max_dur_diffs):.1%}).
+Expected variability of cut durations within a single batch is +/-{np.mean(mean_dur_diffs):.1%} (two closest cuts: {np.mean(min_dur_diffs):.1%}, two most distant cuts: {np.mean(max_dur_diffs):.1%}).
     """

--- a/lhotse/dataset/sampling/utils.py
+++ b/lhotse/dataset/sampling/utils.py
@@ -1,5 +1,8 @@
 import warnings
+from statistics import mean
 from typing import Dict, Tuple
+
+import numpy as np
 
 from lhotse import CutSet
 from lhotse.dataset.sampling.base import CutSampler
@@ -81,3 +84,76 @@ def find_pessimistic_batches(
                 top_batches[crit] = batch
 
     return top_batches, top_values
+
+
+def report_padding_ratio_estimate(sampler: CutSampler, n_samples: int = 1000) -> str:
+    """
+    Returns a human-readable string message about amount of padding diagnostics.
+    Assumes that padding corresponds to segments without any supervision within cuts.
+    """
+    supervised = []
+    total = []
+    gaps = []
+    batch_supervised = []
+    batch_total = []
+    batch_gaps = []
+    min_dur_diffs = []
+    mean_dur_diffs = []
+    max_dur_diffs = []
+    sampler = iter(sampler)
+
+    for i in range(n_samples):
+        try:
+            batch = next(sampler)
+        except StopIteration:
+            break
+
+        if not isinstance(batch, CutSet):
+            raise NotImplemented
+
+        batch = batch.sort_by_duration(ascending=False)
+
+        if len(batch) > 1:
+            min_dur_diffs.append(
+                (batch[0].duration - batch[1].duration) / batch[0].duration
+            )
+            max_dur_diffs.append(
+                (batch[0].duration - batch[len(batch) - 1].duration) / batch[0].duration
+            )
+            mean_dur_diffs.append(
+                mean(
+                    [
+                        batch[0].duration - batch[i].duration
+                        for i in range(1, len(batch))
+                    ]
+                )
+                / batch[0].duration
+            )
+
+        batch = batch.pad()
+        batch_sup = 0
+        batch_tot = 0
+        batch_gap = 0
+        for cut in batch:
+            total.append(cut.duration)
+            supervised.append(sum(s.duration for s in cut.supervisions))
+            gaps.append(total[-1] - supervised[-1])
+            batch_sup += supervised[-1]
+            batch_tot += total[-1]
+            batch_gap += gaps[-1]
+
+        batch_supervised.append(batch_sup)
+        batch_total.append(batch_tot)
+        batch_gaps.append(batch_gap)
+
+    m_supervised = np.mean(supervised)
+    m_total = np.mean(total)
+    m_gaps = np.mean(gaps)
+    m_batch_supervised = np.mean(batch_supervised)
+    m_batch_total = np.mean(batch_total)
+    m_batch_gaps = np.mean(batch_gaps)
+
+    return f"""An average CUT has {m_supervised:.1f}s (std={np.std(supervised):.1f}s) of supervisions vs. {m_total:.1f}s (std={np.std(total):.1f}s) of total duration. Average padding is {m_gaps:.1f}s (std={np.std(gaps):.1f}s), i.e. {m_gaps / m_total:.1%}.
+An average BATCH has {m_batch_supervised:.1f}s (std={np.std(batch_supervised):.1f}s) of combined supervised duration vs. {m_batch_total:.1f}s (std={np.std(batch_total):.1f}s) of combined total duration. Average padding is {m_batch_gaps:.1f}s (std={np.std(batch_gaps):.1f}s), i.e. {m_batch_gaps / m_batch_total:.1%}.
+Expected variability of cut durations within a single batch is +/-{np.mean(mean_dur_diffs):.1%} (min={np.mean(min_dur_diffs):.1%} max={np.mean(max_dur_diffs):.1%}).
+    """

--- a/test/dataset/sampling/test_sampling.py
+++ b/test/dataset/sampling/test_sampling.py
@@ -7,6 +7,7 @@ from tempfile import NamedTemporaryFile
 import pytest
 
 from lhotse import CutSet
+from lhotse.dataset import report_padding_ratio_estimate
 from lhotse.dataset.cut_transforms import concat_cuts
 from lhotse.dataset.sampling import (
     BucketingSampler,
@@ -1054,3 +1055,8 @@ def test_sampler_properties(sampler):
     assert sampler.remaining_cuts == 0
     assert isclose(sampler.remaining_duration, 0.0)
     assert sampler.num_cuts == 10
+
+
+def test_report_padding_ratio_estimate():
+    s = SingleCutSampler(DummyManifest(CutSet, begin_id=0, end_id=1000))
+    report_padding_ratio_estimate(s)  # just test that it runs


### PR DESCRIPTION
This can be useful in tweaking the sampler settings (e.g. num_buckets), see the screenshot.

<img width="1599" alt="image" src="https://user-images.githubusercontent.com/15930688/152217624-5cc7e3a7-27bd-4cc6-a61b-464bdb777a5e.png">
