### PR TITLE
Kaldi impex: remove invalid test

### DIFF
--- a/test/test_kaldi_dirs.py
+++ b/test/test_kaldi_dirs.py
@@ -3,7 +3,6 @@ import os
 import pytest
 
 import lhotse
-import lhotse.utils
 from pathlib import Path
 
 FIXTURE_PATH = Path(__file__).resolve().parent / "fixtures"

--- a/test/test_kaldi_dirs.py
+++ b/test/test_kaldi_dirs.py
@@ -3,6 +3,7 @@ import os
 import pytest
 
 import lhotse
+import lhotse.utils
 from pathlib import Path
 
 FIXTURE_PATH = Path(__file__).resolve().parent / "fixtures"
@@ -163,19 +164,6 @@ def test_kaldi_import(replace):
 
     assert out[0] == recording_set
     assert out[1] == supervision_set
-
-
-@pytest.mark.xfail(reason="Import ordering is somehow not working for now")
-def test_get_duration_failurex(monkeypatch):
-    def always_fail_is_module_available(path):
-        return False
-
-    monkeypatch.setattr(
-        lhotse.utils.is_module_available, always_fail_is_module_available
-    )
-
-    with pytest.raises(ValueError):
-        lhotse.kaldi.get_duration("true |")
 
 
 def open_and_load(path):


### PR DESCRIPTION
I tried all possible combinations and I wasn't able to make it work with monkeypatching. Perhaps I originally didn't understand well enough what it can/cannot do.