### PR TITLE
Change vctk.py to adapt the vctk dataset downloaded from edinburgh url

### DIFF
--- a/lhotse/bin/modes/recipes/vctk.py
+++ b/lhotse/bin/modes/recipes/vctk.py
@@ -10,9 +10,12 @@ __all__ = ["vctk"]
 @prepare.command()
 @click.argument("corpus_dir", type=click.Path(exists=True, dir_okay=True))
 @click.argument("output_dir", type=click.Path())
-def vctk(corpus_dir: Pathlike, output_dir: Pathlike):
+@click.option("--use-edinburgh-vctk-url", default=False)
+def vctk(corpus_dir: Pathlike, output_dir: Pathlike, use_edinburgh_vctk_url: bool):
     """VCTK data preparation."""
-    prepare_vctk(corpus_dir, output_dir=output_dir)
+    prepare_vctk(
+        corpus_dir, output_dir=output_dir, use_edinburgh_vctk_url=use_edinburgh_vctk_url
+    )
 
 
 @download.command()

--- a/lhotse/recipes/vctk.py
+++ b/lhotse/recipes/vctk.py
@@ -139,38 +139,75 @@ def download_vctk(
 def prepare_vctk(
     corpus_dir: Pathlike,
     output_dir: Optional[Pathlike] = None,
+    use_edinburgh_vctk_url: Optional[bool] = False,
+    mic_id: Optional[str] = "mic2",
 ) -> Dict[str, Union[RecordingSet, SupervisionSet]]:
     """
     Prepares and returns the L2 Arctic manifests which consist of Recordings and Supervisions.
 
     :param corpus_dir: Pathlike, the path of the data dir.
     :param output_dir: Pathlike, the path where to write the manifests.
+    :param use_edinburgh_vctk_url: Bool, if use edinburgh_vctk_url to download the
+    :param mic_id: str, the default of mic_id is mic2.
+    dataset, please set it as True.
     :return: a dict with keys "read" and "spontaneous".
         Each hold another dict of {'recordings': ..., 'supervisions': ...}
+
+    Note: when download the vctk dataset with the edinburgh url, there are some points should know:
+        * All the speeches from speaker ``p315`` will be skipped due to the lack of the corresponding text files.
+        * All the speeches from speaker ``p280`` will be skipped for ``mic_id="mic2"`` due to the lack of the audio files.
+        * Some of the speeches from speaker ``p362`` will be skipped due to the lack of  the audio files.
+        * See Also: https://datashare.is.ed.ac.uk/handle/10283/3443
     """
     corpus_dir = Path(corpus_dir)
     assert corpus_dir.is_dir(), f"No such directory: {corpus_dir}"
 
     speaker_meta = _parse_speaker_description(corpus_dir)
 
-    recordings = RecordingSet.from_recordings(
-        Recording.from_file(wav) for wav in (corpus_dir / "wav48").rglob("*.wav")
-    )
+    audios_dir = ""
+    recordings = ""
+    if use_edinburgh_vctk_url:
+        audios_dir = corpus_dir / "wav48_silence_trimmed"
+        recordings = RecordingSet.from_recordings(
+            Recording.from_file(flac) for flac in audios_dir.rglob("*.flac")
+        )
+    else:
+        audios_dir = corpus_dir / "wav48"
+        recordings = RecordingSet.from_recordings(
+            Recording.from_file(wav) for wav in audios_dir.rglob("*.wav")
+        )
+
     supervisions = []
     for path in (corpus_dir / "txt").rglob("*.txt"):
         # One utterance (line) per file
         text = path.read_text().strip()
         speaker = path.name.split("_")[0]  # p226_001.txt -> p226
         seg_id = path.stem
+        audio_file_id = ""
+        if use_edinburgh_vctk_url:
+            if speaker == "p280" and mic_id == "mic2":
+                continue
+            else:
+                audio_file_id = seg_id + "_" + mic_id
+        else:
+            audio_file_id = seg_id
+
+        if speaker == "p362":
+            if audio_file_id not in recordings:
+                continue
+            audio_file_path = recordings[audio_file_id].sources[0].source
+            if not Path(audio_file_path).is_file():
+                continue
+
         meta = speaker_meta.get(speaker, defaultdict(lambda: None))
         if meta is None:
             logging.warning(f"Cannot find metadata for speaker {speaker}.")
         supervisions.append(
             SupervisionSegment(
-                id=seg_id,
-                recording_id=seg_id,
+                id=audio_file_id,
+                recording_id=audio_file_id,
                 start=0,
-                duration=recordings[seg_id].duration,
+                duration=recordings[audio_file_id].duration,
                 text=text,
                 language="English",
                 speaker=speaker,
@@ -207,7 +244,9 @@ def _parse_speaker_description(corpus_dir: Pathlike):
         for line in (corpus_dir / "speaker-info.txt").read_text().splitlines()
     ]
     header = lines[0]
-    assert header == ["ID", "AGE", "GENDER", "ACCENTS", "REGION"]
+
+    assert set(["ID", "AGE", "GENDER", "ACCENTS", "REGION"]).issubset(set(header))
+
     for spk, age, gender, accent, *region in lines[1:]:
         meta[f"p{spk}"] = {
             "age": int(age),

--- a/lhotse/recipes/vctk.py
+++ b/lhotse/recipes/vctk.py
@@ -147,9 +147,8 @@ def prepare_vctk(
 
     :param corpus_dir: Pathlike, the path of the data dir.
     :param output_dir: Pathlike, the path where to write the manifests.
-    :param use_edinburgh_vctk_url: Bool, if use edinburgh_vctk_url to download the
+    :param use_edinburgh_vctk_url: Bool, if use edinburgh_vctk_url to download the dataset, please set it as True.
     :param mic_id: str, the default of mic_id is mic2.
-    dataset, please set it as True.
     :return: a dict with keys "read" and "spontaneous".
         Each hold another dict of {'recordings': ..., 'supervisions': ...}
 


### PR DESCRIPTION
As a response to #774 , I modify the vctk.py to adapt the vctk dataset downloaded from edinburgh url. I refer to the codes from https://pytorch.org/audio/stable/_modules/torchaudio/datasets/vctk.html. Also, I do a test for the new vctk.py in the vctk dataset downloaded from edinburgh url. It runs successfully. But I don't test it on the vctk dataset downloaded from the `CREST_VCTK_URL`.

Usage:
`lhotse prepare vctk download/vctk data/manifests --use-edinburgh-vctk-url True`