### PR TITLE
Revert #738 to use aidatatang as the prefix for aidatatang_200zh.

### DIFF
--- a/lhotse/recipes/aidatatang_200zh.py
+++ b/lhotse/recipes/aidatatang_200zh.py
@@ -137,10 +137,10 @@ def prepare_aidatatang_200zh(
 
         if output_dir is not None:
             supervision_set.to_file(
-                output_dir / f"aidatatang_200zh_supervisions_{part}.jsonl.gz"
+                output_dir / f"aidatatang_supervisions_{part}.jsonl.gz"
             )
             recording_set.to_file(
-                output_dir / f"aidatatang_200zh_recordings_{part}.jsonl.gz"
+                output_dir / f"aidatatang_recordings_{part}.jsonl.gz"
             )
 
         manifests[part] = {"recordings": recording_set, "supervisions": supervision_set}

--- a/lhotse/recipes/aidatatang_200zh.py
+++ b/lhotse/recipes/aidatatang_200zh.py
@@ -139,9 +139,7 @@ def prepare_aidatatang_200zh(
             supervision_set.to_file(
                 output_dir / f"aidatatang_supervisions_{part}.jsonl.gz"
             )
-            recording_set.to_file(
-                output_dir / f"aidatatang_recordings_{part}.jsonl.gz"
-            )
+            recording_set.to_file(output_dir / f"aidatatang_recordings_{part}.jsonl.gz")
 
         manifests[part] = {"recordings": recording_set, "supervisions": supervision_set}
 


### PR DESCRIPTION
We have been using `aidatatang` as the prefix for the dataset `aidatatang_200zh`.

However, #738 changes the prefix to `aidatatang_200zh`, which breaks icefall.

This PR reverts that change.