### PR TITLE
Count num_digits before split-lazy

### DIFF
--- a/lhotse/utils.py
+++ b/lhotse/utils.py
@@ -296,13 +296,21 @@ def split_manifest_lazy(
         prefix = "split"
 
     items = iter(it)
+    num_items = 0
+    for item in items:
+        num_items += 1
+    num_splits = math.ceil(num_items / chunk_size)
+    num_digits = len(str(num_splits))
+
+    items = iter(it)
     split_idx = 1
     splits = []
     while True:
         try:
             written = 0
+            idx = f"{split_idx}".zfill(num_digits)
             with SequentialJsonlWriter(
-                (output_dir / prefix).with_suffix(f".{split_idx}.jsonl.gz")
+                (output_dir / prefix).with_suffix(f".{idx}.jsonl.gz")
             ) as writer:
                 while written < chunk_size:
                     item = next(items)

--- a/lhotse/utils.py
+++ b/lhotse/utils.py
@@ -295,12 +295,7 @@ def split_manifest_lazy(
     if prefix == "":
         prefix = "split"
 
-    items = iter(it)
-    num_items = 0
-    for item in items:
-        num_items += 1
-    num_splits = math.ceil(num_items / chunk_size)
-    num_digits = len(str(num_splits))
+    num_digits = 8
 
     items = iter(it)
     split_idx = 1


### PR DESCRIPTION
change output from `cuts_XL_raw.1.jsonl.gz` to `cuts_XL_raw.0001.jsonl.gz`

this makes `lhotse split-lazy` slightly slower but consistent with `lhotse split`

Feel free to close this PR if this breaks the nature of `lazy-load`