### PR TITLE
Fix samplers dropping cuts when world_size > 1

### DIFF
--- a/lhotse/dataset/sampling/bucketing.py
+++ b/lhotse/dataset/sampling/bucketing.py
@@ -88,12 +88,12 @@ class BucketingSampler(CutSampler):
         """
         # Do not use the distributed capacities of the CutSampler in the top-level sampler.
         super().__init__(
+            drop_last=drop_last,
             world_size=1,
             rank=0,
             seed=seed,
         )
         self.num_buckets = num_buckets
-        self.drop_last = drop_last
         self.proportional_sampling = proportional_sampling
         self.sampler_type = sampler_type
         self.sampler_kwargs = kwargs
@@ -228,7 +228,6 @@ class BucketingSampler(CutSampler):
         state_dict.update(
             {
                 "num_buckets": self.num_buckets,
-                "drop_last": self.drop_last,
                 "proportional_sampling": self.proportional_sampling,
                 "bucket_method": self.bucket_method,
                 "depleted": deepcopy(self.depleted),
@@ -262,7 +261,6 @@ class BucketingSampler(CutSampler):
             "Error in BucketingSampler.load_state_dict(): Inconsistent number of buckets: "
             f"current sampler has {self.num_buckets}, the state_dict has {num_buckets}."
         )
-        self.drop_last = state_dict.pop("drop_last")
         self.proportional_sampling = state_dict.pop("proportional_sampling")
         self.bucket_method = state_dict.pop("bucket_method")
         self.sampler_kwargs = state_dict.pop("sampler_kwargs")

--- a/lhotse/dataset/sampling/cut_pairs.py
+++ b/lhotse/dataset/sampling/cut_pairs.py
@@ -64,6 +64,7 @@ class CutPairsSampler(CutSampler):
         :param seed: Random seed used to consistently shuffle the dataset across different processes.
         """
         super().__init__(
+            drop_last=drop_last,
             shuffle=shuffle,
             world_size=world_size,
             rank=rank,
@@ -86,7 +87,6 @@ class CutPairsSampler(CutSampler):
             max_cuts=max_cuts,
             strict=strict,
         )
-        self.drop_last = drop_last
 
     @property
     def remaining_duration(self) -> Optional[float]:
@@ -125,7 +125,6 @@ class CutPairsSampler(CutSampler):
         state_dict = super().state_dict()
         state_dict.update(
             {
-                "drop_last": self.drop_last,
                 "source_constraints": self.source_constraints.state_dict(),
                 "target_constraints": self.target_constraints.state_dict(),
             }
@@ -150,8 +149,6 @@ class CutPairsSampler(CutSampler):
             For implementers of sub-classes of CutSampler: the flag ``self._just_restored_state`` has to be
             handled in ``__iter__`` to make it avoid resetting the just-restored state (only once).
         """
-        self.drop_last = state_dict.pop("drop_last")
-
         source_constraints = TimeConstraint(**state_dict.pop("source_constraints"))
         if self.source_constraints != source_constraints:
             warnings.warn(

--- a/lhotse/dataset/sampling/dynamic.py
+++ b/lhotse/dataset/sampling/dynamic.py
@@ -108,7 +108,7 @@ class DynamicCutSampler(CutSampler):
         :param rank: Index of distributed node. We will try to infer it by default.
         :param seed: Random seed used to consistently shuffle the dataset across different processes.
         """
-        super().__init__(world_size=world_size, rank=rank, seed=seed)
+        super().__init__(drop_last=drop_last, world_size=world_size, rank=rank, seed=seed)
         if not all(cs.is_lazy for cs in cuts if isinstance(cs, CutSet)):
             warnings.warn(
                 "You are using DynamicCutSampler with an eagerly read CutSet. "
@@ -119,7 +119,6 @@ class DynamicCutSampler(CutSampler):
         self.max_duration = max_duration
         self.max_cuts = max_cuts
         self.shuffle = shuffle
-        self.drop_last = drop_last
         self.consistent_ids = consistent_ids
         self.shuffle_buffer_size = shuffle_buffer_size
         self.strict = strict
@@ -131,7 +130,6 @@ class DynamicCutSampler(CutSampler):
             {
                 "max_duration": self.max_duration,
                 "max_cuts": self.max_cuts,
-                "drop_last": self.drop_last,
                 "consistent_ids": self.consistent_ids,
                 "shuffle_buffer_size": self.shuffle_buffer_size,
                 "strict": self.strict,
@@ -142,7 +140,6 @@ class DynamicCutSampler(CutSampler):
     def load_state_dict(self, sd: Dict[str, Any]) -> None:
         self.max_duration = sd.pop("max_duration")
         self.max_cuts = sd.pop("max_cuts")
-        self.drop_last = sd.pop("drop_last")
         self.consistent_ids = sd.pop("consistent_ids")
         self.shuffle_buffer_size = sd.pop("shuffle_buffer_size")
         self.strict = sd.pop("strict")

--- a/lhotse/dataset/sampling/dynamic.py
+++ b/lhotse/dataset/sampling/dynamic.py
@@ -108,7 +108,9 @@ class DynamicCutSampler(CutSampler):
         :param rank: Index of distributed node. We will try to infer it by default.
         :param seed: Random seed used to consistently shuffle the dataset across different processes.
         """
-        super().__init__(drop_last=drop_last, world_size=world_size, rank=rank, seed=seed)
+        super().__init__(
+            drop_last=drop_last, world_size=world_size, rank=rank, seed=seed
+        )
         if not all(cs.is_lazy for cs in cuts if isinstance(cs, CutSet)):
             warnings.warn(
                 "You are using DynamicCutSampler with an eagerly read CutSet. "

--- a/lhotse/dataset/sampling/dynamic_bucketing.py
+++ b/lhotse/dataset/sampling/dynamic_bucketing.py
@@ -124,7 +124,7 @@ class DynamicBucketingSampler(CutSampler):
         :param rank: Index of distributed node. We will try to infer it by default.
         :param seed: Random seed used to consistently shuffle the dataset across different processes.
         """
-        super().__init__(world_size=world_size, rank=rank, seed=seed)
+        super().__init__(drop_last=drop_last, world_size=world_size, rank=rank, seed=seed)
         if not all(cs.is_lazy for cs in cuts if isinstance(cs, CutSet)):
             warnings.warn(
                 "You are using DynamicBucketingSampler with an eagerly read CutSet. "
@@ -135,7 +135,6 @@ class DynamicBucketingSampler(CutSampler):
         self.max_duration = max_duration
         self.max_cuts = max_cuts
         self.shuffle = shuffle
-        self.drop_last = drop_last
         self.consistent_ids = consistent_ids
         self.num_cuts_for_bins_estimate = num_cuts_for_bins_estimate
         self.buffer_size = buffer_size
@@ -162,7 +161,6 @@ class DynamicBucketingSampler(CutSampler):
             {
                 "max_duration": self.max_duration,
                 "max_cuts": self.max_cuts,
-                "drop_last": self.drop_last,
                 "consistent_ids": self.consistent_ids,
                 "buffer_size": self.buffer_size,
                 "num_cuts_for_bins_estimate": self.num_cuts_for_bins_estimate,
@@ -175,7 +173,6 @@ class DynamicBucketingSampler(CutSampler):
     def load_state_dict(self, sd: Dict[str, Any]) -> None:
         self.max_duration = sd.pop("max_duration")
         self.max_cuts = sd.pop("max_cuts")
-        self.drop_last = sd.pop("drop_last")
         self.consistent_ids = sd.pop("consistent_ids")
         self.num_cuts_for_bins_estimate = sd.pop("num_cuts_for_bins_estimate")
         self.buffer_size = sd.pop("buffer_size")

--- a/lhotse/dataset/sampling/dynamic_bucketing.py
+++ b/lhotse/dataset/sampling/dynamic_bucketing.py
@@ -124,7 +124,9 @@ class DynamicBucketingSampler(CutSampler):
         :param rank: Index of distributed node. We will try to infer it by default.
         :param seed: Random seed used to consistently shuffle the dataset across different processes.
         """
-        super().__init__(drop_last=drop_last, world_size=world_size, rank=rank, seed=seed)
+        super().__init__(
+            drop_last=drop_last, world_size=world_size, rank=rank, seed=seed
+        )
         if not all(cs.is_lazy for cs in cuts if isinstance(cs, CutSet)):
             warnings.warn(
                 "You are using DynamicBucketingSampler with an eagerly read CutSet. "

--- a/lhotse/dataset/sampling/simple.py
+++ b/lhotse/dataset/sampling/simple.py
@@ -65,6 +65,7 @@ class SimpleCutSampler(CutSampler):
         :param seed: Random seed used to consistently shuffle the dataset across different processes.
         """
         super().__init__(
+            drop_last=drop_last,
             shuffle=shuffle,
             world_size=world_size,
             rank=rank,
@@ -78,7 +79,6 @@ class SimpleCutSampler(CutSampler):
             max_cuts=max_cuts,
             strict=strict,
         )
-        self.drop_last = drop_last
 
     @property
     def remaining_duration(self) -> Optional[float]:
@@ -115,7 +115,6 @@ class SimpleCutSampler(CutSampler):
         state_dict = super().state_dict()
         state_dict.update(
             {
-                "drop_last": self.drop_last,
                 "time_constraint": self.time_constraint.state_dict(),
             }
         )
@@ -139,8 +138,6 @@ class SimpleCutSampler(CutSampler):
             For implementers of sub-classes of CutSampler: the flag ``self._just_restored_state`` has to be
             handled in ``__iter__`` to make it avoid resetting the just-restored state (only once).
         """
-        self.drop_last = state_dict.pop("drop_last")
-
         time_constraint = TimeConstraint(**state_dict.pop("time_constraint"))
         if self.time_constraint != time_constraint:
             warnings.warn(

--- a/test/dataset/sampling/test_sampling.py
+++ b/test/dataset/sampling/test_sampling.py
@@ -699,7 +699,9 @@ def test_partitions_are_equal(world_size, n_cuts, sampler_cls):
         c.duration += 10 * random.random()
     # Create a sampler for each "distributed worker."
     samplers = [
-        sampler_cls(cut_set, max_duration=25.0, drop_last=True, rank=i, world_size=world_size)
+        sampler_cls(
+            cut_set, max_duration=25.0, drop_last=True, rank=i, world_size=world_size
+        )
         for i in range(world_size)
     ]
     # Check that it worked.
@@ -1222,12 +1224,15 @@ def test_time_constraint_strictness():
     assert strict.exceeded()
 
 
-@pytest.mark.parametrize("sampler_fn", [
-    SimpleCutSampler,
-    DynamicCutSampler,
-    partial(BucketingSampler, num_buckets=2),
-    partial(DynamicBucketingSampler, num_buckets=2),
-])
+@pytest.mark.parametrize(
+    "sampler_fn",
+    [
+        SimpleCutSampler,
+        DynamicCutSampler,
+        partial(BucketingSampler, num_buckets=2),
+        partial(DynamicBucketingSampler, num_buckets=2),
+    ],
+)
 @pytest.mark.parametrize("world_size", [1, 2, 3, 4])
 def test_sampler_does_not_drop_cuts_with_multiple_ranks(world_size, sampler_fn):
     cuts = DummyManifest(CutSet, begin_id=0, end_id=10)

--- a/test/dataset/sampling/test_sampling.py
+++ b/test/dataset/sampling/test_sampling.py
@@ -1,5 +1,6 @@
 import random
 from copy import deepcopy
+from functools import partial
 from itertools import groupby
 from math import isclose
 from statistics import mean
@@ -698,7 +699,7 @@ def test_partitions_are_equal(world_size, n_cuts, sampler_cls):
         c.duration += 10 * random.random()
     # Create a sampler for each "distributed worker."
     samplers = [
-        sampler_cls(cut_set, max_duration=25.0, rank=i, world_size=world_size)
+        sampler_cls(cut_set, max_duration=25.0, drop_last=True, rank=i, world_size=world_size)
         for i in range(world_size)
     ]
     # Check that it worked.
@@ -1219,3 +1220,22 @@ def test_time_constraint_strictness():
 
     assert not normal.exceeded()
     assert strict.exceeded()
+
+
+@pytest.mark.parametrize("sampler_fn", [
+    SimpleCutSampler,
+    DynamicCutSampler,
+    partial(BucketingSampler, num_buckets=2),
+    partial(DynamicBucketingSampler, num_buckets=2),
+])
+@pytest.mark.parametrize("world_size", [1, 2, 3, 4])
+def test_sampler_does_not_drop_cuts_with_multiple_ranks(world_size, sampler_fn):
+    cuts = DummyManifest(CutSet, begin_id=0, end_id=10)
+
+    tot_cuts = 0
+    for rank in range(world_size):
+        sampler = sampler_fn(cuts, max_duration=1.0, world_size=world_size, rank=rank)
+        for batch in sampler:
+            tot_cuts += len(batch)
+
+    assert tot_cuts == len(cuts)


### PR DESCRIPTION
The old behavior was incorrect in that it dropped the remainder of data even if `drop_last=False`. This PR doesn't add any any extra options, but it is possible that with `drop_last=False` and `world_size>1` some nodes might see one batch less than the others. In this cases we recommend setting `drop_last=True`, or if data loss is unacceptable (e.g., model evaluation), use [PyTorch's distributed join algorithm](https://pytorch.org/docs/stable/distributed.algorithms.join.html?highlight=join#torch.distributed.algorithms.Join).