### PR TITLE
Fix array lengths in custom collation

### DIFF
--- a/lhotse/dataset/collation.py
+++ b/lhotse/dataset/collation.py
@@ -251,9 +251,6 @@ def collate_custom_field(
             )
             pad_value = DEFAULT_PADDING_VALUE
         temporal_dim = first_manifest.temporal_dim
-        arr_lens = torch.tensor(
-            [getattr(c, field).shape[temporal_dim] for c in cuts], dtype=torch.int32
-        )
 
         # We avoid cuts.pad() because the users might be defining frame_shift differently
         # that we typically do in Lhotse. This may result in extra padding where they
@@ -263,6 +260,7 @@ def collate_custom_field(
 
         # Instead, we're going to load everything and pad to the longest sequence.
         arrs = [torch.from_numpy(c.load_custom(field)) for c in cuts]
+        arr_lens = torch.tensor([a.shape[temporal_dim] for a in arrs], dtype=torch.int32)
         largest_arr = max(arrs, key=torch.numel)
         maxlen = largest_arr.shape[temporal_dim]
         collated_shape = (len(arrs), *largest_arr.shape)

--- a/lhotse/dataset/collation.py
+++ b/lhotse/dataset/collation.py
@@ -260,7 +260,9 @@ def collate_custom_field(
 
         # Instead, we're going to load everything and pad to the longest sequence.
         arrs = [torch.from_numpy(c.load_custom(field)) for c in cuts]
-        arr_lens = torch.tensor([a.shape[temporal_dim] for a in arrs], dtype=torch.int32)
+        arr_lens = torch.tensor(
+            [a.shape[temporal_dim] for a in arrs], dtype=torch.int32
+        )
         largest_arr = max(arrs, key=torch.numel)
         maxlen = largest_arr.shape[temporal_dim]
         collated_shape = (len(arrs), *largest_arr.shape)

--- a/lhotse/serialization.py
+++ b/lhotse/serialization.py
@@ -356,6 +356,8 @@ def load_manifest(path: Pathlike, manifest_cls: Optional[Type] = None) -> Manife
     for manifest_type in candidates:
         try:
             data_set = manifest_type.from_dicts(raw_data)
+            if len(data_set) == 0:
+                raise RuntimeError()
             break
         except Exception:
             pass

--- a/test/dataset/test_collation.py
+++ b/test/dataset/test_collation.py
@@ -238,7 +238,9 @@ def test_collate_custom_temporal_array_ints_with_truncate(pad_value):
             )
 
         cuts = cuts.truncate(max_duration=1, offset_type="start")
-        max_num_frames = max(seconds_to_frames(cut.duration, FRAME_SHIFT) for cut in cuts)
+        max_num_frames = max(
+            seconds_to_frames(cut.duration, FRAME_SHIFT) for cut in cuts
+        )
 
         codebook_indices, codebook_indices_lens = collate_custom_field(
             cuts, "codebook_indices", pad_value=pad_value
@@ -256,7 +258,9 @@ def test_collate_custom_temporal_array_ints_with_truncate(pad_value):
         assert codebook_indices.shape == (len(cuts), max_num_frames)
         for idx, cbidxs in enumerate(expected_codebook_indices):
             # PyTorch < 1.9.0 doesn't have an assert_equal function.
-            np.testing.assert_equal(codebook_indices[idx, :max_num_frames].numpy(), cbidxs[:max_num_frames])
+            np.testing.assert_equal(
+                codebook_indices[idx, :max_num_frames].numpy(), cbidxs[:max_num_frames]
+            )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
If cuts were truncated, the array lengths weren't reflecting that. 