### PR TITLE
Normalize output path names for recipes

### DIFF
--- a/docs/corpus.rst
+++ b/docs/corpus.rst
@@ -168,6 +168,14 @@ Adding new corpora
     ``{'train': {'recordings': <RecordingSet>, 'supervisions': <SupervisionSet>}, 'dev': ...}``
 
 .. hint::
+    **Manifest naming convention.** The default naming convention is ``<corpus-name>_<manifest-type>_<split>.jsonl.gz``,
+    i.e., we save the manifests in a compressed JSONL file. Here, ``<manifest-type>`` can be ``recordings``, 
+    ``supervisions``, etc., and ``<split>`` can be ``train``, ``dev``, ``test``, etc. In case the corpus
+    has no such split defined, we can use ``all`` as default. Other information, e.g., mic type, language, etc. may 
+    be included in the ``<corpus-name>``. Some examples are: ``cmu-indic_recordings_all.jsonl.gz``,
+    ``ami-ihm_supervisions_dev.jsonl.gz``, ``mtedx-english_recordings_train.jsonl.gz``.
+
+.. hint::
     **Isolated utterance corpora.** Some corpora (like LibriSpeech) come with pre-segmented recordings.
     In these cases, the :class:`~lhotse.supervision.SupervisionSegment` will exactly match the
     :class:`~lhotse.recording.Recording` duration

--- a/lhotse/recipes/adept.py
+++ b/lhotse/recipes/adept.py
@@ -147,7 +147,7 @@ def prepare_adept(
 
     if output_dir is not None:
         output_dir = Path(output_dir)
-        supervisions.to_file(output_dir / "adept_supervisions.json")
-        recordings.to_file(output_dir / "adept_recordings.json")
+        supervisions.to_file(output_dir / "adept_supervisions.jsonl")
+        recordings.to_file(output_dir / "adept_recordings.jsonl")
 
     return {"recordings": recordings, "supervisions": supervisions}

--- a/lhotse/recipes/adept.py
+++ b/lhotse/recipes/adept.py
@@ -147,7 +147,7 @@ def prepare_adept(
 
     if output_dir is not None:
         output_dir = Path(output_dir)
-        supervisions.to_file(output_dir / "adept_supervisions.jsonl")
-        recordings.to_file(output_dir / "adept_recordings.jsonl")
+        supervisions.to_file(output_dir / "adept_supervisions_all.jsonl.gz")
+        recordings.to_file(output_dir / "adept_recordings_all.jsonl.gz")
 
     return {"recordings": recordings, "supervisions": supervisions}

--- a/lhotse/recipes/aidatatang_200zh.py
+++ b/lhotse/recipes/aidatatang_200zh.py
@@ -133,7 +133,7 @@ def prepare_aidatatang_200zh(
             supervision_set.to_file(
                 output_dir / f"aidatatang_supervisions_{part}.jsonl"
             )
-            recording_set.to_file(output_dir / f"aidatatang_recordings_{part}.jsonl")
+            recording_set.to_file(output_dir / f"aidatatang_recordings_{part}.jsonl.gz")
 
         manifests[part] = {"recordings": recording_set, "supervisions": supervision_set}
 

--- a/lhotse/recipes/aidatatang_200zh.py
+++ b/lhotse/recipes/aidatatang_200zh.py
@@ -131,7 +131,7 @@ def prepare_aidatatang_200zh(
 
         if output_dir is not None:
             supervision_set.to_file(
-                output_dir / f"aidatatang_supervisions_{part}.jsonl"
+                output_dir / f"aidatatang_supervisions_{part}.jsonl.gz"
             )
             recording_set.to_file(output_dir / f"aidatatang_recordings_{part}.jsonl.gz")
 

--- a/lhotse/recipes/aidatatang_200zh.py
+++ b/lhotse/recipes/aidatatang_200zh.py
@@ -130,8 +130,10 @@ def prepare_aidatatang_200zh(
         validate_recordings_and_supervisions(recording_set, supervision_set)
 
         if output_dir is not None:
-            supervision_set.to_json(output_dir / f"supervisions_{part}.json")
-            recording_set.to_json(output_dir / f"recordings_{part}.json")
+            supervision_set.to_file(
+                output_dir / f"aidatatang_supervisions_{part}.jsonl"
+            )
+            recording_set.to_file(output_dir / f"aidatatang_recordings_{part}.jsonl")
 
         manifests[part] = {"recordings": recording_set, "supervisions": supervision_set}
 

--- a/lhotse/recipes/aishell.py
+++ b/lhotse/recipes/aishell.py
@@ -117,7 +117,7 @@ def prepare_aishell(
 
         if output_dir is not None:
             supervision_set.to_file(output_dir / f"aishell_supervisions_{part}.jsonl")
-            recording_set.to_json(output_dir / f"aishell_recordings_{part}.jsonl")
+            recording_set.to_file(output_dir / f"aishell_recordings_{part}.jsonl")
 
         manifests[part] = {"recordings": recording_set, "supervisions": supervision_set}
 

--- a/lhotse/recipes/aishell.py
+++ b/lhotse/recipes/aishell.py
@@ -116,8 +116,10 @@ def prepare_aishell(
         validate_recordings_and_supervisions(recording_set, supervision_set)
 
         if output_dir is not None:
-            supervision_set.to_file(output_dir / f"aishell_supervisions_{part}.jsonl")
-            recording_set.to_file(output_dir / f"aishell_recordings_{part}.jsonl")
+            supervision_set.to_file(
+                output_dir / f"aishell_supervisions_{part}.jsonl.gz"
+            )
+            recording_set.to_file(output_dir / f"aishell_recordings_{part}.jsonl.gz")
 
         manifests[part] = {"recordings": recording_set, "supervisions": supervision_set}
 

--- a/lhotse/recipes/aishell.py
+++ b/lhotse/recipes/aishell.py
@@ -116,8 +116,8 @@ def prepare_aishell(
         validate_recordings_and_supervisions(recording_set, supervision_set)
 
         if output_dir is not None:
-            supervision_set.to_json(output_dir / f"supervisions_{part}.json")
-            recording_set.to_json(output_dir / f"recordings_{part}.json")
+            supervision_set.to_file(output_dir / f"aishell_supervisions_{part}.jsonl")
+            recording_set.to_json(output_dir / f"aishell_recordings_{part}.jsonl")
 
         manifests[part] = {"recordings": recording_set, "supervisions": supervision_set}
 

--- a/lhotse/recipes/aishell4.py
+++ b/lhotse/recipes/aishell4.py
@@ -144,8 +144,10 @@ def prepare_aishell4(
         validate_recordings_and_supervisions(recording_set, supervision_set)
 
         if output_dir is not None:
-            supervision_set.to_file(output_dir / f"aishell4_supervisions_{part}.jsonl")
-            recording_set.to_file(output_dir / f"aishell4_recordings_{part}.jsonl")
+            supervision_set.to_file(
+                output_dir / f"aishell4_supervisions_{part}.jsonl.gz"
+            )
+            recording_set.to_file(output_dir / f"aishell4_recordings_{part}.jsonl.gz")
 
         manifests[part] = {"recordings": recording_set, "supervisions": supervision_set}
 

--- a/lhotse/recipes/aishell4.py
+++ b/lhotse/recipes/aishell4.py
@@ -144,8 +144,8 @@ def prepare_aishell4(
         validate_recordings_and_supervisions(recording_set, supervision_set)
 
         if output_dir is not None:
-            supervision_set.to_file(output_dir / f"supervisions_{part}.jsonl")
-            recording_set.to_file(output_dir / f"recordings_{part}.jsonl")
+            supervision_set.to_file(output_dir / f"aishell4_supervisions_{part}.jsonl")
+            recording_set.to_file(output_dir / f"aishell4_recordings_{part}.jsonl")
 
         manifests[part] = {"recordings": recording_set, "supervisions": supervision_set}
 

--- a/lhotse/recipes/ali_meeting.py
+++ b/lhotse/recipes/ali_meeting.py
@@ -173,10 +173,10 @@ def prepare_ali_meeting(
 
         if output_dir is not None:
             supervision_set.to_file(
-                output_dir / f"alimeeting_supervisions_{part.lower()}.jsonl"
+                output_dir / f"alimeeting_supervisions_{part.lower()}.jsonl.gz"
             )
             recording_set.to_file(
-                output_dir / f"alimeeting_recordings_{part.lower()}.jsonl"
+                output_dir / f"alimeeting_recordings_{part.lower()}.jsonl.gz"
             )
 
         manifests[part.lower()] = {

--- a/lhotse/recipes/ali_meeting.py
+++ b/lhotse/recipes/ali_meeting.py
@@ -172,8 +172,12 @@ def prepare_ali_meeting(
         validate_recordings_and_supervisions(recording_set, supervision_set)
 
         if output_dir is not None:
-            supervision_set.to_file(output_dir / f"supervisions_{part.lower()}.jsonl")
-            recording_set.to_file(output_dir / f"recordings_{part.lower()}.jsonl")
+            supervision_set.to_file(
+                output_dir / f"alimeeting_supervisions_{part.lower()}.jsonl"
+            )
+            recording_set.to_file(
+                output_dir / f"alimeeting_recordings_{part.lower()}.jsonl"
+            )
 
         manifests[part.lower()] = {
             "recordings": recording_set,

--- a/lhotse/recipes/ami.py
+++ b/lhotse/recipes/ami.py
@@ -646,8 +646,10 @@ def prepare_ami(
 
         # Write to output directory if a path is provided
         if output_dir is not None:
-            audio_part.to_file(output_dir / f"ami_recordings_{part}.jsonl")
-            supervision_part.to_file(output_dir / f"ami_supervisions_{part}.jsonl")
+            audio_part.to_file(output_dir / f"ami-{mic}_recordings_{part}.jsonl.gz")
+            supervision_part.to_file(
+                output_dir / f"ami-{mic}_supervisions_{part}.jsonl.gz"
+            )
 
         audio_part, supervision_part = fix_manifests(audio_part, supervision_part)
         validate_recordings_and_supervisions(audio_part, supervision_part)

--- a/lhotse/recipes/ami.py
+++ b/lhotse/recipes/ami.py
@@ -646,8 +646,8 @@ def prepare_ami(
 
         # Write to output directory if a path is provided
         if output_dir is not None:
-            audio_part.to_file(output_dir / f"recordings_{part}.jsonl")
-            supervision_part.to_file(output_dir / f"supervisions_{part}.jsonl")
+            audio_part.to_file(output_dir / f"ami_recordings_{part}.jsonl")
+            supervision_part.to_file(output_dir / f"ami_supervisions_{part}.jsonl")
 
         audio_part, supervision_part = fix_manifests(audio_part, supervision_part)
         validate_recordings_and_supervisions(audio_part, supervision_part)

--- a/lhotse/recipes/aspire.py
+++ b/lhotse/recipes/aspire.py
@@ -167,8 +167,8 @@ def prepare_aspire(
         validate_recordings_and_supervisions(recording_set, supervision_set)
 
         if output_dir is not None:
-            supervision_set.to_file(output_dir / f"aspire_supervisions_{part}.jsonl")
-            recording_set.to_file(output_dir / f"aspire_recordings_{part}.jsonl")
+            supervision_set.to_file(output_dir / f"aspire_supervisions_{part}.jsonl.gz")
+            recording_set.to_file(output_dir / f"aspire_recordings_{part}.jsonl.gz")
 
         manifests[part] = {"recordings": recording_set, "supervisions": supervision_set}
 

--- a/lhotse/recipes/aspire.py
+++ b/lhotse/recipes/aspire.py
@@ -167,8 +167,8 @@ def prepare_aspire(
         validate_recordings_and_supervisions(recording_set, supervision_set)
 
         if output_dir is not None:
-            supervision_set.to_file(output_dir / f"supervisions_{part}.jsonl")
-            recording_set.to_file(output_dir / f"recordings_{part}.jsonl")
+            supervision_set.to_file(output_dir / f"aspire_supervisions_{part}.jsonl")
+            recording_set.to_file(output_dir / f"aspire_recordings_{part}.jsonl")
 
         manifests[part] = {"recordings": recording_set, "supervisions": supervision_set}
 

--- a/lhotse/recipes/babel.py
+++ b/lhotse/recipes/babel.py
@@ -193,9 +193,11 @@ def prepare_single_babel_language(
             output_dir.mkdir(parents=True, exist_ok=True)
             language = BABELCODE2LANG[lang_code]
             save_split = "train" if split == "training" else split
-            recordings.to_file(output_dir / f"recordings_{language}_{save_split}.json")
+            recordings.to_file(
+                output_dir / f"babel_recordings_{language}_{save_split}.jsonl"
+            )
             supervisions.to_file(
-                output_dir / f"supervisions_{language}_{save_split}.json"
+                output_dir / f"babel_supervisions_{language}_{save_split}.jsonl"
             )
 
     return dict(manifests)

--- a/lhotse/recipes/babel.py
+++ b/lhotse/recipes/babel.py
@@ -194,10 +194,10 @@ def prepare_single_babel_language(
             language = BABELCODE2LANG[lang_code]
             save_split = "train" if split == "training" else split
             recordings.to_file(
-                output_dir / f"babel_recordings_{language}_{save_split}.jsonl"
+                output_dir / f"babel-{language}_recordings_{save_split}.jsonl.gz"
             )
             supervisions.to_file(
-                output_dir / f"babel_supervisions_{language}_{save_split}.jsonl"
+                output_dir / f"babel-{language}_supervisions_{save_split}.jsonl.gz"
             )
 
     return dict(manifests)

--- a/lhotse/recipes/broadcast_news.py
+++ b/lhotse/recipes/broadcast_news.py
@@ -70,9 +70,13 @@ def prepare_broadcast_news(
     if output_dir is not None:
         output_dir = Path(output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
-        recordings.to_file(output_dir / "broadcast_news_recordings.jsonl")
-        section_supervisions.to_file(output_dir / "broadcast_news_sections.jsonl")
-        segment_supervisions.to_file(output_dir / "broadcast_news_segments.jsonl")
+        recordings.to_file(output_dir / "broadcast-news_recordings_all.jsonl.gz")
+        section_supervisions.to_file(
+            output_dir / "broadcast-news_sections_all.jsonl.gz"
+        )
+        segment_supervisions.to_file(
+            output_dir / "broadcast-news_segments_all.jsonl.gz"
+        )
 
     return {
         "recordings": recordings,

--- a/lhotse/recipes/broadcast_news.py
+++ b/lhotse/recipes/broadcast_news.py
@@ -70,9 +70,9 @@ def prepare_broadcast_news(
     if output_dir is not None:
         output_dir = Path(output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
-        recordings.to_json(output_dir / "recordings.json")
-        section_supervisions.to_json(output_dir / "sections.json")
-        segment_supervisions.to_json(output_dir / "segments.json")
+        recordings.to_file(output_dir / "broadcast_news_recordings.jsonl")
+        section_supervisions.to_file(output_dir / "broadcast_news_sections.jsonl")
+        segment_supervisions.to_file(output_dir / "broadcast_news_segments.jsonl")
 
     return {
         "recordings": recordings,

--- a/lhotse/recipes/bvcc.py
+++ b/lhotse/recipes/bvcc.py
@@ -135,9 +135,11 @@ def prepare_bvcc(
         output_dir = Path(output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
         for part, d in manifests.items():
-            d["recordings"].to_file(output_dir / f"recordings_{part}.jsonl.gz")
+            d["recordings"].to_file(output_dir / f"bvcc_recordings_{part}.jsonl.gz")
             if "supervisions" in d:
-                d["supervisions"].to_file(output_dir / f"supervisions_{part}.jsonl.gz")
+                d["supervisions"].to_file(
+                    output_dir / f"bvcc_supervisions_{part}.jsonl.gz"
+                )
 
     return manifests
 

--- a/lhotse/recipes/callhome_egyptian.py
+++ b/lhotse/recipes/callhome_egyptian.py
@@ -104,10 +104,10 @@ def prepare_callhome_egyptian(
             output_dir = Path(output_dir)
             output_dir.mkdir(parents=True, exist_ok=True)
             recordings.to_file(
-                output_dir / f"callhome_egyptian_recordings_{split}.jsonl"
+                output_dir / f"callhome-egyptian_recordings_{split}.jsonl.gz"
             )
             supervisions.to_file(
-                output_dir / f"callhome_egyptian_supervisions_{split}.jsonl"
+                output_dir / f"callhome-egyptian_supervisions_{split}.jsonl.gz"
             )
 
         manifests[split] = {"recordings": recordings, "supervisions": supervisions}

--- a/lhotse/recipes/callhome_egyptian.py
+++ b/lhotse/recipes/callhome_egyptian.py
@@ -103,8 +103,12 @@ def prepare_callhome_egyptian(
         if output_dir is not None:
             output_dir = Path(output_dir)
             output_dir.mkdir(parents=True, exist_ok=True)
-            recordings.to_json(output_dir / f"recordings_{split}.json")
-            supervisions.to_json(output_dir / f"supervisions_{split}.json")
+            recordings.to_file(
+                output_dir / f"callhome_egyptian_recordings_{split}.jsonl"
+            )
+            supervisions.to_file(
+                output_dir / f"callhome_egyptian_supervisions_{split}.jsonl"
+            )
 
         manifests[split] = {"recordings": recordings, "supervisions": supervisions}
 

--- a/lhotse/recipes/callhome_english.py
+++ b/lhotse/recipes/callhome_english.py
@@ -209,8 +209,12 @@ def prepare_callhome_english_asr(
         if output_dir is not None:
             output_dir = Path(output_dir)
             output_dir.mkdir(parents=True, exist_ok=True)
-            recordings.to_json(output_dir / f"recordings_{split}.json")
-            supervisions.to_json(output_dir / f"supervisions_{split}.json")
+            recordings.to_file(
+                output_dir / f"callhome_english_recordings_{split}.jsonl"
+            )
+            supervisions.to_file(
+                output_dir / f"callhome_english_supervisions_{split}.jsonl"
+            )
 
         manifests[split] = {"recordings": recordings, "supervisions": supervisions}
 

--- a/lhotse/recipes/callhome_english.py
+++ b/lhotse/recipes/callhome_english.py
@@ -210,10 +210,10 @@ def prepare_callhome_english_asr(
             output_dir = Path(output_dir)
             output_dir.mkdir(parents=True, exist_ok=True)
             recordings.to_file(
-                output_dir / f"callhome_english_recordings_{split}.jsonl"
+                output_dir / f"callhome-english_recordings_{split}.jsonl.gz"
             )
             supervisions.to_file(
-                output_dir / f"callhome_english_supervisions_{split}.jsonl"
+                output_dir / f"callhome-english_supervisions_{split}.jsonl.gz"
             )
 
         manifests[split] = {"recordings": recordings, "supervisions": supervisions}

--- a/lhotse/recipes/cmu_arctic.py
+++ b/lhotse/recipes/cmu_arctic.py
@@ -177,8 +177,8 @@ def prepare_cmu_arctic(
 
     if output_dir is not None:
         output_dir = Path(output_dir)
-        recordings.to_json(output_dir / "cmu_arctic_recordings.json")
-        supervisions.to_json(output_dir / "cmu_arctic_supervisions.json")
+        recordings.to_file(output_dir / "cmu_arctic_recordings.jsonl")
+        supervisions.to_file(output_dir / "cmu_arctic_supervisions.jsonl")
 
     return {"recordings": recordings, "supervisions": supervisions}
 

--- a/lhotse/recipes/cmu_arctic.py
+++ b/lhotse/recipes/cmu_arctic.py
@@ -177,8 +177,8 @@ def prepare_cmu_arctic(
 
     if output_dir is not None:
         output_dir = Path(output_dir)
-        recordings.to_file(output_dir / "cmu_arctic_recordings.jsonl")
-        supervisions.to_file(output_dir / "cmu_arctic_supervisions.jsonl")
+        recordings.to_file(output_dir / "cmu-arctic_recordings_all.jsonl.gz")
+        supervisions.to_file(output_dir / "cmu-arctic_supervisions_all.jsonl.gz")
 
     return {"recordings": recordings, "supervisions": supervisions}
 

--- a/lhotse/recipes/cmu_indic.py
+++ b/lhotse/recipes/cmu_indic.py
@@ -204,8 +204,8 @@ def prepare_cmu_indic(
 
     if output_dir is not None:
         output_dir = Path(output_dir)
-        recordings.to_json(output_dir / "cmu_indic_recordings.json")
-        supervisions.to_json(output_dir / "cmu_indic_supervisions.json")
+        recordings.to_file(output_dir / "cmu_indic_recordings.jsonl")
+        supervisions.to_file(output_dir / "cmu_indic_supervisions.jsonl")
 
     return {"recordings": recordings, "supervisions": supervisions}
 

--- a/lhotse/recipes/cmu_indic.py
+++ b/lhotse/recipes/cmu_indic.py
@@ -204,8 +204,8 @@ def prepare_cmu_indic(
 
     if output_dir is not None:
         output_dir = Path(output_dir)
-        recordings.to_file(output_dir / "cmu_indic_recordings.jsonl")
-        supervisions.to_file(output_dir / "cmu_indic_supervisions.jsonl")
+        recordings.to_file(output_dir / "cmu-indic_recordings_all.jsonl.gz")
+        supervisions.to_file(output_dir / "cmu-indic_supervisions_all.jsonl.gz")
 
     return {"recordings": recordings, "supervisions": supervisions}
 

--- a/lhotse/recipes/cmu_kids.py
+++ b/lhotse/recipes/cmu_kids.py
@@ -140,7 +140,9 @@ def prepare_cmu_kids(
         logging.info("Writing manifests to JSONL files")
         output_dir = Path(output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
-        manifests["recordings"].to_file(output_dir / "cmu_kids_recordings.jsonl")
-        manifests["supervisions"].to_file(output_dir / "cmu_kids_supervisions.jsonl")
+        manifests["recordings"].to_file(output_dir / "cmu-kids_recordings_all.jsonl.gz")
+        manifests["supervisions"].to_file(
+            output_dir / "cmu-kids_supervisions_all.jsonl.gz"
+        )
 
     return manifests

--- a/lhotse/recipes/cmu_kids.py
+++ b/lhotse/recipes/cmu_kids.py
@@ -137,10 +137,10 @@ def prepare_cmu_kids(
     }
 
     if output_dir is not None:
-        logging.info("Writing manifests to JSON files")
+        logging.info("Writing manifests to JSONL files")
         output_dir = Path(output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
-        manifests["recordings"].to_json(output_dir / "recordings.json")
-        manifests["supervisions"].to_json(output_dir / "supervisions.json")
+        manifests["recordings"].to_file(output_dir / "cmu_kids_recordings.jsonl")
+        manifests["supervisions"].to_file(output_dir / "cmu_kids_supervisions.jsonl")
 
     return manifests

--- a/lhotse/recipes/commonvoice.py
+++ b/lhotse/recipes/commonvoice.py
@@ -224,10 +224,10 @@ def prepare_single_commonvoice_tsv(
     df = pd.read_csv(tsv_path, sep="\t")
     # Scan all the audio files
     with RecordingSet.open_writer(
-        output_dir / f"cv_recordings_{lang}_{part}.jsonl.gz",
+        output_dir / f"cv-{lang}_recordings_{part}.jsonl.gz",
         overwrite=False,
     ) as recs_writer, SupervisionSet.open_writer(
-        output_dir / f"cv_supervisions_{lang}_{part}.jsonl.gz",
+        output_dir / f"cv-{lang}_supervisions_{part}.jsonl.gz",
         overwrite=False,
     ) as sups_writer:
         for idx, row in tqdm(

--- a/lhotse/recipes/cslu_kids.py
+++ b/lhotse/recipes/cslu_kids.py
@@ -139,7 +139,7 @@ def prepare_cslu_kids(
         logging.info("Writing manifests to JSON files")
         output_dir = Path(output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
-        manifests["recordings"].to_json(output_dir / "recordings.json")
-        manifests["supervisions"].to_json(output_dir / "supervisions.json")
+        manifests["recordings"].to_file(output_dir / "cslu_kids_recordings.jsonl")
+        manifests["supervisions"].to_file(output_dir / "cslu_kids_supervisions.jsonl")
 
     return manifests

--- a/lhotse/recipes/cslu_kids.py
+++ b/lhotse/recipes/cslu_kids.py
@@ -139,7 +139,11 @@ def prepare_cslu_kids(
         logging.info("Writing manifests to JSON files")
         output_dir = Path(output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
-        manifests["recordings"].to_file(output_dir / "cslu_kids_recordings.jsonl")
-        manifests["supervisions"].to_file(output_dir / "cslu_kids_supervisions.jsonl")
+        manifests["recordings"].to_file(
+            output_dir / "cslu-kids_recordings_all.jsonl.gz"
+        )
+        manifests["supervisions"].to_file(
+            output_dir / "cslu_kids_supervisions_all.jsonl.gz"
+        )
 
     return manifests

--- a/lhotse/recipes/dihard3.py
+++ b/lhotse/recipes/dihard3.py
@@ -85,10 +85,10 @@ def prepare_dihard3(
         if output_dir is not None:
             output_dir = Path(output_dir)
             output_dir.mkdir(parents=True, exist_ok=True)
-            recordings.to_json(output_dir / f"recordings_{part}.json")
-            supervisions.to_json(output_dir / f"supervisions_{part}.json")
+            recordings.to_file(output_dir / f"dihard3_recordings_{part}.jsonl")
+            supervisions.to_file(output_dir / f"dihard3_supervisions_{part}.jsonl")
             if uem_manifest:
-                uem.to_json(output_dir / f"uem_{part}.json")
+                uem.to_json(output_dir / f"dihard3_uem_{part}.json")
         manifests[part] = {"recordings": recordings, "supervisions": supervisions}
         if uem_manifest:
             manifests[part].update({"uem": uem})

--- a/lhotse/recipes/dihard3.py
+++ b/lhotse/recipes/dihard3.py
@@ -85,10 +85,10 @@ def prepare_dihard3(
         if output_dir is not None:
             output_dir = Path(output_dir)
             output_dir.mkdir(parents=True, exist_ok=True)
-            recordings.to_file(output_dir / f"dihard3_recordings_{part}.jsonl")
-            supervisions.to_file(output_dir / f"dihard3_supervisions_{part}.jsonl")
+            recordings.to_file(output_dir / f"dihard3_recordings_{part}.jsonl.gz")
+            supervisions.to_file(output_dir / f"dihard3_supervisions_{part}.jsonl.gz")
             if uem_manifest:
-                uem.to_json(output_dir / f"dihard3_uem_{part}.json")
+                uem.to_json(output_dir / f"dihard3_uem_{part}.jsonl.gz")
         manifests[part] = {"recordings": recordings, "supervisions": supervisions}
         if uem_manifest:
             manifests[part].update({"uem": uem})

--- a/lhotse/recipes/earnings21.py
+++ b/lhotse/recipes/earnings21.py
@@ -171,7 +171,7 @@ def prepare_earnings21(
 
     validate_recordings_and_supervisions(recording_set, supervision_set)
     if output_dir is not None:
-        supervision_set.to_jsonl(output_dir / "supervisions.jsonl")
-        recording_set.to_jsonl(output_dir / "recordings.jsonl")
+        supervision_set.to_file(output_dir / "earnings21_supervisions.jsonl")
+        recording_set.to_file(output_dir / "earnings21_recordings.jsonl")
 
     return recording_set, supervision_set

--- a/lhotse/recipes/earnings21.py
+++ b/lhotse/recipes/earnings21.py
@@ -171,7 +171,7 @@ def prepare_earnings21(
 
     validate_recordings_and_supervisions(recording_set, supervision_set)
     if output_dir is not None:
-        supervision_set.to_file(output_dir / "earnings21_supervisions.jsonl")
-        recording_set.to_file(output_dir / "earnings21_recordings.jsonl")
+        supervision_set.to_file(output_dir / "earnings21_supervisions_all.jsonl.gz")
+        recording_set.to_file(output_dir / "earnings21_recordings_all.jsonl.gz")
 
     return recording_set, supervision_set

--- a/lhotse/recipes/eval2000.py
+++ b/lhotse/recipes/eval2000.py
@@ -65,8 +65,8 @@ def prepare_eval2000(
     if output_dir is not None:
         output_dir = Path(output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
-        recordings.to_file(output_dir / "eval2000_recordings.jsonl")
-        supervision_set.to_file(output_dir / "eval2000_supervisions_unnorm.jsonl")
+        recordings.to_file(output_dir / "eval2000_recordings_all.jsonl.gz")
+        supervision_set.to_file(output_dir / "eval2000_supervisions_unnorm.jsonl.gz")
     return {"recordings": recordings, "supervisions": supervisions}
 
 

--- a/lhotse/recipes/eval2000.py
+++ b/lhotse/recipes/eval2000.py
@@ -65,8 +65,8 @@ def prepare_eval2000(
     if output_dir is not None:
         output_dir = Path(output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
-        recordings.to_file(output_dir / "recordings_eval2000.jsonl")
-        supervision_set.to_file(output_dir / "supervisions_unnorm_eval2000.jsonl")
+        recordings.to_file(output_dir / "eval2000_recordings.jsonl")
+        supervision_set.to_file(output_dir / "eval2000_supervisions_unnorm.jsonl")
     return {"recordings": recordings, "supervisions": supervisions}
 
 

--- a/lhotse/recipes/fisher_english.py
+++ b/lhotse/recipes/fisher_english.py
@@ -254,7 +254,7 @@ def prepare_fisher_english(
     validate_recordings_and_supervisions(recordings, supervisions)
 
     # Write the fixed and validated version to files with standard names.
-    recordings.to_file(recs_path.parent / "fisher_english_recordings.jsonl.gz")
-    supervisions.to_file(sups_path.parent / "fisher_english_supervisions.jsonl.gz")
+    recordings.to_file(recs_path.parent / "fisher-english_recordings_all.jsonl.gz")
+    supervisions.to_file(sups_path.parent / "fisher-english_supervisions_all.jsonl.gz")
 
     return {"recordings": recordings, "supervisions": supervisions}

--- a/lhotse/recipes/fisher_english.py
+++ b/lhotse/recipes/fisher_english.py
@@ -254,7 +254,7 @@ def prepare_fisher_english(
     validate_recordings_and_supervisions(recordings, supervisions)
 
     # Write the fixed and validated version to files with standard names.
-    recordings.to_file(recs_path.parent / "recordings.jsonl.gz")
-    supervisions.to_file(sups_path.parent / "supervisions.jsonl.gz")
+    recordings.to_file(recs_path.parent / "fisher_english_recordings.jsonl.gz")
+    supervisions.to_file(sups_path.parent / "fisher_english_supervisions.jsonl.gz")
 
     return {"recordings": recordings, "supervisions": supervisions}

--- a/lhotse/recipes/fisher_spanish.py
+++ b/lhotse/recipes/fisher_spanish.py
@@ -127,7 +127,7 @@ def prepare_fisher_spanish(
     if output_dir is not None:
         output_dir = Path(output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
-        recordings.to_file(output_dir / "fisher_spanish_recordings.jsonl")
-        supervisions.to_file(output_dir / "fisher_spanish_supervisions.jsonl")
+        recordings.to_file(output_dir / "fisher-spanish_recordings_all.jsonl")
+        supervisions.to_file(output_dir / "fisher-spanish_supervisions_all.jsonl")
 
     return {"recordings": recordings, "supervisions": supervisions}

--- a/lhotse/recipes/fisher_spanish.py
+++ b/lhotse/recipes/fisher_spanish.py
@@ -127,7 +127,7 @@ def prepare_fisher_spanish(
     if output_dir is not None:
         output_dir = Path(output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
-        recordings.to_json(output_dir / "recordings.json")
-        supervisions.to_json(output_dir / "supervisions.json")
+        recordings.to_file(output_dir / "fisher_spanish_recordings.jsonl")
+        supervisions.to_file(output_dir / "fisher_spanish_supervisions.jsonl")
 
     return {"recordings": recordings, "supervisions": supervisions}

--- a/lhotse/recipes/gale_arabic.py
+++ b/lhotse/recipes/gale_arabic.py
@@ -155,10 +155,10 @@ def prepare_gale_arabic(
         output_dir.mkdir(parents=True, exist_ok=True)
         for part in ["train", "test"]:
             manifests[part]["recordings"].to_file(
-                output_dir / f"gale_arabic_recordings_{part}.jsonl"
+                output_dir / f"gale-arabic_recordings_{part}.jsonl.gz"
             )
             manifests[part]["supervisions"].to_file(
-                output_dir / f"gale_arabic_supervisions_{part}.jsonl"
+                output_dir / f"gale-arabic_supervisions_{part}.jsonl.gz"
             )
 
     return manifests

--- a/lhotse/recipes/gale_arabic.py
+++ b/lhotse/recipes/gale_arabic.py
@@ -150,15 +150,15 @@ def prepare_gale_arabic(
     }
 
     if output_dir is not None:
-        logging.info("Writing manifests to JSON files")
+        logging.info("Writing manifests to JSONL files")
         output_dir = Path(output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
         for part in ["train", "test"]:
-            manifests[part]["recordings"].to_json(
-                output_dir / f"recordings_{part}.json"
+            manifests[part]["recordings"].to_file(
+                output_dir / f"gale_arabic_recordings_{part}.jsonl"
             )
-            manifests[part]["supervisions"].to_json(
-                output_dir / f"supervisions_{part}.json"
+            manifests[part]["supervisions"].to_file(
+                output_dir / f"gale_arabic_supervisions_{part}.jsonl"
             )
 
     return manifests

--- a/lhotse/recipes/gale_mandarin.py
+++ b/lhotse/recipes/gale_mandarin.py
@@ -135,15 +135,15 @@ def prepare_gale_mandarin(
     }
 
     if output_dir is not None:
-        logging.info("Writing manifests to JSON files")
+        logging.info("Writing manifests to JSONL files")
         output_dir = Path(output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
         for part in ["train", "dev"]:
-            manifests[part]["recordings"].to_json(
-                output_dir / f"recordings_{part}.json"
+            manifests[part]["recordings"].to_file(
+                output_dir / f"gale_mandarin_recordings_{part}.jsonl"
             )
-            manifests[part]["supervisions"].to_json(
-                output_dir / f"supervisions_{part}.json"
+            manifests[part]["supervisions"].to_file(
+                output_dir / f"gale_mandarin_supervisions_{part}.jsonl"
             )
 
     return manifests

--- a/lhotse/recipes/gale_mandarin.py
+++ b/lhotse/recipes/gale_mandarin.py
@@ -140,10 +140,10 @@ def prepare_gale_mandarin(
         output_dir.mkdir(parents=True, exist_ok=True)
         for part in ["train", "dev"]:
             manifests[part]["recordings"].to_file(
-                output_dir / f"gale_mandarin_recordings_{part}.jsonl"
+                output_dir / f"gale-mandarin_recordings_{part}.jsonl.gz"
             )
             manifests[part]["supervisions"].to_file(
-                output_dir / f"gale_mandarin_supervisions_{part}.jsonl"
+                output_dir / f"gale-mandarin_supervisions_{part}.jsonl.gz"
             )
 
     return manifests

--- a/lhotse/recipes/heroico.py
+++ b/lhotse/recipes/heroico.py
@@ -281,8 +281,8 @@ def prepare_heroico(
         validate_recordings_and_supervisions(audio, supervision)
 
         if output_dir is not None:
-            supervision.to_json(output_dir / f"supervisions_{fld}.json")
-            audio.to_json(output_dir / f"recordings_{fld}.json")
+            supervision.to_file(output_dir / f"heroico_supervisions_{fld}.jsonl")
+            audio.to_file(output_dir / f"heroico_recordings_{fld}.jsonl")
 
         manifests[fld] = {"recordings": audio, "supervisions": supervision}
 

--- a/lhotse/recipes/heroico.py
+++ b/lhotse/recipes/heroico.py
@@ -281,8 +281,8 @@ def prepare_heroico(
         validate_recordings_and_supervisions(audio, supervision)
 
         if output_dir is not None:
-            supervision.to_file(output_dir / f"heroico_supervisions_{fld}.jsonl")
-            audio.to_file(output_dir / f"heroico_recordings_{fld}.jsonl")
+            supervision.to_file(output_dir / f"heroico_supervisions_{fld}.jsonl.gz")
+            audio.to_file(output_dir / f"heroico_recordings_{fld}.jsonl.gz")
 
         manifests[fld] = {"recordings": audio, "supervisions": supervision}
 

--- a/lhotse/recipes/hifitts.py
+++ b/lhotse/recipes/hifitts.py
@@ -164,10 +164,10 @@ def prepare_hifitts(
 
             if output_dir is not None:
                 supervisions.to_file(
-                    output_dir / f"hifitts_supervisions_{partition_id}.jsonl"
+                    output_dir / f"hifitts_supervisions_{partition_id}.jsonl.gz"
                 )
                 recordings.to_file(
-                    output_dir / f"hifitts_recordings_{partition_id}.jsonl"
+                    output_dir / f"hifitts_recordings_{partition_id}.jsonl.gz"
                 )
 
             manifests[partition_id] = {

--- a/lhotse/recipes/hifitts.py
+++ b/lhotse/recipes/hifitts.py
@@ -163,11 +163,11 @@ def prepare_hifitts(
             recordings, supervisions = future.result()
 
             if output_dir is not None:
-                supervisions.to_json(
-                    output_dir / f"hifitts_supervisions_{partition_id}.json"
+                supervisions.to_file(
+                    output_dir / f"hifitts_supervisions_{partition_id}.jsonl"
                 )
-                recordings.to_json(
-                    output_dir / f"hifitts_recordings_{partition_id}.json"
+                recordings.to_file(
+                    output_dir / f"hifitts_recordings_{partition_id}.jsonl"
                 )
 
             manifests[partition_id] = {

--- a/lhotse/recipes/icsi.py
+++ b/lhotse/recipes/icsi.py
@@ -548,8 +548,10 @@ def prepare_icsi(
 
         # Write to output directory if a path is provided
         if output_dir is not None:
-            audio_part.to_file(output_dir / f"icsi_recordings_{part}.jsonl")
-            supervision_part.to_file(output_dir / f"icsi_supervisions_{part}.jsonl")
+            audio_part.to_file(output_dir / f"icsi-{mic}_recordings_{part}.jsonl.gz")
+            supervision_part.to_file(
+                output_dir / f"icsi-{mic}_supervisions_{part}.jsonl.gz"
+            )
 
         audio_part, supervision_part = fix_manifests(audio_part, supervision_part)
         validate_recordings_and_supervisions(audio_part, supervision_part)

--- a/lhotse/recipes/icsi.py
+++ b/lhotse/recipes/icsi.py
@@ -548,8 +548,8 @@ def prepare_icsi(
 
         # Write to output directory if a path is provided
         if output_dir is not None:
-            audio_part.to_file(output_dir / f"recordings_{part}.jsonl")
-            supervision_part.to_file(output_dir / f"supervisions_{part}.jsonl")
+            audio_part.to_file(output_dir / f"icsi_recordings_{part}.jsonl")
+            supervision_part.to_file(output_dir / f"icsi_supervisions_{part}.jsonl")
 
         audio_part, supervision_part = fix_manifests(audio_part, supervision_part)
         validate_recordings_and_supervisions(audio_part, supervision_part)

--- a/lhotse/recipes/l2_arctic.py
+++ b/lhotse/recipes/l2_arctic.py
@@ -186,10 +186,10 @@ def prepare_l2_arctic(
         makedirs(output_dir, exist_ok=True)
         for key, manifests in splits.items():
             manifests["recordings"].to_file(
-                output_dir / f"l2_arctic_recordings_{key}.jsonl"
+                output_dir / f"l2-arctic_recordings_{key}.jsonl.gz"
             )
             manifests["supervisions"].to_file(
-                output_dir / f"l2_arctic_supervisions_{key}.jsonl"
+                output_dir / f"l2-arctic_supervisions_{key}.jsonl.gz"
             )
 
     return splits

--- a/lhotse/recipes/l2_arctic.py
+++ b/lhotse/recipes/l2_arctic.py
@@ -185,8 +185,12 @@ def prepare_l2_arctic(
         output_dir = Path(output_dir)
         makedirs(output_dir, exist_ok=True)
         for key, manifests in splits.items():
-            manifests["recordings"].to_json(output_dir / f"recordings-{key}.json")
-            manifests["supervisions"].to_json(output_dir / f"supervisions-{key}.json")
+            manifests["recordings"].to_file(
+                output_dir / f"l2_arctic_recordings_{key}.jsonl"
+            )
+            manifests["supervisions"].to_file(
+                output_dir / f"l2_arctic_supervisions_{key}.jsonl"
+            )
 
     return splits
 

--- a/lhotse/recipes/libricss.py
+++ b/lhotse/recipes/libricss.py
@@ -195,8 +195,8 @@ def prepare_libricss(
     if output_dir is not None:
         output_dir = Path(output_dir)
         output_dir.mkdir(exist_ok=True, parents=True)
-        recordings.to_file(output_dir / "libricss_recordings.jsonl")
-        supervisions.to_file(output_dir / "libricss_supervisions.jsonl")
+        recordings.to_file(output_dir / "libricss_recordings_all.jsonl.gz")
+        supervisions.to_file(output_dir / "libricss_supervisions_all.jsonl.gz")
 
     return {"recordings": recordings, "supervisions": supervisions}
 

--- a/lhotse/recipes/libricss.py
+++ b/lhotse/recipes/libricss.py
@@ -195,8 +195,8 @@ def prepare_libricss(
     if output_dir is not None:
         output_dir = Path(output_dir)
         output_dir.mkdir(exist_ok=True, parents=True)
-        recordings.to_jsonl(output_dir / "recordings.jsonl")
-        supervisions.to_jsonl(output_dir / "supervisions.jsonl")
+        recordings.to_file(output_dir / "libricss_recordings.jsonl")
+        supervisions.to_file(output_dir / "libricss_supervisions.jsonl")
 
     return {"recordings": recordings, "supervisions": supervisions}
 

--- a/lhotse/recipes/librimix.py
+++ b/lhotse/recipes/librimix.py
@@ -70,8 +70,8 @@ def prepare_librimix(
     supervision_sources = make_corresponding_supervisions(audio_sources)
     validate_recordings_and_supervisions(audio_sources, supervision_sources)
     if output_dir is not None:
-        audio_sources.to_json(output_dir / "recordings_sources.json")
-        supervision_sources.to_json(output_dir / "supervisions_sources.json")
+        audio_sources.to_file(output_dir / "librimix_recordings_sources.jsonl")
+        supervision_sources.to_file(output_dir / "librimix_supervisions_sources.jsonl")
     manifests["sources"] = {
         "recordings": audio_sources,
         "supervisions": supervision_sources,
@@ -97,8 +97,8 @@ def prepare_librimix(
         supervision_mix = make_corresponding_supervisions(audio_mix)
         validate_recordings_and_supervisions(audio_mix, supervision_mix)
         if output_dir is not None:
-            audio_mix.to_json(output_dir / "recordings_mix.json")
-            supervision_mix.to_json(output_dir / "supervisions_mix.json")
+            audio_mix.to_file(output_dir / "librimix_recordings_mix.jsonl")
+            supervision_mix.to_file(output_dir / "librimix_supervisions_mix.jsonl")
         manifests["premixed"] = {
             "recordings": audio_mix,
             "supervisions": supervision_mix,
@@ -123,8 +123,8 @@ def prepare_librimix(
         supervision_noise = make_corresponding_supervisions(audio_noise)
         validate_recordings_and_supervisions(audio_noise, supervision_noise)
         if output_dir is not None:
-            audio_noise.to_json(output_dir / "recordings_noise.json")
-            supervision_noise.to_json(output_dir / "supervisions_noise.json")
+            audio_noise.to_file(output_dir / "librimix_recordings_noise.jsonl")
+            supervision_noise.to_file(output_dir / "libirmix_supervisions_noise.jsonl")
         manifests["noise"] = {
             "recordings": audio_noise,
             "supervisions": supervision_noise,

--- a/lhotse/recipes/librimix.py
+++ b/lhotse/recipes/librimix.py
@@ -70,8 +70,10 @@ def prepare_librimix(
     supervision_sources = make_corresponding_supervisions(audio_sources)
     validate_recordings_and_supervisions(audio_sources, supervision_sources)
     if output_dir is not None:
-        audio_sources.to_file(output_dir / "librimix_recordings_sources.jsonl")
-        supervision_sources.to_file(output_dir / "librimix_supervisions_sources.jsonl")
+        audio_sources.to_file(output_dir / "librimix_recordings_sources.jsonl.gz")
+        supervision_sources.to_file(
+            output_dir / "librimix_supervisions_sources.jsonl.gz"
+        )
     manifests["sources"] = {
         "recordings": audio_sources,
         "supervisions": supervision_sources,
@@ -97,8 +99,8 @@ def prepare_librimix(
         supervision_mix = make_corresponding_supervisions(audio_mix)
         validate_recordings_and_supervisions(audio_mix, supervision_mix)
         if output_dir is not None:
-            audio_mix.to_file(output_dir / "librimix_recordings_mix.jsonl")
-            supervision_mix.to_file(output_dir / "librimix_supervisions_mix.jsonl")
+            audio_mix.to_file(output_dir / "librimix_recordings_mix.jsonl.gz")
+            supervision_mix.to_file(output_dir / "librimix_supervisions_mix.jsonl.gz")
         manifests["premixed"] = {
             "recordings": audio_mix,
             "supervisions": supervision_mix,
@@ -123,8 +125,10 @@ def prepare_librimix(
         supervision_noise = make_corresponding_supervisions(audio_noise)
         validate_recordings_and_supervisions(audio_noise, supervision_noise)
         if output_dir is not None:
-            audio_noise.to_file(output_dir / "librimix_recordings_noise.jsonl")
-            supervision_noise.to_file(output_dir / "libirmix_supervisions_noise.jsonl")
+            audio_noise.to_file(output_dir / "librimix_recordings_noise.jsonl.gz")
+            supervision_noise.to_file(
+                output_dir / "libirmix_supervisions_noise.jsonl.gz"
+            )
         manifests["noise"] = {
             "recordings": audio_noise,
             "supervisions": supervision_noise,

--- a/lhotse/recipes/librispeech.py
+++ b/lhotse/recipes/librispeech.py
@@ -203,10 +203,10 @@ def prepare_librispeech(
 
             if output_dir is not None:
                 supervision_set.to_file(
-                    output_dir / f"librispeech_supervisions_{part}.jsonl"
+                    output_dir / f"librispeech_supervisions_{part}.jsonl.gz"
                 )
                 recording_set.to_file(
-                    output_dir / f"librispeech_recordings_{part}.jsonl"
+                    output_dir / f"librispeech_recordings_{part}.jsonl.gz"
                 )
 
             manifests[part] = {

--- a/lhotse/recipes/librispeech.py
+++ b/lhotse/recipes/librispeech.py
@@ -202,8 +202,12 @@ def prepare_librispeech(
             validate_recordings_and_supervisions(recording_set, supervision_set)
 
             if output_dir is not None:
-                supervision_set.to_file(output_dir / f"supervisions_{part}.json")
-                recording_set.to_file(output_dir / f"recordings_{part}.json")
+                supervision_set.to_file(
+                    output_dir / f"librispeech_supervisions_{part}.jsonl"
+                )
+                recording_set.to_file(
+                    output_dir / f"librispeech_recordings_{part}.jsonl"
+                )
 
             manifests[part] = {
                 "recordings": recording_set,

--- a/lhotse/recipes/libritts.py
+++ b/lhotse/recipes/libritts.py
@@ -208,8 +208,8 @@ def prepare_libritts(
         validate_recordings_and_supervisions(recordings, supervisions)
 
         if output_dir is not None:
-            supervisions.to_file(output_dir / f"libritts_supervisions_{part}.jsonl")
-            recordings.to_file(output_dir / f"libritts_recordings_{part}.jsonl")
+            supervisions.to_file(output_dir / f"libritts_supervisions_{part}.jsonl.gz")
+            recordings.to_file(output_dir / f"libritts_recordings_{part}.jsonl.gz")
 
         manifests[part] = {"recordings": recordings, "supervisions": supervisions}
 

--- a/lhotse/recipes/libritts.py
+++ b/lhotse/recipes/libritts.py
@@ -208,8 +208,8 @@ def prepare_libritts(
         validate_recordings_and_supervisions(recordings, supervisions)
 
         if output_dir is not None:
-            supervisions.to_json(output_dir / f"libritts_supervisions_{part}.json")
-            recordings.to_json(output_dir / f"libritts_recordings_{part}.json")
+            supervisions.to_file(output_dir / f"libritts_supervisions_{part}.jsonl")
+            recordings.to_file(output_dir / f"libritts_recordings_{part}.jsonl")
 
         manifests[part] = {"recordings": recordings, "supervisions": supervisions}
 

--- a/lhotse/recipes/ljspeech.py
+++ b/lhotse/recipes/ljspeech.py
@@ -98,8 +98,8 @@ def prepare_ljspeech(
     validate_recordings_and_supervisions(recording_set, supervision_set)
 
     if output_dir is not None:
-        supervision_set.to_json(output_dir / "supervisions.json")
-        recording_set.to_json(output_dir / "recordings.json")
+        supervision_set.to_file(output_dir / "ljspeech_supervisions.jsonl")
+        recording_set.to_file(output_dir / "ljspeech_recordings.jsonl")
 
     return {"recordings": recording_set, "supervisions": supervision_set}
 

--- a/lhotse/recipes/ljspeech.py
+++ b/lhotse/recipes/ljspeech.py
@@ -98,8 +98,8 @@ def prepare_ljspeech(
     validate_recordings_and_supervisions(recording_set, supervision_set)
 
     if output_dir is not None:
-        supervision_set.to_file(output_dir / "ljspeech_supervisions.jsonl")
-        recording_set.to_file(output_dir / "ljspeech_recordings.jsonl")
+        supervision_set.to_file(output_dir / "ljspeech_supervisions_all.jsonl.gz")
+        recording_set.to_file(output_dir / "ljspeech_recordings_all.jsonl.gz")
 
     return {"recordings": recording_set, "supervisions": supervision_set}
 

--- a/lhotse/recipes/mls.py
+++ b/lhotse/recipes/mls.py
@@ -74,12 +74,12 @@ def prepare_mls(
             recordings_path = (
                 None
                 if output_dir is None
-                else output_dir / f"mls_recordings_{lang}_{split}.jsonl.gz"
+                else output_dir / f"mls-{lang}_recordings_{split}.jsonl.gz"
             )
             supervisions_path = (
                 None
                 if output_dir is None
-                else output_dir / f"mls_supervisions_{lang}_{split}.jsonl.gz"
+                else output_dir / f"mls-{lang}_supervisions_{split}.jsonl.gz"
             )
             if (
                 recordings_path is not None

--- a/lhotse/recipes/mls.py
+++ b/lhotse/recipes/mls.py
@@ -74,12 +74,12 @@ def prepare_mls(
             recordings_path = (
                 None
                 if output_dir is None
-                else output_dir / f"recordings_{lang}_{split}.jsonl.gz"
+                else output_dir / f"mls_recordings_{lang}_{split}.jsonl.gz"
             )
             supervisions_path = (
                 None
                 if output_dir is None
-                else output_dir / f"supervisions_{lang}_{split}.jsonl.gz"
+                else output_dir / f"mls_supervisions_{lang}_{split}.jsonl.gz"
             )
             if (
                 recordings_path is not None

--- a/lhotse/recipes/mobvoihotwords.py
+++ b/lhotse/recipes/mobvoihotwords.py
@@ -141,8 +141,8 @@ def prepare_mobvoihotwords(
         validate_recordings_and_supervisions(recording_set, supervision_set)
 
         if output_dir is not None:
-            supervision_set.to_json(output_dir / f"supervisions_{part}.json")
-            recording_set.to_json(output_dir / f"recordings_{part}.json")
+            supervision_set.to_file(output_dir / f"mobvoi_supervisions_{part}.jsonl")
+            recording_set.to_file(output_dir / f"mobvoi_recordings_{part}.jsonl")
 
         manifests[part] = {"recordings": recording_set, "supervisions": supervision_set}
 

--- a/lhotse/recipes/mobvoihotwords.py
+++ b/lhotse/recipes/mobvoihotwords.py
@@ -141,8 +141,8 @@ def prepare_mobvoihotwords(
         validate_recordings_and_supervisions(recording_set, supervision_set)
 
         if output_dir is not None:
-            supervision_set.to_file(output_dir / f"mobvoi_supervisions_{part}.jsonl")
-            recording_set.to_file(output_dir / f"mobvoi_recordings_{part}.jsonl")
+            supervision_set.to_file(output_dir / f"mobvoi_supervisions_{part}.jsonl.gz")
+            recording_set.to_file(output_dir / f"mobvoi_recordings_{part}.jsonl.gz")
 
         manifests[part] = {"recordings": recording_set, "supervisions": supervision_set}
 

--- a/lhotse/recipes/mtedx.py
+++ b/lhotse/recipes/mtedx.py
@@ -245,10 +245,10 @@ def prepare_single_mtedx_language(
                 output_dir.mkdir(parents=True, exist_ok=True)
                 save_split = "dev" if split == "valid" else split
                 recordings.to_file(
-                    output_dir / f"mtedx_recordings_{language}_{split}.jsonl"
+                    output_dir / f"mtedx-{language}_recordings_{split}.jsonl.gz"
                 )
                 supervisions.to_file(
-                    output_dir / f"mtedx_supervisions_{language}_{split}.jsonl"
+                    output_dir / f"mtedx-{language}_supervisions_{split}.jsonl.gz"
                 )
 
     return dict(manifests)

--- a/lhotse/recipes/mtedx.py
+++ b/lhotse/recipes/mtedx.py
@@ -244,9 +244,11 @@ def prepare_single_mtedx_language(
                     output_dir = Path(output_dir)
                 output_dir.mkdir(parents=True, exist_ok=True)
                 save_split = "dev" if split == "valid" else split
-                recordings.to_file(output_dir / f"recordings_{language}_{split}.json")
+                recordings.to_file(
+                    output_dir / f"mtedx_recordings_{language}_{split}.jsonl"
+                )
                 supervisions.to_file(
-                    output_dir / f"supervisions_{language}_{split}.json"
+                    output_dir / f"mtedx_supervisions_{language}_{split}.jsonl"
                 )
 
     return dict(manifests)

--- a/lhotse/recipes/musan.py
+++ b/lhotse/recipes/musan.py
@@ -90,7 +90,7 @@ def prepare_musan(
         output_dir.mkdir(parents=True, exist_ok=True)
         for part in manifests:
             for key, manifest in manifests[part].items():
-                manifest.to_json(output_dir / f"{key}_{part}.json")
+                manifest.to_json(output_dir / f"musan_{key}_{part}.json")
 
     return manifests
 

--- a/lhotse/recipes/musan.py
+++ b/lhotse/recipes/musan.py
@@ -90,7 +90,7 @@ def prepare_musan(
         output_dir.mkdir(parents=True, exist_ok=True)
         for part in manifests:
             for key, manifest in manifests[part].items():
-                manifest.to_json(output_dir / f"musan_{key}_{part}.json")
+                manifest.to_json(output_dir / f"musan_{key}_{part}.jsonl.gz")
 
     return manifests
 

--- a/lhotse/recipes/musan.py
+++ b/lhotse/recipes/musan.py
@@ -90,7 +90,7 @@ def prepare_musan(
         output_dir.mkdir(parents=True, exist_ok=True)
         for part in manifests:
             for key, manifest in manifests[part].items():
-                manifest.to_json(output_dir / f"musan_{key}_{part}.jsonl.gz")
+                manifest.to_file(output_dir / f"musan_{key}_{part}.jsonl.gz")
 
     return manifests
 

--- a/lhotse/recipes/nsc.py
+++ b/lhotse/recipes/nsc.py
@@ -73,10 +73,12 @@ def prepare_nsc(
     if output_dir is not None:
         output_dir = Path(output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
-        manifests["supervisions"].to_json(
-            output_dir / f"supervisions_{dataset_part}.json"
+        manifests["supervisions"].to_file(
+            output_dir / f"nsc_supervisions_{dataset_part}.jsonl"
         )
-        manifests["recordings"].to_json(output_dir / f"recordings_{dataset_part}.json")
+        manifests["recordings"].to_file(
+            output_dir / f"nsc_recordings_{dataset_part}.jsonl"
+        )
 
     return manifests
 

--- a/lhotse/recipes/nsc.py
+++ b/lhotse/recipes/nsc.py
@@ -74,10 +74,10 @@ def prepare_nsc(
         output_dir = Path(output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
         manifests["supervisions"].to_file(
-            output_dir / f"nsc_supervisions_{dataset_part}.jsonl"
+            output_dir / f"nsc_supervisions_{dataset_part}.jsonl.gz"
         )
         manifests["recordings"].to_file(
-            output_dir / f"nsc_recordings_{dataset_part}.jsonl"
+            output_dir / f"nsc_recordings_{dataset_part}.jsonl.gz"
         )
 
     return manifests

--- a/lhotse/recipes/peoples_speech.py
+++ b/lhotse/recipes/peoples_speech.py
@@ -52,8 +52,8 @@ def prepare_peoples_speech(
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    recs_path = output_dir / "peoples-speech_recordings.jsonl.gz"
-    sups_path = output_dir / "peoples-speech_supervisions.jsonl.gz"
+    recs_path = output_dir / "peoples-speech_recordings_all.jsonl.gz"
+    sups_path = output_dir / "peoples-speech_supervisions_all.jsonl.gz"
 
     if recs_path.is_file() and sups_path.is_file():
         # Nothing to do: just open the manifests in lazy mode.

--- a/lhotse/recipes/rir_noise.py
+++ b/lhotse/recipes/rir_noise.py
@@ -157,6 +157,8 @@ def prepare_rir_noise(
         output_dir.mkdir(parents=True, exist_ok=True)
         for part in manifests:
             for key, manifest in manifests[part].items():
-                manifest.to_file(output_dir / f"{key}_{part}.jsonl")
+                manifest.to_file(
+                    output_dir / f"{part.replace('_','-')}_{key}_all.jsonl.gz"
+                )
 
     return manifests

--- a/lhotse/recipes/rir_noise.py
+++ b/lhotse/recipes/rir_noise.py
@@ -157,6 +157,6 @@ def prepare_rir_noise(
         output_dir.mkdir(parents=True, exist_ok=True)
         for part in manifests:
             for key, manifest in manifests[part].items():
-                manifest.to_file(output_dir / f"{key}_{part}.json")
+                manifest.to_file(output_dir / f"{key}_{part}.jsonl")
 
     return manifests

--- a/lhotse/recipes/switchboard.py
+++ b/lhotse/recipes/switchboard.py
@@ -91,8 +91,8 @@ def prepare_switchboard(
     if output_dir is not None:
         output_dir = Path(output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
-        recordings.to_file(output_dir / "swbd_recordings.jsonl")
-        supervisions.to_file(output_dir / "swbd_supervisions.jsonl")
+        recordings.to_file(output_dir / "swbd_recordings_all.jsonl.gz")
+        supervisions.to_file(output_dir / "swbd_supervisions_all.jsonl.gz")
     return {"recordings": recordings, "supervisions": supervisions}
 
 

--- a/lhotse/recipes/tedlium.py
+++ b/lhotse/recipes/tedlium.py
@@ -134,7 +134,7 @@ def prepare_tedlium(
         validate_recordings_and_supervisions(**corpus[split])
 
         if output_dir is not None:
-            recordings.to_json(output_dir / f"recordings_{split}.json")
-            supervisions.to_json(output_dir / f"supervisions_{split}.json")
+            recordings.to_file(output_dir / f"tedlium_recordings_{split}.jsonl")
+            supervisions.to_file(output_dir / f"tedlium_supervisions_{split}.jsonl")
 
     return corpus

--- a/lhotse/recipes/tedlium.py
+++ b/lhotse/recipes/tedlium.py
@@ -134,7 +134,7 @@ def prepare_tedlium(
         validate_recordings_and_supervisions(**corpus[split])
 
         if output_dir is not None:
-            recordings.to_file(output_dir / f"tedlium_recordings_{split}.jsonl")
-            supervisions.to_file(output_dir / f"tedlium_supervisions_{split}.jsonl")
+            recordings.to_file(output_dir / f"tedlium_recordings_{split}.jsonl.gz")
+            supervisions.to_file(output_dir / f"tedlium_supervisions_{split}.jsonl.gz")
 
     return corpus

--- a/lhotse/recipes/timit.py
+++ b/lhotse/recipes/timit.py
@@ -160,8 +160,10 @@ def prepare_timit(
                 validate_recordings_and_supervisions(recording_set, supervision_set)
 
                 if output_dir is not None:
-                    supervision_set.to_json(output_dir / f"supervisions_{part}.json")
-                    recording_set.to_json(output_dir / f"recordings_{part}.json")
+                    supervision_set.to_file(
+                        output_dir / f"timit_supervisions_{part}.jsonl"
+                    )
+                    recording_set.to_file(output_dir / f"timit_recordings_{part}.jsonl")
 
                 manifests[part] = {
                     "recordings": recording_set,

--- a/lhotse/recipes/timit.py
+++ b/lhotse/recipes/timit.py
@@ -161,9 +161,11 @@ def prepare_timit(
 
                 if output_dir is not None:
                     supervision_set.to_file(
-                        output_dir / f"timit_supervisions_{part}.jsonl"
+                        output_dir / f"timit_supervisions_{part}.jsonl.gz"
                     )
-                    recording_set.to_file(output_dir / f"timit_recordings_{part}.jsonl")
+                    recording_set.to_file(
+                        output_dir / f"timit_recordings_{part}.jsonl.gz"
+                    )
 
                 manifests[part] = {
                     "recordings": recording_set,

--- a/lhotse/recipes/utils.py
+++ b/lhotse/recipes/utils.py
@@ -21,7 +21,7 @@ def read_manifests_if_cached(
     dataset_parts: Optional[Sequence[str]],
     output_dir: Optional[Pathlike],
     prefix: str = "",
-    suffix: Optional[str] = "json",
+    suffix: Optional[str] = "jsonl.gz",
     types: Iterable[str] = DEFAULT_DETECTED_MANIFEST_TYPES,
     lazy: bool = False,
 ) -> Optional[Dict[str, Dict[str, Union[RecordingSet, SupervisionSet]]]]:

--- a/lhotse/recipes/vctk.py
+++ b/lhotse/recipes/vctk.py
@@ -194,8 +194,8 @@ def prepare_vctk(
     if output_dir is not None:
         output_dir = Path(output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
-        recordings.to_file(output_dir / "vctk_recordings.jsonl")
-        supervisions.to_file(output_dir / "vctk_supervisions.jsonl")
+        recordings.to_file(output_dir / "vctk_recordings_all.jsonl.gz")
+        supervisions.to_file(output_dir / "vctk_supervisions_all.jsonl.gz")
 
     return {"recordings": recordings, "supervisions": supervisions}
 

--- a/lhotse/recipes/vctk.py
+++ b/lhotse/recipes/vctk.py
@@ -194,8 +194,8 @@ def prepare_vctk(
     if output_dir is not None:
         output_dir = Path(output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
-        recordings.to_json(output_dir / "recordings.json")
-        supervisions.to_json(output_dir / "supervisions.json")
+        recordings.to_file(output_dir / "vctk_recordings.jsonl")
+        supervisions.to_file(output_dir / "vctk_supervisions.jsonl")
 
     return {"recordings": recordings, "supervisions": supervisions}
 

--- a/lhotse/recipes/voxceleb.py
+++ b/lhotse/recipes/voxceleb.py
@@ -235,17 +235,17 @@ def prepare_voxceleb(
         supervisions = manifests[split]["supervisions"]
         validate_recordings_and_supervisions(recordings, supervisions)
         if output_dir is not None:
-            recordings.to_file(output_dir / f"recordings_voxceleb_{split}.jsonl.gz")
-            supervisions.to_file(output_dir / f"supervisions_voxceleb_{split}.jsonl.gz")
+            recordings.to_file(output_dir / f"voxceleb_recordings_{split}.jsonl.gz")
+            supervisions.to_file(output_dir / f"voxceleb_supervisions_{split}.jsonl.gz")
 
     # Write the trials cut sets to the output directory
     if output_dir is not None:
         if "pos_trials" in manifests:
             for i, cuts in enumerate(manifests["pos_trials"]):
-                cuts.to_file(output_dir / f"pos_trials_voxceleb_utt{i+1}.jsonl.gz")
+                cuts.to_file(output_dir / f"voxceleb_pos_trials_utt{i+1}.jsonl.gz")
         if "neg_trials" in manifests:
             for i, cuts in enumerate(manifests["neg_trials"]):
-                cuts.to_file(output_dir / f"neg_trials_voxceleb_utt{i+1}.jsonl.gz")
+                cuts.to_file(output_dir / f"voxceleb_neg_trials_utt{i+1}.jsonl.gz")
 
     return manifests
 

--- a/lhotse/recipes/voxceleb.py
+++ b/lhotse/recipes/voxceleb.py
@@ -242,10 +242,10 @@ def prepare_voxceleb(
     if output_dir is not None:
         if "pos_trials" in manifests:
             for i, cuts in enumerate(manifests["pos_trials"]):
-                cuts.to_file(output_dir / f"voxceleb_pos_trials_utt{i+1}.jsonl.gz")
+                cuts.to_file(output_dir / f"voxceleb_pos-trials_utt{i+1}.jsonl.gz")
         if "neg_trials" in manifests:
             for i, cuts in enumerate(manifests["neg_trials"]):
-                cuts.to_file(output_dir / f"voxceleb_neg_trials_utt{i+1}.jsonl.gz")
+                cuts.to_file(output_dir / f"voxceleb_neg-trials_utt{i+1}.jsonl.gz")
 
     return manifests
 

--- a/lhotse/recipes/wenet_speech.py
+++ b/lhotse/recipes/wenet_speech.py
@@ -93,8 +93,10 @@ def prepare_wenet_speech(
         )
 
         if output_dir is not None:
-            supervisions.to_file(output_dir / f"supervisions_{sub}.jsonl.gz")
-            recordings.to_file(output_dir / f"recordings_{sub}.jsonl.gz")
+            supervisions.to_file(
+                output_dir / f"wenetspeech_supervisions_{sub}.jsonl.gz"
+            )
+            recordings.to_file(output_dir / f"wenetspeech_recordings_{sub}.jsonl.gz")
 
         manifests[sub] = {
             "recordings": recordings,

--- a/lhotse/recipes/yesno.py
+++ b/lhotse/recipes/yesno.py
@@ -158,8 +158,8 @@ def prepare_yesno(
         validate_recordings_and_supervisions(recording_set, supervision_set)
 
         if output_dir is not None:
-            supervision_set.to_file(output_dir / f"yesno_supervisions_{name}.jsonl")
-            recording_set.to_file(output_dir / f"yesno_recordings_{name}.jsonl")
+            supervision_set.to_file(output_dir / f"yesno_supervisions_{name}.jsonl.gz")
+            recording_set.to_file(output_dir / f"yesno_recordings_{name}.jsonl.gz")
 
         manifests[name] = {
             "recordings": recording_set,

--- a/lhotse/recipes/yesno.py
+++ b/lhotse/recipes/yesno.py
@@ -158,8 +158,8 @@ def prepare_yesno(
         validate_recordings_and_supervisions(recording_set, supervision_set)
 
         if output_dir is not None:
-            supervision_set.to_json(output_dir / f"supervisions_{name}.json")
-            recording_set.to_json(output_dir / f"recordings_{name}.json")
+            supervision_set.to_file(output_dir / f"yesno_supervisions_{name}.jsonl")
+            recording_set.to_file(output_dir / f"yesno_recordings_{name}.jsonl")
 
         manifests[name] = {
             "recordings": recording_set,


### PR DESCRIPTION
This PR "normalizes" the output manifests for the recipes:
* All JSON type outputs are changed to JSONL (ses [this comment](https://github.com/lhotse-speech/lhotse/pull/709#discussion_r872698200))
* Manifests are named as `<corpus-name>_<manifest-type>_<part>.jsonl`, e.g., "ami_recordings_dev.jsonl". This is to ensure that manifests from multiple corpora can be saved to same directory without name-based confusion as would occur with names like "recordings_dev.jsonl".

Obviously, we would have to modify the data preparation in icefall to be compatible with these changes, but I feel it's better to switch to this normalized naming scheme now rather than when it would break a lot more recipes.