### PR TITLE
[ali_meeting] Fix some path errors for ali_meeting.py

### DIFF
--- a/lhotse/recipes/ali_meeting.py
+++ b/lhotse/recipes/ali_meeting.py
@@ -95,6 +95,7 @@ def prepare_ali_meeting(
         recordings = []
         supervisions = []
         # Eval and Test may further be inside another folder (since the "far" and "near" are grouped together)
+        corpus_dir_split = corpus_dir
         if part == "Eval" or part == "Test":
             corpus_dir_split = (
                 corpus_dir / f"{part}_Ali"

--- a/lhotse/recipes/ali_meeting.py
+++ b/lhotse/recipes/ali_meeting.py
@@ -96,13 +96,13 @@ def prepare_ali_meeting(
         supervisions = []
         # Eval and Test may further be inside another folder (since the "far" and "near" are grouped together)
         if part == "Eval" or part == "Test":
-            corpus_dir = (
+            corpus_dir_split = (
                 corpus_dir / f"{part}_Ali"
                 if (corpus_dir / f"{part}_Ali").is_dir()
                 else corpus_dir
             )
-        wav_paths = corpus_dir / f"{part}_Ali_{mic}" / "audio_dir"
-        text_paths = corpus_dir / f"{part}_Ali_{mic}" / "textgrid_dir"
+        wav_paths = corpus_dir_split / f"{part}_Ali_{mic}" / "audio_dir"
+        text_paths = corpus_dir_split / f"{part}_Ali_{mic}" / "textgrid_dir"
 
         # For 'near' setting:
         #  - wav files have names like R0003_M0046_F_SPK0093.wav


### PR DESCRIPTION
In the original ali_meeting.py, the line 99-103 is 
```
            corpus_dir = (
                corpus_dir / f"{part}_Ali"
                if (corpus_dir / f"{part}_Ali").is_dir()
                else corpus_dir
            )
```
After the loop when the part is "Eval", the corpus_dir becomes `corpus_dir / "Eval_Ali"`. And then, when comes to the loop that the part is "Test", the corpus_dir will be `corpus_dir / "Eval_Ali" / "Test_Ali"`. However, `corpus_dir / "Eval_Ali" / "Test_Ali"` doesn't  exist. It's wrong. So I change the codes from 99 to 105 line as follows:
```
        corpus_dir_split = corpus_dir
        if part == "Eval" or part == "Test":
            corpus_dir_split = (
                corpus_dir / f"{part}_Ali"
                if (corpus_dir / f"{part}_Ali").is_dir()
                else corpus_dir
            )
        wav_paths = corpus_dir_split / f"{part}_Ali_{mic}" / "audio_dir"
        text_paths = corpus_dir_split / f"{part}_Ali_{mic}" / "textgrid_dir"
```
If not do the above changes, there will be an error when generating the test manifest as follows (because the corpur_dir for test doesn't exist.):
![image](https://user-images.githubusercontent.com/37799481/167386165-5dbd585d-99a2-43d2-a391-2e271b744e1a.png)
