### PR TITLE
Avoid being converted to ASCII when preparing manifest

### DIFF
--- a/lhotse/serialization.py
+++ b/lhotse/serialization.py
@@ -61,7 +61,7 @@ class YamlMixin:
 def save_to_json(data: Any, path: Pathlike) -> None:
     """Save the data to a JSON file. Will use GZip to compress it if the path ends with a ``.gz`` extension."""
     with open_best(path, "w") as f:
-        json.dump(data, f, indent=2)
+        json.dump(data, f, indent=2, ensure_ascii=False)
 
 
 def load_json(path: Pathlike) -> Union[dict, list]:


### PR DESCRIPTION
When I use the lhotse to prepare manifest for aidatatang_200zh, the text in manifest is converted to ASCII. So I add `ensure_ascii=False` to avoid this case. And after adding it, the text in manifest is normal (char).