### PR TITLE
FIX: kaldi import fets.scp -- use the correct id when underscore mapping

### DIFF
--- a/lhotse/kaldi.py
+++ b/lhotse/kaldi.py
@@ -150,7 +150,7 @@ def load_kaldi_data_dir(
                     storage_type=KaldiReader.name,
                     storage_path=str(feats_scp),
                     storage_key=utt_id,
-                    recording_id=supervision_set[utt_id].recording_id
+                    recording_id=supervision_set[fix_id(utt_id)].recording_id
                     if supervision_set is not None
                     else utt_id,
                     channels=0,


### PR DESCRIPTION
This fixes crash when the `--map-string-to-underscores` option is used