### PR TITLE
Fix reading duration when importing piped input data from kaldi

### DIFF
--- a/lhotse/kaldi.py
+++ b/lhotse/kaldi.py
@@ -35,10 +35,10 @@ def get_duration(
             )
         import kaldi_native_io
 
-        wave_info = kaldi_native_io.read_wave_info(path)
-        assert wave_info.num_channels == 1, wave_info.num_channels
+        wave = kaldi_native_io.read_wave(path)
+        assert wave.data.shape[0] == 1, f"Expect 1 channel. Given {wave.data.shape[0]}"
 
-        return wave_info.duration
+        return wave.duration
     try:
         # Try to parse the file using pysoundfile first.
         import soundfile


### PR DESCRIPTION
Fixes #659

The original implementation only reads the header to get the wave info. It is efficient when the input is a file.
However, it causes problems when the input is from a pipe as it closes the pipe as soon as it finishes reading the data, even if the pipe writer is still writing.

This PR should fix that. It requires kaldi_native_io v1.5 (i.e., the latest version as of 2022-04-13)