### PR TITLE
WIP: add cut extend method

### DIFF
--- a/lhotse/testing/dummies.py
+++ b/lhotse/testing/dummies.py
@@ -46,7 +46,7 @@ def DummyManifest(type_: Type, *, begin_id: int, end_id: int) -> Manifest:
         )
 
 
-def dummy_recording(unique_id: int) -> Recording:
+def dummy_recording(unique_id: int, duration: float = 1.0) -> Recording:
     return Recording(
         id=f"dummy-recording-{unique_id:04d}",
         sources=[
@@ -54,7 +54,7 @@ def dummy_recording(unique_id: int) -> Recording:
         ],
         sampling_rate=16000,
         num_samples=16000,
-        duration=1.0,
+        duration=duration,
     )
 
 
@@ -93,12 +93,14 @@ def dummy_supervision(
     )
 
 
-def dummy_features(unique_id: int) -> Features:
+def dummy_features(
+    unique_id: int, start: float = 0.0, duration: float = 1.0
+) -> Features:
     return Features(
         recording_id=f"dummy-recording-{unique_id:04d}",
         channels=0,
-        start=0.0,
-        duration=1.0,
+        start=start,
+        duration=duration,
         type="fbank",
         num_frames=100,
         num_features=23,
@@ -111,15 +113,20 @@ def dummy_features(unique_id: int) -> Features:
 
 
 def dummy_cut(
-    unique_id: int, start: float = 0.0, duration: float = 1.0, supervisions=None
+    unique_id: int,
+    start: float = 0.0,
+    duration: float = 1.0,
+    recording: Recording = None,
+    features: Features = None,
+    supervisions=None,
 ):
     return MonoCut(
         id=f"dummy-cut-{unique_id:04d}",
         start=start,
         duration=duration,
         channel=0,
-        recording=dummy_recording(unique_id),
-        features=dummy_features(unique_id),
+        recording=recording if recording else dummy_recording(unique_id),
+        features=features if features else dummy_features(unique_id),
         supervisions=supervisions if supervisions is not None else [],
     )
 

--- a/test/cut/test_cut_extend.py
+++ b/test/cut/test_cut_extend.py
@@ -1,0 +1,86 @@
+from math import isclose
+
+import pytest
+
+from lhotse.utils import uuid4
+from lhotse.testing.dummies import dummy_features, dummy_cut
+
+
+@pytest.mark.parametrize(
+    [
+        "cut_start",
+        "cut_duration",
+        "extend_duration",
+        "extend_direction",
+        "expected_start",
+        "expected_end",
+    ],
+    [
+        (0.0, 0.5, 0.3, "right", 0.0, 0.8),
+        (0.0, 0.5, 0.3, "both", 0.0, 0.8),
+        (0.2, 0.5, 0.3, "left", 0.0, 0.7),
+        (0.2, 0.5, 0.1, "both", 0.1, 0.8),
+        (0.0, 0.8, 0.3, "both", 0.0, 1.0),
+    ],
+)
+def test_extend_cut(
+    cut_start,
+    cut_duration,
+    extend_duration,
+    extend_direction,
+    expected_start,
+    expected_end,
+):
+    cut = dummy_cut(int(uuid4()), start=cut_start, duration=cut_duration)
+    extended_cut = cut.extend(duration=extend_duration, direction=extend_direction)
+    assert isclose(extended_cut.start, expected_start)
+    assert isclose(extended_cut.end, expected_end)
+
+
+@pytest.mark.parametrize("preserve_id", [True, False])
+def test_extend_cut_preserve_id(preserve_id):
+    cut = dummy_cut(int(uuid4()), start=0.0, duration=0.5)
+    extended_cut = cut.extend(duration=0.3, direction="right", preserve_id=preserve_id)
+    if preserve_id:
+        assert extended_cut.id == cut.id
+    else:
+        assert extended_cut.id != cut.id
+
+
+@pytest.mark.parametrize(
+    [
+        "cut_start",
+        "cut_duration",
+        "feature_start",
+        "feature_duration",
+        "extend_duration",
+        "extend_direction",
+        "expected",
+    ],
+    [
+        (0.3, 0.8, 0.0, 1.0, 0.1, "both", True),
+        (0.3, 0.8, 0.3, 0.8, 0.1, "both", False),
+    ],
+)
+def test_extend_cut_with_features(
+    cut_start,
+    cut_duration,
+    feature_start,
+    feature_duration,
+    extend_duration,
+    extend_direction,
+    expected,
+):
+    cut = dummy_cut(
+        int(uuid4()),
+        start=cut_start,
+        duration=cut_duration,
+        features=dummy_features(
+            int(uuid4()), start=feature_start, duration=feature_duration
+        ),
+    )
+    extended_cut = cut.extend(duration=extend_duration, direction=extend_direction)
+    if expected:
+        assert extended_cut.features == cut.features
+    else:
+        assert extended_cut.features is None


### PR DESCRIPTION
This method can be used to extend a cut by adding context on one or both sides. I'm still working on the implementation for `MixedCut` and need some feedback about what exactly should be done for this case?