### PR TITLE
Cut into windows with hop

### DIFF
--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -4058,12 +4058,12 @@ class CutSet(Serializable, AlgorithmMixin):
             )
             for cut in self
         )
-        
+
     @staticmethod
-    def num_windows(sig_len:Seconds, win_len:Seconds, hop:Seconds)->int:
+    def num_windows(sig_len: Seconds, win_len: Seconds, hop: Seconds) -> int:
         """
         Returns a number of windows obtained from signal of length equal to ``sig_len``
-        with windows of ``win_len`` and ``hop`` denoting shift between windows. 
+        with windows of ``win_len`` and ``hop`` denoting shift between windows.
 
         :param sig_len: Signal length in seconds.
         :param win_len: Window length in seconds
@@ -4071,7 +4071,7 @@ class CutSet(Serializable, AlgorithmMixin):
         :return: number of windows in signal assuming that last .
         """
         n = ceil(max(sig_len - win_len, 0) / hop)
-        b = (sig_len - n*hop) > 0
+        b = (sig_len - n * hop) > 0
         return (sig_len > 0) * (n + int(b))
 
     def cut_into_windows(
@@ -4101,7 +4101,7 @@ class CutSet(Serializable, AlgorithmMixin):
             new_cuts = []
             for cut in self:
                 n_windows = self.num_windows(cut.duration, duration, hop)
-                #n_windows = ceil(cut.duration / duration)
+                # n_windows = ceil(cut.duration / duration)
                 for i in range(n_windows):
                     new_cuts.append(
                         cut.truncate(

--- a/test/cut/test_cut.py
+++ b/test/cut/test_cut.py
@@ -67,7 +67,26 @@ def test_num_frames(libri_cut):
 
     expected_cut_frame_count = round(10 / 0.01)  # duration / frame_shift
     assert libri_cut.num_frames == expected_cut_frame_count
+    
+    
+@pytest.mark.parametrize(
+    "params, expected_n_win", #params: (sig_len,win_len,hop)
+    [
+        ((1, 6.1, 3), 1),  # 0-1
+        ((3, 1, 6.1), 1),  # 0-1
+        ((3, 6.1, 1), 1),  # 0-3
+        ((5.9, 1, 3), 2),  # 0-1, 3-4
+        ((5.9, 3, 1), 4),  # 0-3, 1-4, 2-5, 3-5.9
+        ((6.1, 1, 3), 3),  # 0-1, 3-4, 6-6.1
+        ((6.1, 3, 1), 5),  # 0-3, 1-4, 2-5, 3-6, 4-6.1
+        ((5.9, 3, 3), 2),  # 0-3, 3-5.9
+        ((6.1, 3, 3), 3),  # 0-3, 3-6, 6-6.1
+        ((0.0, 3, 3), 0),
+    ],
+)
 
+def test_num_windows(params, expected_n_win):
+    assert CutSet.num_windows(params[0], params[1], params[2]) == expected_n_win
 
 def test_load_features(libri_cut):
     feats = libri_cut.load_features()

--- a/test/fixtures/ljspeech/cuts.json
+++ b/test/fixtures/ljspeech/cuts.json
@@ -44,7 +44,7 @@
       "num_samples": 33949,
       "duration": 1.5396371882086168
     },
-    "type": "Cut"
+    "type": "MonoCut"
   },
   {
     "id": "d9145a74-749e-489a-b3d5-653e047bd274",
@@ -91,6 +91,6 @@
       "num_samples": 35229,
       "duration": 1.5976870748299319
     },
-    "type": "Cut"
+    "type": "MonoCut"
   }
 ]


### PR DESCRIPTION
Hi!
I encountered the missing `hop` feature in CutSet.cut_into_windows(). This is usefull particularily in testing.
This PR includes new, more general function for estimation of number of windows with corresponding unit tests and the modifications in CutSet.cut_into_windows(). In specific I assumed the following output of number of frames based on signal duration, window length and hop size:
```
#(sig_len,win_len,hop): expected_n_win
  ((1, 6.1, 3), 1),  # 0-1
  ((3, 1, 6.1), 1),  # 0-1
  ((3, 6.1, 1), 1),  # 0-3
  ((5.9, 1, 3), 2),  # 0-1, 3-4
  ((5.9, 3, 1), 4),  # 0-3, 1-4, 2-5, 3-5.9
  ((6.1, 1, 3), 3),  # 0-1, 3-4, 6-6.1
  ((6.1, 3, 1), 5),  # 0-3, 1-4, 2-5, 3-6, 4-6.1
  ((5.9, 3, 3), 2),  # 0-3, 3-5.9
  ((6.1, 3, 3), 3),  # 0-3, 3-6, 6-6.1
  ((0.0, 3, 3), 0),
```
I have also regenerated the cuts ljspeech manifest used in the test but apparently it does not remove the warning that this manifest was created with Lhotse version earlier than 0.8. 
Kind regards!