### PR TITLE
Fixes to split-lazy

### DIFF
--- a/lhotse/audio.py
+++ b/lhotse/audio.py
@@ -933,7 +933,9 @@ class RecordingSet(Serializable, AlgorithmMixin):
             )
         ]
 
-    def split_lazy(self, output_dir: Pathlike, chunk_size: int) -> List["RecordingSet"]:
+    def split_lazy(
+        self, output_dir: Pathlike, chunk_size: int, prefix: str
+    ) -> List["RecordingSet"]:
         """
         Splits a manifest (either lazily or eagerly opened) into chunks, each
         with ``chunk_size`` items (except for the last one, typically).
@@ -945,11 +947,14 @@ class RecordingSet(Serializable, AlgorithmMixin):
             input manifest for this method.
 
         :param output_dir: directory where the split manifests are saved.
-            Each manifest is saved at: ``{output_dir}/{split_idx}.jsonl.gz``
+            Each manifest is saved at: ``{output_dir}/{prefix}.{split_idx}.jsonl.gz``
         :param chunk_size: the number of items in each chunk.
+        :param prefix: the prefix of each manifest.
         :return: a list of lazily opened chunk manifests.
         """
-        return split_manifest_lazy(self, output_dir=output_dir, chunk_size=chunk_size)
+        return split_manifest_lazy(
+            self, output_dir=output_dir, chunk_size=chunk_size, prefix=prefix
+        )
 
     def subset(
         self, first: Optional[int] = None, last: Optional[int] = None

--- a/lhotse/audio.py
+++ b/lhotse/audio.py
@@ -934,7 +934,7 @@ class RecordingSet(Serializable, AlgorithmMixin):
         ]
 
     def split_lazy(
-        self, output_dir: Pathlike, chunk_size: int, prefix: str
+        self, output_dir: Pathlike, chunk_size: int, prefix: str = ""
     ) -> List["RecordingSet"]:
         """
         Splits a manifest (either lazily or eagerly opened) into chunks, each

--- a/lhotse/bin/modes/manipulation.py
+++ b/lhotse/bin/modes/manipulation.py
@@ -165,7 +165,7 @@ def split_lazy(manifest: Pathlike, output_dir: Pathlike, chunk_size: int):
     """
     Load MANIFEST (lazily if in JSONL format) and split it into parts,
     each with CHUNK_SIZE items.
-    The parts are saved to separate files with pattern 
+    The parts are saved to separate files with pattern
     "{output_dir}/{manifest.stem}.{chunk_idx}.jsonl.gz".
 
     Prefer this to "lhotse split" when your manifests are very large.

--- a/lhotse/bin/modes/manipulation.py
+++ b/lhotse/bin/modes/manipulation.py
@@ -165,7 +165,8 @@ def split_lazy(manifest: Pathlike, output_dir: Pathlike, chunk_size: int):
     """
     Load MANIFEST (lazily if in JSONL format) and split it into parts,
     each with CHUNK_SIZE items.
-    The parts are saved to separate files with pattern "{output_dir}/{chunk_idx}.jsonl.gz".
+    The parts are saved to separate files with pattern 
+    "{output_dir}/{manifest.stem}.{chunk_idx}.jsonl.gz".
 
     Prefer this to "lhotse split" when your manifests are very large.
     """
@@ -174,7 +175,9 @@ def split_lazy(manifest: Pathlike, output_dir: Pathlike, chunk_size: int):
     output_dir = Path(output_dir)
     manifest = Path(manifest)
     any_set = load_manifest_lazy_or_eager(manifest)
-    any_set.split_lazy(output_dir=output_dir, chunk_size=chunk_size)
+    any_set.split_lazy(
+        output_dir=output_dir, chunk_size=chunk_size, prefix=manifest.stem
+    )
 
 
 @cli.command()

--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -3655,7 +3655,7 @@ class CutSet(Serializable, AlgorithmMixin):
         ]
 
     def split_lazy(
-        self, output_dir: Pathlike, chunk_size: int, prefix: str
+        self, output_dir: Pathlike, chunk_size: int, prefix: str = ""
     ) -> List["CutSet"]:
         """
         Splits a manifest (either lazily or eagerly opened) into chunks, each

--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -3654,7 +3654,9 @@ class CutSet(Serializable, AlgorithmMixin):
             )
         ]
 
-    def split_lazy(self, output_dir: Pathlike, chunk_size: int) -> List["CutSet"]:
+    def split_lazy(
+        self, output_dir: Pathlike, chunk_size: int, prefix: str
+    ) -> List["CutSet"]:
         """
         Splits a manifest (either lazily or eagerly opened) into chunks, each
         with ``chunk_size`` items (except for the last one, typically).
@@ -3667,11 +3669,14 @@ class CutSet(Serializable, AlgorithmMixin):
 
         :param it: any iterable of Lhotse manifests.
         :param output_dir: directory where the split manifests are saved.
-            Each manifest is saved at: ``{output_dir}/{split_idx}.jsonl.gz``
+            Each manifest is saved at: ``{output_dir}/{prefix}.{split_idx}.jsonl.gz``
         :param chunk_size: the number of items in each chunk.
+        :param prefix: the prefix of each manifest.
         :return: a list of lazily opened chunk manifests.
         """
-        return split_manifest_lazy(self, output_dir=output_dir, chunk_size=chunk_size)
+        return split_manifest_lazy(
+            self, output_dir=output_dir, chunk_size=chunk_size, prefix=prefix
+        )
 
     def subset(
         self,

--- a/lhotse/features/base.py
+++ b/lhotse/features/base.py
@@ -636,7 +636,7 @@ class FeatureSet(Serializable, AlgorithmMixin):
         ]
 
     def split_lazy(
-        self, output_dir: Pathlike, chunk_size: int, prefix: str
+        self, output_dir: Pathlike, chunk_size: int, prefix: str = ""
     ) -> List["FeatureSet"]:
         """
         Splits a manifest (either lazily or eagerly opened) into chunks, each

--- a/lhotse/features/base.py
+++ b/lhotse/features/base.py
@@ -635,7 +635,9 @@ class FeatureSet(Serializable, AlgorithmMixin):
             )
         ]
 
-    def split_lazy(self, output_dir: Pathlike, chunk_size: int) -> List["FeatureSet"]:
+    def split_lazy(
+        self, output_dir: Pathlike, chunk_size: int, prefix: str
+    ) -> List["FeatureSet"]:
         """
         Splits a manifest (either lazily or eagerly opened) into chunks, each
         with ``chunk_size`` items (except for the last one, typically).
@@ -648,11 +650,14 @@ class FeatureSet(Serializable, AlgorithmMixin):
 
         :param it: any iterable of Lhotse manifests.
         :param output_dir: directory where the split manifests are saved.
-            Each manifest is saved at: ``{output_dir}/{split_idx}.jsonl.gz``
+            Each manifest is saved at: ``{output_dir}/{prefix}.{split_idx}.jsonl.gz``
         :param chunk_size: the number of items in each chunk.
+        :param prefix: the prefix of each manifest.
         :return: a list of lazily opened chunk manifests.
         """
-        return split_manifest_lazy(self, output_dir=output_dir, chunk_size=chunk_size)
+        return split_manifest_lazy(
+            self, output_dir=output_dir, chunk_size=chunk_size, prefix=prefix
+        )
 
     def shuffle(self, *args, **kwargs):
         raise NotImplementedError("FeatureSet does not support shuffling.")

--- a/lhotse/supervision.py
+++ b/lhotse/supervision.py
@@ -657,7 +657,7 @@ class SupervisionSet(Serializable, AlgorithmMixin):
         ]
 
     def split_lazy(
-        self, output_dir: Pathlike, chunk_size: int, prefix: str
+        self, output_dir: Pathlike, chunk_size: int, prefix: str = ""
     ) -> List["SupervisionSet"]:
         """
         Splits a manifest (either lazily or eagerly opened) into chunks, each

--- a/lhotse/supervision.py
+++ b/lhotse/supervision.py
@@ -657,7 +657,7 @@ class SupervisionSet(Serializable, AlgorithmMixin):
         ]
 
     def split_lazy(
-        self, output_dir: Pathlike, chunk_size: int
+        self, output_dir: Pathlike, chunk_size: int, prefix: str
     ) -> List["SupervisionSet"]:
         """
         Splits a manifest (either lazily or eagerly opened) into chunks, each
@@ -671,11 +671,14 @@ class SupervisionSet(Serializable, AlgorithmMixin):
 
         :param it: any iterable of Lhotse manifests.
         :param output_dir: directory where the split manifests are saved.
-            Each manifest is saved at: ``{output_dir}/{split_idx}.jsonl.gz``
+            Each manifest is saved at: ``{output_dir}/{prefix}.{split_idx}.jsonl.gz``
         :param chunk_size: the number of items in each chunk.
+        :param prefix: the prefix of each manifest.
         :return: a list of lazily opened chunk manifests.
         """
-        return split_manifest_lazy(self, output_dir=output_dir, chunk_size=chunk_size)
+        return split_manifest_lazy(
+            self, output_dir=output_dir, chunk_size=chunk_size, prefix=prefix
+        )
 
     def subset(
         self, first: Optional[int] = None, last: Optional[int] = None

--- a/lhotse/utils.py
+++ b/lhotse/utils.py
@@ -293,7 +293,7 @@ def split_manifest_lazy(
     output_dir.mkdir(parents=True, exist_ok=True)
 
     items = iter(it)
-    split_idx = 0
+    split_idx = 1
     splits = []
     while True:
         try:

--- a/lhotse/utils.py
+++ b/lhotse/utils.py
@@ -268,7 +268,7 @@ def fastcopy(dataclass_obj: T, **kwargs) -> T:
 
 
 def split_manifest_lazy(
-    it: Iterable[Any], output_dir: Pathlike, chunk_size: int
+    it: Iterable[Any], output_dir: Pathlike, chunk_size: int, prefix: str
 ) -> List:
     """
     Splits a manifest (either lazily or eagerly opened) into chunks, each
@@ -282,8 +282,9 @@ def split_manifest_lazy(
 
     :param it: any iterable of Lhotse manifests.
     :param output_dir: directory where the split manifests are saved.
-        Each manifest is saved at: ``{output_dir}/{split_idx}.jsonl.gz``
+        Each manifest is saved at: ``{output_dir}/{prefix}.{split_idx}.jsonl.gz``
     :param chunk_size: the number of items in each chunk.
+    :param prefix: the prefix of each manifest.
     :return: a list of lazily opened chunk manifests.
     """
     from lhotse.serialization import SequentialJsonlWriter
@@ -297,7 +298,9 @@ def split_manifest_lazy(
     while True:
         try:
             written = 0
-            with SequentialJsonlWriter(output_dir / f"{split_idx}.jsonl.gz") as writer:
+            with SequentialJsonlWriter(
+                (output_dir / prefix).with_suffix(f".{split_idx}.jsonl.gz")
+            ) as writer:
                 while written < chunk_size:
                     item = next(items)
                     writer.write(item)

--- a/lhotse/utils.py
+++ b/lhotse/utils.py
@@ -268,7 +268,7 @@ def fastcopy(dataclass_obj: T, **kwargs) -> T:
 
 
 def split_manifest_lazy(
-    it: Iterable[Any], output_dir: Pathlike, chunk_size: int, prefix: str
+    it: Iterable[Any], output_dir: Pathlike, chunk_size: int, prefix: str = ""
 ) -> List:
     """
     Splits a manifest (either lazily or eagerly opened) into chunks, each
@@ -291,6 +291,9 @@ def split_manifest_lazy(
 
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
+
+    if prefix == "":
+        prefix = "split"
 
     items = iter(it)
     split_idx = 1


### PR DESCRIPTION
Add prefix and start from 1: change from `0.jsonl.gz` to `cuts_XL_raw.1.jsonl.gz`

However, it's hard to generate `cuts_XL_raw.0001.jsonl.gz`, because we cannot know how many splits would be in advance while doing lazy-loading.