### PR TITLE
Fix restoring state in dynamic samplers with DataLoader num_workers>0

### DIFF
--- a/lhotse/dataset/sampling/dynamic.py
+++ b/lhotse/dataset/sampling/dynamic.py
@@ -168,7 +168,6 @@ class DynamicCutSampler(CutSampler):
 
     def __iter__(self) -> "DynamicCutSampler":
         if self._just_restored_state:
-            self.allow_iter_to_reset_state()
             return self
         self.rng = random.Random(self.seed + self.epoch)
         # Initiate iteration

--- a/lhotse/dataset/sampling/dynamic_bucketing.py
+++ b/lhotse/dataset/sampling/dynamic_bucketing.py
@@ -203,7 +203,6 @@ class DynamicBucketingSampler(CutSampler):
 
     def __iter__(self) -> "DynamicBucketingSampler":
         if self._just_restored_state:
-            self.allow_iter_to_reset_state()
             return self
         self.rng = random.Random(self.seed + self.epoch)
         # Initiate iteration

--- a/lhotse/dataset/sampling/simple.py
+++ b/lhotse/dataset/sampling/simple.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, Optional
 from lhotse import CutSet, Seconds
 from lhotse.dataset.sampling.base import CutSampler, TimeConstraint
 from lhotse.dataset.sampling.data_source import DataSource
-from lhotse.utils import is_none_or_gt
 
 
 class SimpleCutSampler(CutSampler):

--- a/test/dataset/sampling/test_sampler_restoring.py
+++ b/test/dataset/sampling/test_sampler_restoring.py
@@ -246,8 +246,12 @@ class DummyDataset(torch.utils.data.Dataset):
                 drop_last=True,
             ),
         ),
-        lambda: DynamicCutSampler(CUTS, max_duration=10.0, shuffle=True, drop_last=True),
-        lambda: DynamicBucketingSampler(CUTS, max_duration=10.0, shuffle=True, drop_last=True),
+        lambda: DynamicCutSampler(
+            CUTS, max_duration=10.0, shuffle=True, drop_last=True
+        ),
+        lambda: DynamicBucketingSampler(
+            CUTS, max_duration=10.0, shuffle=True, drop_last=True
+        ),
     ],
 )
 @pytest.mark.parametrize("num_workers", [0, 1])

--- a/test/dataset/sampling/test_sampler_restoring.py
+++ b/test/dataset/sampling/test_sampler_restoring.py
@@ -246,6 +246,8 @@ class DummyDataset(torch.utils.data.Dataset):
                 drop_last=True,
             ),
         ),
+        lambda: DynamicCutSampler(CUTS, max_duration=10.0, shuffle=True, drop_last=True),
+        lambda: DynamicBucketingSampler(CUTS, max_duration=10.0, shuffle=True, drop_last=True),
     ],
 )
 @pytest.mark.parametrize("num_workers", [0, 1])

--- a/test/dataset/sampling/test_sampler_restoring.py
+++ b/test/dataset/sampling/test_sampler_restoring.py
@@ -301,3 +301,8 @@ def test_e2e_restore_with_dataloader(num_workers, create_sampler):
         # and we cannot recover from it for now)
         assert len(batches) == 3
         assert batches == expected_batches[2:]
+
+    # Advance the epoch and make sure it is fully iterated
+    restored_dloader.sampler.set_epoch(2)
+    ep2_batches = list(restored_dloader)
+    assert len(ep2_batches) == 10


### PR DESCRIPTION
CC @luomingshuang now it should finally work as intended (I forgot to add state restoring tests for dynamic samplers so didn't find the issue before).