### PR TITLE
Fix CutSet sample, and add mix padding

### DIFF
--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -266,12 +266,18 @@ class Cut:
         self,
         other: "Cut",
         offset_other_by: Seconds = 0.0,
+        allow_padding: bool = False,
         snr: Optional[Decibels] = None,
         preserve_id: Optional[str] = None,
     ) -> "MixedCut":
         """Refer to :function:`~lhotse.cut.mix` documentation."""
         return mix(
-            self, other, offset=offset_other_by, snr=snr, preserve_id=preserve_id
+            self,
+            other,
+            offset=offset_other_by,
+            allow_padding=allow_padding,
+            snr=snr,
+            preserve_id=preserve_id,
         )
 
     def append(
@@ -3936,7 +3942,7 @@ class CutSet(Serializable, Sequence[Cut]):
         assert n_cuts > 0
         # TODO: We might want to make this more efficient in the future
         #  by holding a cached list of cut ids as a member of CutSet...
-        cut_indices = [random.randint(0, len(self) - 1) for _ in range(n_cuts)]
+        cut_indices = random.sample(range(len(self)), min(n_cuts, len(self)))
         cuts = [self[idx] for idx in cut_indices]
         if n_cuts == 1:
             return cuts[0]
@@ -4041,6 +4047,7 @@ class CutSet(Serializable, Sequence[Cut]):
         self,
         cuts: "CutSet",
         duration: Optional[Seconds] = None,
+        allow_padding: bool = False,
         snr: Optional[Union[Decibels, Sequence[Decibels]]] = 20,
         preserve_id: Optional[str] = None,
         mix_prob: float = 1.0,
@@ -4055,6 +4062,9 @@ class CutSet(Serializable, Sequence[Cut]):
             (i.e. we'll truncate the mix if it exceeded the original duration).
             Otherwise, we will keep sampling cuts to mix in until we reach the specified
             ``duration`` (and truncate to that value, should it be exceeded).
+        :param allow_padding: an optional bool.
+            When it is ``True``, we will allow the offset to be larger than the reference
+            cut by padding the reference cut.
         :param snr: an optional float, or pair (range) of floats, in decibels.
             When it's a single float, we will mix all cuts with this SNR level
             (where cuts in ``self`` are treated as signals, and cuts in ``cuts`` are treated as noise).
@@ -4104,6 +4114,7 @@ class CutSet(Serializable, Sequence[Cut]):
                         other=to_mix,
                         snr=snr,
                         offset_other_by=mixed_in_duration,
+                        allow_padding=allow_padding,
                         preserve_id=preserve_id,
                     )
                     # Since we're adding floats, we can be off by an epsilon and trigger
@@ -4872,6 +4883,7 @@ def mix(
     reference_cut: Cut,
     mixed_in_cut: Cut,
     offset: Seconds = 0,
+    allow_padding: bool = False,
     snr: Optional[Decibels] = None,
     preserve_id: Optional[str] = None,
 ) -> MixedCut:
@@ -4884,6 +4896,7 @@ def mix(
     :param reference_cut: The reference cut for the mix - offset and snr are specified w.r.t this cut.
     :param mixed_in_cut: The mixed-in cut - it will be offset and rescaled to match the offset and snr parameters.
     :param offset: How many seconds to shift the ``mixed_in_cut`` w.r.t. the ``reference_cut``.
+    :param allow_padding: If the offset is larger than the cut duration, allow the cut to be padded.
     :param snr: Desired SNR of the ``right_cut`` w.r.t. the ``left_cut`` in the mix.
     :param preserve_id: optional string ("left", "right"). when specified, append will preserve the cut id
         of the left- or right-hand side argument. otherwise, a new random id is generated.
@@ -4906,10 +4919,10 @@ def mix(
         assert (
             reference_cut.num_features == mixed_in_cut.num_features
         ), "Cannot mix cuts with different feature dimensions."
-    assert offset <= reference_cut.duration, (
+    assert offset <= reference_cut.duration or allow_padding, (
         f"Cannot mix cut '{mixed_in_cut.id}' with offset {offset},"
         f" which is greater than cuts {reference_cut.id} duration"
-        f" of {reference_cut.duration}"
+        f" of {reference_cut.duration}. Set `allow_padding=True` to allow padding."
     )
     assert reference_cut.sampling_rate == mixed_in_cut.sampling_rate, (
         f"Cannot mix cuts with different sampling rates "
@@ -4930,6 +4943,10 @@ def mix(
             "Unexpected value for 'preserve_id' argument: "
             f"got '{preserve_id}', expected one of (None, 'left', 'right')."
         )
+
+    # If the offset is larger than the left_cut duration, pad it.
+    if offset > reference_cut.duration:
+        reference_cut = reference_cut.pad(duration=offset)
 
     # When the left_cut is a MixedCut, take its existing tracks, otherwise create a new track.
     if isinstance(reference_cut, MixedCut):

--- a/test/cut/test_cut_mixing.py
+++ b/test/cut/test_cut_mixing.py
@@ -32,20 +32,21 @@ def test_append_cut_duration_and_supervisions(cut1, cut2):
 
 
 @pytest.mark.parametrize(
-    ["offset", "expected_duration", "exception_expectation"],
+    ["offset", "allow_padding", "expected_duration", "exception_expectation"],
     [
-        (0, 10.0, does_not_raise()),
-        (1, 11.0, does_not_raise()),
-        (5, 15.0, does_not_raise()),
-        (10, 20.0, does_not_raise()),
-        (100, "irrelevant", pytest.raises(AssertionError)),
+        (0, False, 10.0, does_not_raise()),
+        (1, False, 11.0, does_not_raise()),
+        (5, False, 15.0, does_not_raise()),
+        (10, False, 20.0, does_not_raise()),
+        (100, False, "irrelevant", pytest.raises(AssertionError)),
+        (100, True, 110.0, does_not_raise()),
     ],
 )
 def test_overlay_cut_duration_and_supervisions(
-    offset, expected_duration, exception_expectation, cut1, cut2
+    offset, allow_padding, expected_duration, exception_expectation, cut1, cut2
 ):
     with exception_expectation:
-        mixed_cut = cut1.mix(cut2, offset_other_by=offset)
+        mixed_cut = cut1.mix(cut2, offset_other_by=offset, allow_padding=allow_padding)
 
         assert isinstance(mixed_cut, MixedCut)
         assert mixed_cut.duration == expected_duration
@@ -123,7 +124,7 @@ def libri_cut(libri_cut_set) -> MonoCut:
 def E(x):
     if x.shape[0] == 1:
         # audio
-        return np.sum(x ** 2)
+        return np.sum(x**2)
     # fbank
     return np.sum(np.exp(x))
 

--- a/test/cut/test_cut_mixing.py
+++ b/test/cut/test_cut_mixing.py
@@ -124,7 +124,7 @@ def libri_cut(libri_cut_set) -> MonoCut:
 def E(x):
     if x.shape[0] == 1:
         # audio
-        return np.sum(x**2)
+        return np.sum(x ** 2)
     # fbank
     return np.sum(np.exp(x))
 

--- a/test/cut/test_invariants_randomized.py
+++ b/test/cut/test_invariants_randomized.py
@@ -44,10 +44,10 @@ class TestMixedCutNumFramesNumSamplesRandomized(RandomCutTestCase):
         mixed = cuts[0]
         for idx, cut in enumerate(cuts[1:]):
             offset = rand_gen.draw(
-                st.floats(min_value=0.1, max_value=mixed.duration),
+                st.floats(min_value=0.1, max_value=2 * mixed.duration),
                 label=f"Offset for cut {idx + 1}",
             )
-            mixed = mixed.mix(cut, offset_other_by=offset)
+            mixed = mixed.mix(cut, offset_other_by=offset, allow_padding=True)
         # Truncate somewhere around the middle
         # end = rand_gen.draw(st.floats(mixed.duration * 0.4, mixed.duration * 0.6), label='Truncated duration')
         # mixed = mixed.truncate(duration=end)


### PR DESCRIPTION
* Fix for https://github.com/lhotse-speech/lhotse/issues/588
* Allow `offset` to be larger than reference cut duration by padding the reference cut