### PR TITLE
`nara_wpe` based WPE dereverberation as data augmentation

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -46,6 +46,7 @@ jobs:
         pip install opensmile  # for running opensmile tests
         pip install kaldi_native_io  # for running kaldi_native_io tests
         pip install webdataset==0.1.103 # for running webdataset tests
+        pip install git+https://github.com/fgnt/nara_wpe  # for running WPE tests
     - name: Install sph2pipe
       run: |
         lhotse install-sph2pipe  # Handle sphere files.

--- a/lhotse/augmentation/__init__.py
+++ b/lhotse/augmentation/__init__.py
@@ -1,3 +1,5 @@
 from .common import AugmentFn
 from .torchaudio import *
+from .transform import AudioTransform
 from .utils import convolve1d
+from .wpe import DereverbWPE, dereverb_wpe_torch

--- a/lhotse/augmentation/torchaudio.py
+++ b/lhotse/augmentation/torchaudio.py
@@ -1,18 +1,19 @@
 import warnings
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from decimal import ROUND_HALF_UP
 from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
 
+from lhotse.augmentation.transform import AudioTransform
+from lhotse.augmentation.utils import convolve1d
 from lhotse.utils import (
     Seconds,
     compute_num_samples,
     during_docs_build,
     perturb_num_samples,
 )
-from lhotse.augmentation.utils import convolve1d
 
 
 @dataclass
@@ -99,74 +100,6 @@ class SoxEffectTransform:
             ]
             for effect in self.effects
         ]
-
-
-class AudioTransform:
-    """
-    Base class for all audio transforms that are going to be lazily applied on
-    ``Recording`` during loading the audio into memory.
-
-    Any ``AudioTransform`` can be used like a Python function, that expects two arguments:
-    a numpy array of samples, and a sampling rate. E.g.:
-
-        >>> fn = AudioTransform.from_dict(...)
-        >>> new_audio = fn(audio, sampling_rate)
-
-    Since we often use cuts of the original recording, they will refer to the timestamps
-    of the augmented audio (which might be speed perturbed and of different duration).
-    Each transform provides a helper method to recover the original audio timestamps:
-
-        >>> # When fn does speed perturbation:
-        >>> fn.reverse_timestamps(offset=5.055555, duration=10.1111111, sampling_rate=16000)
-        ... (5.0, 10.0)
-
-    Furthermore, ``AudioTransform`` can be easily (de)serialized to/from dict
-    that contains its name and parameters.
-    This enables storing recording and cut manifests with the transform info
-    inside, avoiding the need to store the augmented recording version on disk.
-
-    All audio transforms derived from this class are "automagically" registered,
-    so that ``AudioTransform.from_dict()`` can "find" the right type given its name
-    to instantiate a specific transform object.
-    All child classes are expected to be decorated with a ``@dataclass`` decorator.
-    """
-
-    KNOWN_TRANSFORMS = {}
-
-    def __init_subclass__(cls, **kwargs):
-        if cls.__name__ not in AudioTransform.KNOWN_TRANSFORMS:
-            AudioTransform.KNOWN_TRANSFORMS[cls.__name__] = cls
-        super().__init_subclass__(**kwargs)
-
-    def to_dict(self) -> dict:
-        data = asdict(self)
-        return {"name": type(self).__name__, "kwargs": data}
-
-    @staticmethod
-    def from_dict(data: dict) -> "AudioTransform":
-        assert (
-            data["name"] in AudioTransform.KNOWN_TRANSFORMS
-        ), f"Unknown transform type: {data['name']}"
-        return AudioTransform.KNOWN_TRANSFORMS[data["name"]](**data["kwargs"])
-
-    def __call__(self, samples: np.ndarray, sampling_rate: int) -> np.ndarray:
-        """
-        Apply transform.
-
-        To be implemented in derived classes.
-        """
-        raise NotImplementedError
-
-    def reverse_timestamps(
-        self, offset: Seconds, duration: Optional[Seconds], sampling_rate: int
-    ) -> Tuple[Seconds, Optional[Seconds]]:
-        """
-        Convert ``offset`` and ``duration`` timestamps to be adequate for the audio before the transform.
-        Useful for on-the-fly augmentation when a particular chunk of audio needs to be read from disk.
-
-        To be implemented in derived classes.
-        """
-        raise NotImplementedError
 
 
 @dataclass

--- a/lhotse/augmentation/transform.py
+++ b/lhotse/augmentation/transform.py
@@ -1,0 +1,74 @@
+from dataclasses import asdict
+from typing import Optional, Tuple
+
+import numpy as np
+
+from lhotse.utils import Seconds
+
+
+class AudioTransform:
+    """
+    Base class for all audio transforms that are going to be lazily applied on
+    ``Recording`` during loading the audio into memory.
+
+    Any ``AudioTransform`` can be used like a Python function, that expects two arguments:
+    a numpy array of samples, and a sampling rate. E.g.:
+
+        >>> fn = AudioTransform.from_dict(...)
+        >>> new_audio = fn(audio, sampling_rate)
+
+    Since we often use cuts of the original recording, they will refer to the timestamps
+    of the augmented audio (which might be speed perturbed and of different duration).
+    Each transform provides a helper method to recover the original audio timestamps:
+
+        >>> # When fn does speed perturbation:
+        >>> fn.reverse_timestamps(offset=5.055555, duration=10.1111111, sampling_rate=16000)
+        ... (5.0, 10.0)
+
+    Furthermore, ``AudioTransform`` can be easily (de)serialized to/from dict
+    that contains its name and parameters.
+    This enables storing recording and cut manifests with the transform info
+    inside, avoiding the need to store the augmented recording version on disk.
+
+    All audio transforms derived from this class are "automagically" registered,
+    so that ``AudioTransform.from_dict()`` can "find" the right type given its name
+    to instantiate a specific transform object.
+    All child classes are expected to be decorated with a ``@dataclass`` decorator.
+    """
+
+    KNOWN_TRANSFORMS = {}
+
+    def __init_subclass__(cls, **kwargs):
+        if cls.__name__ not in AudioTransform.KNOWN_TRANSFORMS:
+            AudioTransform.KNOWN_TRANSFORMS[cls.__name__] = cls
+        super().__init_subclass__(**kwargs)
+
+    def to_dict(self) -> dict:
+        data = asdict(self)
+        return {"name": type(self).__name__, "kwargs": data}
+
+    @staticmethod
+    def from_dict(data: dict) -> "AudioTransform":
+        assert (
+            data["name"] in AudioTransform.KNOWN_TRANSFORMS
+        ), f"Unknown transform type: {data['name']}"
+        return AudioTransform.KNOWN_TRANSFORMS[data["name"]](**data["kwargs"])
+
+    def __call__(self, samples: np.ndarray, sampling_rate: int) -> np.ndarray:
+        """
+        Apply transform.
+
+        To be implemented in derived classes.
+        """
+        raise NotImplementedError
+
+    def reverse_timestamps(
+        self, offset: Seconds, duration: Optional[Seconds], sampling_rate: int
+    ) -> Tuple[Seconds, Optional[Seconds]]:
+        """
+        Convert ``offset`` and ``duration`` timestamps to be adequate for the audio before the transform.
+        Useful for on-the-fly augmentation when a particular chunk of audio needs to be read from disk.
+
+        To be implemented in derived classes.
+        """
+        raise NotImplementedError

--- a/lhotse/augmentation/wpe.py
+++ b/lhotse/augmentation/wpe.py
@@ -1,0 +1,75 @@
+from dataclasses import asdict, dataclass
+from typing import Optional, Tuple
+
+import numpy as np
+import torch
+
+from lhotse.augmentation.transform import AudioTransform
+from lhotse.utils import Seconds, is_module_available
+
+
+@dataclass
+class DereverbWPE(AudioTransform):
+    """
+    Dereverberation with Weighted Prediction Error (WPE).
+    The implementation and default values are borrowed from `nara_wpe`.
+    """
+
+    n_fft: int = 512
+    hop_length: int = 128
+    taps: int = 10
+    delay: int = 3
+    iterations: int = 3
+    statistics_mode: str = "full"
+
+    def __call__(self, samples: np.ndarray, *args, **kwargs) -> np.ndarray:
+        if isinstance(samples, np.ndarray):
+            samples = torch.from_numpy(samples)
+        augmented = dereverb_wpe_torch(samples, **asdict(self))
+        return augmented.numpy()
+
+    def reverse_timestamps(
+        self, offset: Seconds, duration: Optional[Seconds], sampling_rate: int
+    ) -> Tuple[Seconds, Optional[Seconds]]:
+        return offset, duration
+
+
+def dereverb_wpe_torch(
+    audio: torch.Tensor,
+    n_fft: int = 512,
+    hop_length: int = 128,
+    taps: int = 10,
+    delay: int = 3,
+    iterations: int = 3,
+    statistics_mode: str = "full",
+) -> torch.Tensor:
+    if not is_module_available("nara_wpe"):
+        raise ImportError(
+            "Please install nara_wpe first using 'pip install git+https://github.com/fgnt/nara_wpe' "
+            "(at the time of writing, only GitHub version has a PyTorch implementation)."
+        )
+
+    from nara_wpe.torch_wpe import wpe_v6
+
+    assert audio.ndim == 2
+
+    window = torch.blackman_window(n_fft)
+    Y = torch.stft(
+        audio,
+        n_fft=n_fft,
+        hop_length=hop_length,
+        return_complex=True,
+        window=window,
+    )
+    Y = Y.permute(1, 0, 2)
+    Z = wpe_v6(
+        Y,
+        taps=taps,
+        delay=delay,
+        iterations=iterations,
+        statistics_mode=statistics_mode,
+    )
+    z = torch.istft(
+        Z.permute(1, 0, 2), n_fft=n_fft, hop_length=hop_length, window=window
+    )
+    return z

--- a/lhotse/augmentation/wpe.py
+++ b/lhotse/augmentation/wpe.py
@@ -12,7 +12,8 @@ from lhotse.utils import Seconds, is_module_available
 class DereverbWPE(AudioTransform):
     """
     Dereverberation with Weighted Prediction Error (WPE).
-    The implementation and default values are borrowed from `nara_wpe`.
+    The implementation and default values are borrowed from `nara_wpe` package:
+    https://github.com/fgnt/nara_wpe
     """
 
     n_fft: int = 512

--- a/lhotse/dataset/signal_transforms.py
+++ b/lhotse/dataset/signal_transforms.py
@@ -403,6 +403,7 @@ class DereverbWPE(torch.nn.Module):
     The method and library are described in the following paper:
     https://groups.uni-paderborn.de/nt/pubs/2018/ITG_2018_Drude_Paper.pdf
     """
+
     def __init__(self, n_fft: int = 512, hop_length: int = 128):
         super().__init__()
         self.n_fft = n_fft

--- a/lhotse/dataset/signal_transforms.py
+++ b/lhotse/dataset/signal_transforms.py
@@ -395,6 +395,14 @@ def random_mask_along_batch_axis(tensor: torch.Tensor, p: float = 0.5) -> torch.
 
 
 class DereverbWPE(torch.nn.Module):
+    """
+    Dereverberation with Weighted Prediction Error (WPE).
+    The implementation and default values are borrowed from `nara_wpe` package:
+    https://github.com/fgnt/nara_wpe
+
+    The method and library are described in the following paper:
+    https://groups.uni-paderborn.de/nt/pubs/2018/ITG_2018_Drude_Paper.pdf
+    """
     def __init__(self, n_fft: int = 512, hop_length: int = 128):
         super().__init__()
         self.n_fft = n_fft

--- a/lhotse/dataset/signal_transforms.py
+++ b/lhotse/dataset/signal_transforms.py
@@ -1,15 +1,16 @@
 import bisect
 import math
 import random
-from typing import Optional, Sequence, Tuple, TypeVar, Union, Dict
+from typing import Dict, Optional, Sequence, Tuple, TypeVar, Union
 
 import numpy as np
 import torch
 
 from lhotse import CutSet
+from lhotse.augmentation import dereverb_wpe_torch
 from lhotse.utils import Pathlike
 
-__all__ = ["GlobalMVN", "SpecAugment", "RandomizedSmoothing"]
+__all__ = ["GlobalMVN", "SpecAugment", "RandomizedSmoothing", "DereverbWPE"]
 
 
 class GlobalMVN(torch.nn.Module):
@@ -391,3 +392,40 @@ def random_mask_along_batch_axis(tensor: torch.Tensor, p: float = 0.5) -> torch.
     mask_shape = (tensor.shape[0],) + tuple(1 for _ in tensor.shape[1:])
     mask = (torch.rand(mask_shape) > p).to(torch.float32)
     return mask
+
+
+class DereverbWPE(torch.nn.Module):
+    def __init__(self, n_fft: int = 512, hop_length: int = 128):
+        super().__init__()
+        self.n_fft = n_fft
+        self.hop_length = hop_length
+
+    def forward(self, audio: torch.Tensor, *args, **kwargs) -> torch.Tensor:
+        """
+        Expects audio to be 2D or 3D tensor.
+        2D means a batch of single-channel audio, shape (B, T).
+        3D means a batch of multi-channel audio, shape (B, D, T).
+        B => batch size; D => number of channels; T => number of audio samples.
+        """
+
+        # Assume batch of single-channel data: apply dereverb to each example independently.
+        if audio.ndim == 2:
+            return torch.cat(
+                [
+                    dereverb_wpe_torch(
+                        a.unsqueeze(0), n_fft=self.n_fft, hop_length=self.hop_length
+                    )
+                    for a in audio
+                ],
+                dim=0,
+            )
+
+        # Assume batch of multi-channel data: each example has D channels.
+        assert audio.ndim == 3
+        return torch.stack(
+            [
+                dereverb_wpe_torch(a, n_fft=self.n_fft, hop_length=self.hop_length)
+                for a in audio
+            ],
+            dim=0,
+        )

--- a/test/augmentation/test_torchaudio.py
+++ b/test/augmentation/test_torchaudio.py
@@ -1,8 +1,8 @@
 import math
 
+import numpy as np
 import pytest
 import torch
-import numpy as np
 from hypothesis import given, settings
 from hypothesis import strategies as st
 from numpy.testing import assert_array_almost_equal
@@ -20,7 +20,8 @@ from lhotse.augmentation import (
     Volume,
     ReverbWithImpulseResponse,
 )
-from lhotse import AudioTransform, MonoCut, Recording, Resample, Seconds
+from lhotse import MonoCut, Recording, Resample, Seconds
+from lhotse.augmentation.transform import AudioTransform
 
 SAMPLING_RATE = 16000
 

--- a/test/dataset/test_signal_transforms.py
+++ b/test/dataset/test_signal_transforms.py
@@ -169,7 +169,9 @@ def test_randomized_smoothing_schedule():
     assert audio_aug2.abs().sum() > audio_aug.abs().sum()
 
 
-@pytest.mark.skipif(not is_module_available("nara_wpe"), reason="Requires nara_wpe to be installed.")
+@pytest.mark.skipif(
+    not is_module_available("nara_wpe"), reason="Requires nara_wpe to be installed."
+)
 def test_wpe_single_channel():
     B, T = 16, 32000
     audio = torch.randn(B, T, dtype=torch.float32)
@@ -181,7 +183,9 @@ def test_wpe_single_channel():
     assert (audio != audio_aug).any()
 
 
-@pytest.mark.skipif(not is_module_available("nara_wpe"), reason="Requires nara_wpe to be installed.")
+@pytest.mark.skipif(
+    not is_module_available("nara_wpe"), reason="Requires nara_wpe to be installed."
+)
 def test_wpe_multi_channel():
     B, D, T = 16, 2, 32000
     audio = torch.randn(B, D, T, dtype=torch.float32)

--- a/test/dataset/test_signal_transforms.py
+++ b/test/dataset/test_signal_transforms.py
@@ -6,6 +6,7 @@ import torch
 from lhotse import CutSet
 from lhotse.dataset import GlobalMVN, RandomizedSmoothing, SpecAugment
 from lhotse.dataset.collation import collate_features
+from lhotse.dataset.signal_transforms import DereverbWPE
 
 
 @pytest.fixture
@@ -165,3 +166,25 @@ def test_randomized_smoothing_schedule():
     audio_aug2 = tfnm(audio)
     # The schedule kicked in and the abs magnitudes should be larger.
     assert audio_aug2.abs().sum() > audio_aug.abs().sum()
+
+
+def test_wpe_single_channel():
+    B, T = 16, 32000
+    audio = torch.randn(B, T, dtype=torch.float32)
+    tfnm = DereverbWPE()
+    audio_aug = tfnm(audio)
+    # Shapes are the same
+    assert audio.shape == audio_aug.shape
+    # Some samples are different than the input audio
+    assert (audio != audio_aug).any()
+
+
+def test_wpe_multi_channel():
+    B, D, T = 16, 2, 32000
+    audio = torch.randn(B, D, T, dtype=torch.float32)
+    tfnm = DereverbWPE()
+    audio_aug = tfnm(audio)
+    # Shapes are the same
+    assert audio.shape == audio_aug.shape
+    # Some samples are different than the input audio
+    assert (audio != audio_aug).any()

--- a/test/dataset/test_signal_transforms.py
+++ b/test/dataset/test_signal_transforms.py
@@ -7,6 +7,7 @@ from lhotse import CutSet
 from lhotse.dataset import GlobalMVN, RandomizedSmoothing, SpecAugment
 from lhotse.dataset.collation import collate_features
 from lhotse.dataset.signal_transforms import DereverbWPE
+from lhotse.utils import is_module_available
 
 
 @pytest.fixture
@@ -168,6 +169,7 @@ def test_randomized_smoothing_schedule():
     assert audio_aug2.abs().sum() > audio_aug.abs().sum()
 
 
+@pytest.mark.skipif(not is_module_available("nara_wpe"), reason="Requires nara_wpe to be installed.")
 def test_wpe_single_channel():
     B, T = 16, 32000
     audio = torch.randn(B, T, dtype=torch.float32)
@@ -179,6 +181,7 @@ def test_wpe_single_channel():
     assert (audio != audio_aug).any()
 
 
+@pytest.mark.skipif(not is_module_available("nara_wpe"), reason="Requires nara_wpe to be installed.")
 def test_wpe_multi_channel():
     B, D, T = 16, 2, 32000
     audio = torch.randn(B, D, T, dtype=torch.float32)


### PR DESCRIPTION
I added WPE using `nara_wpe` (optional dependency) as a torch.nn.Module `DereverbWPE`. I was able to verify by listening to the outputs that it appears to work correctly (although the audible differences are very slight, at least for single-channel data).

It also moves `AudioTransform` to a different file without any changes. Ultimately I didn't add a complementary `cut.dereverb_wpe()` API, but it should be straightforward to do by following other data aug examples (e.g. `perturb_speed`, `reverb_rir`) if somebody needs it.