### PR TITLE
Updated ICSI download structure/args for clarity

### DIFF
--- a/lhotse/recipes/icsi.py
+++ b/lhotse/recipes/icsi.py
@@ -193,17 +193,18 @@ def download_icsi(
 ) -> None:
     """
     Download ICSI audio and annotations for provided microphone setting.
-    :param target_dir: Pathlike, the path in which audio and transcripts dir are created by default. 
+    :param target_dir: Pathlike, the path in which audio and transcripts dir are created by default.
     :param audio_dir: Pathlike (default = None), the path to store the audio data.
-    :param transcripts_dir: Pathlike (default = None), path to store the transcripts data 
+    :param transcripts_dir: Pathlike (default = None), path to store the transcripts data
     :param force_download: bool (default = False), if True, download even if file is present.
     :param url: str (default = 'http://groups.inf.ed.ac.uk/ami'), download URL.
     :param mic: str {'ihm','ihm-mix','sdm','mdm'}, type of mic setting.
     """
     target_dir = Path(target_dir)
-    audio_dir = Path(audio_dir) if audio_dir else target_dir / 'audio'
-    transcripts_dir = Path(
-        transcripts_dir) if transcripts_dir else target_dir / 'transcripts'
+    audio_dir = Path(audio_dir) if audio_dir else target_dir / "audio"
+    transcripts_dir = (
+        Path(transcripts_dir) if transcripts_dir else target_dir / "transcripts"
+    )
 
     # Audio
     download_audio(audio_dir, force_download, url, mic)
@@ -229,7 +230,7 @@ def download_icsi(
         z.extractall()  # unzips to a dir called 'transcripts'
         # If custom dir is passed, rename 'transcripts' dir accordingly
         if transcripts_dir:
-            Path('transcripts').rename(transcripts_dir)
+            Path("transcripts").rename(transcripts_dir)
 
 
 def parse_icsi_annotations(

--- a/lhotse/recipes/icsi.py
+++ b/lhotse/recipes/icsi.py
@@ -194,14 +194,14 @@ def download_icsi(
     """
     Download ICSI audio and annotations for provided microphone setting.
     :param target_dir: Pathlike, the path in which audio and transcripts dir are created by default.
-    :param audio_dir: Pathlike (default = None), the path to store the audio data.
-    :param transcripts_dir: Pathlike (default = None), path to store the transcripts data
+    :param audio_dir: Pathlike (default = '<target_dir>/audio'), the path to store the audio data.
+    :param transcripts_dir: Pathlike (default = '<target_dir>/transcripts'), path to store the transcripts data
     :param force_download: bool (default = False), if True, download even if file is present.
     :param url: str (default = 'http://groups.inf.ed.ac.uk/ami'), download URL.
     :param mic: str {'ihm','ihm-mix','sdm','mdm'}, type of mic setting.
     """
     target_dir = Path(target_dir)
-    audio_dir = Path(audio_dir) if audio_dir else target_dir / "audio"
+    audio_dir = Path(audio_dir) if audio_dir else target_dir / "speech"
     transcripts_dir = (
         Path(transcripts_dir) if transcripts_dir else target_dir / "transcripts"
     )


### PR DESCRIPTION
+ introduced target_dir arg which is the root for downloaded data
+ by default an 'audio' and 'transcripts' dir in this target
  dir will hold the corpus data
+ the user can pass arguments to adjust the name of audio and transcripts dir


I found it a bit confusing that the `audio_dir` was also used for the transcripts by default and intuitively didn't expect that passing a `transcripts_dir` means that the final transcripts will be in a subfolder of that folder, namely `<your passed dir>/transcripts`. 

Using one `target_dir` which contains an `audio` dir for audio and a `transcripts` dir for transcripts seemed more intuitive.

Let me know what you think. 