### PR TITLE
Fix rank/world_size settings for ZipSampler and RoundRobinSampler

### DIFF
--- a/lhotse/dataset/sampling/round_robin.py
+++ b/lhotse/dataset/sampling/round_robin.py
@@ -36,7 +36,7 @@ class RoundRobinSampler(CutSampler):
 
         :param samplers: The list of samplers from which we sample batches in turns.
         """
-        super().__init__()
+        super().__init__(rank=0, world_size=1)
         self.samplers = samplers
         self._nondepleted_samplers_indices = list(range(len(self.samplers)))
         self._cur_sampler_idx = 0

--- a/lhotse/dataset/sampling/zip.py
+++ b/lhotse/dataset/sampling/zip.py
@@ -38,7 +38,7 @@ class ZipSampler(CutSampler):
             or return a tuple of CutSets. Setting this to ``False`` makes ZipSampler behave
             more like Python's ``zip`` function.
         """
-        super().__init__()
+        super().__init__(rank=0, world_size=1)
         self.samplers = samplers
         self.merge_batches = merge_batches
 


### PR DESCRIPTION
Composite samplers shouldn't auto-detect rank and world_size as that would result in dropping of too many batches; only the "base" samplers (SimpleCutSampler, CutPairsSampler, DynamicCutSampler, and DynamicBucketingSampler) should do that. BucketingSampler did already set these correctly to rank=0 and world_size=1.