### PR TITLE
Fixes for PyTorch 1.11

### DIFF
--- a/lhotse/audio.py
+++ b/lhotse/audio.py
@@ -722,7 +722,7 @@ class Recording:
         )
 
 
-class RecordingSet(Serializable, Sequence[Recording]):
+class RecordingSet(Serializable):
     """
     :class:`~lhotse.audio.RecordingSet` represents a collection of recordings, indexed by recording IDs.
     It does not contain any annotation such as the transcript or the speaker identity --

--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -3121,7 +3121,7 @@ class MixedCut(Cut):
         return [t for t in self.tracks if not isinstance(t.cut, PaddingCut)][0]
 
 
-class CutSet(Serializable, Sequence[Cut]):
+class CutSet(Serializable):
     """
     :class:`~lhotse.cut.CutSet` represents a collection of cuts, indexed by cut IDs.
     CutSet ties together all types of data -- audio, features and supervisions, and is suitable to represent

--- a/lhotse/features/base.py
+++ b/lhotse/features/base.py
@@ -562,7 +562,7 @@ class Features:
         )
 
 
-class FeatureSet(Serializable, Sequence[Features]):
+class FeatureSet(Serializable):
     """
     Represents a feature manifest, and allows to read features for given recordings
     within particular channels and time ranges.

--- a/lhotse/supervision.py
+++ b/lhotse/supervision.py
@@ -436,7 +436,7 @@ class SupervisionSegment:
             raise AttributeError(f"No such attribute: {name}")
 
 
-class SupervisionSet(Serializable, Sequence[SupervisionSegment]):
+class SupervisionSet(Serializable):
     """
     :class:`~lhotse.supervision.SupervisionSet` represents a collection of segments containing some
     supervision information (see :class:`~lhotse.supervision.SupervisionSegment`),


### PR DESCRIPTION
PyTorch `collate_fn` now has special support for generic Sequence and Mapping with some hard assumptions about their constructors, so I have remove the inheritance in CutSet and the rest of classes; I don't think it was really correct to inherit from Sequence anyway.