### PR TITLE
Further resampling speedup

### DIFF
--- a/lhotse/audio.py
+++ b/lhotse/audio.py
@@ -688,7 +688,7 @@ class Recording:
         normalize_output: bool = True,
         early_only: bool = False,
         affix_id: bool = True,
-        rir_channels: List[int] = [0],
+        rir_channels: Optional[List[int]] = None,
     ) -> "Recording":
         """
         Return a new ``Recording`` that will lazily apply reverberation based on provided
@@ -700,7 +700,7 @@ class Recording:
         :param affix_id: When true, we will modify the ``Recording.id`` field
             by affixing it with "_rvb".
         :param rir_channels: The channels of the impulse response to be used (in case of multi-channel
-            impulse responses).
+            impulse responses). By default, only the first channel is used.
         :return: the perturbed ``Recording``.
         """
         transforms = self.transforms.copy() if self.transforms is not None else []
@@ -709,7 +709,7 @@ class Recording:
                 rir_recording,
                 normalize_output=normalize_output,
                 early_only=early_only,
-                rir_channels=rir_channels,
+                rir_channels=rir_channels if rir_channels is not None else [0],
             ).to_dict()
         )
         return fastcopy(
@@ -724,6 +724,9 @@ class Recording:
         :param sampling_rate: The new sampling rate.
         :return: A resampled ``Recording``.
         """
+        if sampling_rate == self.sampling_rate:
+            return fastcopy(self)
+
         transforms = self.transforms.copy() if self.transforms is not None else []
 
         if not any(

--- a/lhotse/augmentation/torchaudio.py
+++ b/lhotse/augmentation/torchaudio.py
@@ -1,7 +1,7 @@
 import warnings
 from dataclasses import asdict, dataclass, field
 from decimal import ROUND_HALF_UP
-from typing import List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -220,6 +220,25 @@ class Speed(AudioTransform):
         )
 
 
+_precompiled_resamplers: Dict[Tuple[int, int], torch.nn.Module] = {}
+
+
+def get_or_create_resampler(
+    source_sampling_rate: int, target_sampling_rate: int
+) -> torch.nn.Module:
+    global _precompiled_resamplers
+
+    tpl = (source_sampling_rate, target_sampling_rate)
+    if tpl not in _precompiled_resamplers:
+        check_torchaudio_version()
+        import torchaudio
+
+        _precompiled_resamplers[tpl] = torchaudio.transforms.Resample(
+            source_sampling_rate, target_sampling_rate
+        )
+    return _precompiled_resamplers[tpl]
+
+
 @dataclass
 class Resample(AudioTransform):
     """
@@ -230,12 +249,9 @@ class Resample(AudioTransform):
     target_sampling_rate: int
 
     def __post_init__(self):
-        check_torchaudio_version()
-        import torchaudio
-
         self.source_sampling_rate = int(self.source_sampling_rate)
         self.target_sampling_rate = int(self.target_sampling_rate)
-        self.resampler = torchaudio.transforms.Resample(
+        self.resampler = get_or_create_resampler(
             self.source_sampling_rate, self.target_sampling_rate
         )
 

--- a/lhotse/augmentation/torchaudio.py
+++ b/lhotse/augmentation/torchaudio.py
@@ -256,6 +256,8 @@ class Resample(AudioTransform):
         )
 
     def __call__(self, samples: np.ndarray, *args, **kwargs) -> np.ndarray:
+        if self.source_sampling_rate == self.target_sampling_rate:
+            return samples
 
         if isinstance(samples, np.ndarray):
             samples = torch.from_numpy(samples)
@@ -277,6 +279,9 @@ class Resample(AudioTransform):
         E.g. 16kHz, 235636 samples correspond to 14.72725s duration; after resampling to 22.05kHz,
         it is 324736 samples which correspond to 14.727256235827664s duration.
         """
+        if self.source_sampling_rate == self.target_sampling_rate:
+            return offset, duration
+
         old_num_samples = compute_num_samples(
             offset, self.source_sampling_rate, rounding=ROUND_HALF_UP
         )


### PR DESCRIPTION
It keeps resampling transforms in global variable space, this helps if you're resampling a lot of audio because it keeps sinc kernels in memory instead of recomputing them each time.