### PR TITLE
Remove file handle caching from LilcomChunkyReader

### DIFF
--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -1157,7 +1157,7 @@ class MonoCut(Cut):
             old_sup = self.supervisions[0]
             if isclose(old_sup.start, 0) and isclose(old_sup.duration, self.duration):
                 return self
-            if old_sup.start < 0 or old_sup.end > self.end and not shrink_ok:
+            if (old_sup.start < 0 or old_sup.end > self.end) and not shrink_ok:
                 raise ValueError(
                     f"Cannot shrink supervision (start={old_sup.start}, end={old_sup.end}) to cut "
                     f"(start=0, duration={self.duration}) because the argument `shrink_ok` is `False`. "

--- a/lhotse/features/io.py
+++ b/lhotse/features/io.py
@@ -746,8 +746,6 @@ class LilcomChunkyReader(FeaturesReader):
         chunk_data = []
         with open(self.storage_path, "rb") as file:
             for offset, end in pairwise(chunk_offsets):
-                # We need to use locks to avoid race conditions between seek
-                # and read in multi-threaded reads.
                 file.seek(offset)
                 chunk_data.append(file.read(end - offset))
 

--- a/lhotse/features/io.py
+++ b/lhotse/features/io.py
@@ -370,20 +370,6 @@ def lookup_cache_or_open(storage_path: str):
 
 
 @lru_cache(maxsize=None)
-def lookup_cache_or_open_regular_file(storage_path: str):
-    """
-    Helper internal function used in "fast" file readers.
-    It opens regular files and keeps their handles open in a global program cache
-    to avoid excessive amount of syscalls when the Reader class is instantiated
-    and destroyed in a loop repeatedly (frequent use-case).
-
-    The file handles can be freed at any time by calling ``close_cached_file_handles()``.
-    """
-    f = open(storage_path, "rb")
-    return f
-
-
-@lru_cache(maxsize=None)
 def lookup_chunk_size(h5_file_handle) -> int:
     """
     Helper internal function to retrieve the chunk size from an HDF5 file.
@@ -394,7 +380,6 @@ def lookup_chunk_size(h5_file_handle) -> int:
 
 def close_cached_file_handles() -> None:
     """Closes the cached file handles in ``lookup_cache_or_open`` (see its docs for more details)."""
-    lookup_cache_or_open_regular_file.cache_clear()
     lookup_cache_or_open.cache_clear()
     lookup_chunk_size.cache_clear()
 
@@ -737,8 +722,7 @@ class LilcomChunkyReader(FeaturesReader):
 
     def __init__(self, storage_path: Pathlike, *args, **kwargs):
         super().__init__()
-        self.file = lookup_cache_or_open_regular_file(storage_path)
-        self.lock = threading.Lock()
+        self.storage_path = storage_path
 
     @dynamic_lru_cache
     def read(
@@ -760,12 +744,12 @@ class LilcomChunkyReader(FeaturesReader):
         chunk_offsets = chunk_offsets[left_chunk_idx:right_chunk_idx]
 
         chunk_data = []
-        for offset, end in pairwise(chunk_offsets):
-            # We need to use locks to avoid race conditions between seek
-            # and read in multi-threaded reads.
-            with self.lock:
-                self.file.seek(offset)
-                chunk_data.append(self.file.read(end - offset))
+        with open(self.storage_path, "rb") as file:
+            for offset, end in pairwise(chunk_offsets):
+                # We need to use locks to avoid race conditions between seek
+                # and read in multi-threaded reads.
+                file.seek(offset)
+                chunk_data.append(file.read(end - offset))
 
         # Read, decode, concat
         decompressed_chunks = [lilcom.decompress(data) for data in chunk_data]


### PR DESCRIPTION
This should resolve https://github.com/lhotse-speech/lhotse/issues/607 at the cost of some speed possibly. On a local system with fast CPU and SSD, iterating dataloader from 4 lilcom chunky archives with 8 workers using mini-librispeech, I got the following:

```
master 194it [00:05, 36.32it/s]

this PR 194it [00:05, 35.60it/s]
```

There is a tiny difference which could be larger on slow systems. @csukuangfj you did something similar before; did you notice a slowdown of training? Anyway I think we should merge it, it's better to be a bit slower but correct..