### PR TITLE
~20x faster speed perturbation

### DIFF
--- a/lhotse/augmentation/torchaudio.py
+++ b/lhotse/augmentation/torchaudio.py
@@ -114,16 +114,10 @@ class Speed(AudioTransform):
     factor: float
 
     def __call__(self, samples: np.ndarray, sampling_rate: int) -> np.ndarray:
-        check_torchaudio_version()
-        import torchaudio
-
-        sampling_rate = int(sampling_rate)  # paranoia mode
-        effect = [["speed", str(self.factor)], ["rate", str(sampling_rate)]]
-        if isinstance(samples, np.ndarray):
-            samples = torch.from_numpy(samples)
-        augmented, new_sampling_rate = torchaudio.sox_effects.apply_effects_tensor(
-            samples, sampling_rate, effect
+        resampler = get_or_create_resampler(
+            round(sampling_rate * self.factor), sampling_rate
         )
+        augmented = resampler(torch.from_numpy(samples))
         return augmented.numpy()
 
     def reverse_timestamps(

--- a/test/augmentation/test_torchaudio.py
+++ b/test/augmentation/test_torchaudio.py
@@ -127,7 +127,7 @@ def test_reverb_normalize_output(audio, rir, normalize_output, early_only):
 def test_speed(audio):
     speed = Speed(factor=1.1)
     perturbed = speed(audio, SAMPLING_RATE)
-    assert perturbed.shape == (1, 14545)
+    assert perturbed.shape == (1, 14546)
 
 
 @pytest.mark.parametrize("scale", [0.125, 1.0, 2.0])
@@ -143,7 +143,7 @@ def test_deserialize_transform_speed(audio):
     speed = AudioTransform.from_dict({"name": "Speed", "kwargs": {"factor": 1.1}})
     perturbed_speed = speed(audio, SAMPLING_RATE)
 
-    assert perturbed_speed.shape == (1, 14545)
+    assert perturbed_speed.shape == (1, 14546)
 
 
 def test_deserialize_transform_volume(audio):
@@ -160,7 +160,7 @@ def test_serialize_deserialize_transform_speed(audio):
     speed = AudioTransform.from_dict(data_speed)
     perturbed_speed = speed(audio, SAMPLING_RATE)
 
-    assert perturbed_speed.shape == (1, 14545)
+    assert perturbed_speed.shape == (1, 14546)
 
 
 def test_serialize_deserialize_transform_volume(audio):


### PR DESCRIPTION
CC @csukuangfj @danpovey this might help you with speeding up on the fly extraction. A while ago I noticed that resampling was the biggest bottleneck in my dataloading code, and then I found that sox uses a very high quality algorithm that is 20-30x slower than torchaudio's sinc interpolation. Since speed perturbation is just resampling, I figured the same speedup can be achieved here. A simple benchmark of new vs old impl:

<img width="670" alt="image" src="https://user-images.githubusercontent.com/15930688/163300248-a4817f75-ca72-410e-bc19-4c7d1b6605db.png">

There are slight differences in the signal, but they are not audible to me (note the Y axis scales).. 
<img width="414" alt="image" src="https://user-images.githubusercontent.com/15930688/163300413-99af4772-92cf-4bfb-993e-96618b6f8ccf.png">
