### PR TITLE
Add `pad_silence` option to `extend_by`

### DIFF
--- a/lhotse/cut.py
+++ b/lhotse/cut.py
@@ -1375,7 +1375,7 @@ class MonoCut(Cut):
         duration: Seconds,
         direction: str = "both",
         preserve_id: bool = False,
-        pad_silence: bool = False,
+        pad_silence: bool = True,
     ) -> "MonoCut":
         """
         Returns a new MonoCut that is an extended region of the current MonoCut by extending
@@ -1391,15 +1391,15 @@ class MonoCut(Cut):
             the "real" content of the recording that the cut is part of. For example, a MonoCut spanning
             the region from 2s to 5s in a recording, when extended by 2s to the right, will now span
             the region from 2s to 7s in the same recording (provided the recording length exceeds 7s).
-            If the recording is shorter, the cut will only be extended up to the duration of the recording.
-            To "expand" a cut by padding, use :meth:`MonoCut.pad`. To "truncate" a cut, use :meth:`MonoCut.truncate`.
+            If the recording is shorter, additional silence will be padded to achieve the desired duration
+            by default. This behavior can be changed by setting ``pad_silence=False``.
+            Also see :meth:`MonoCut.pad` which pads a cut "to" a specified length.
+            To "truncate" a cut, use :meth:`MonoCut.truncate`.
 
         .. hint::
 
-            If `pad_silence` is set to True, then the cut will be extended by the specified duration
-            regardless of the length of the actual recording, by additionally padding with silence if
-            required. For example, in the above example, if the recording is only 6s long, the cut will
-            be extended by 1s of silence.
+            If `pad_silence` is set to False, then the cut will be extended only as much as allowed
+            within the recording's boundary.
 
         .. hint::
 
@@ -1411,6 +1411,9 @@ class MonoCut(Cut):
         :param direction: string, 'left', 'right' or 'both'. Determines whether to extend on the left,
             right, or both sides. If 'both', extend on both sides by the duration specified in `duration`.
         :param preserve_id: bool. Should the extended cut keep the same ID or get a new, random one.
+        :param pad_silence: bool. Should the cut be padded with silence if the recording is shorter than
+            the desired duration. If False, the cut will be extended only as much as allowed within the
+            recording's boundary.
         :return: a new MonoCut instance.
         """
         from lhotse.array import TemporalArray
@@ -2015,6 +2018,7 @@ class PaddingCut(Cut):
         duration: Seconds,
         direction: str = "both",
         preserve_id: bool = False,
+        pad_silence: bool = True,
     ) -> "PaddingCut":
         """
         Return a new PaddingCut with region extended by the specified duration.
@@ -2025,6 +2029,7 @@ class PaddingCut(Cut):
             the specified duration on both sides.
         :param preserve_id: When ``True``, preserves the cut ID from before padding.
             Otherwise, generates a new random ID (default).
+        :param pad_silence: See usage in :func:`lhotse.cut.MonoCut.extend_by`. It is ignored here.
         :return: an extended PaddingCut.
         """
         new_duration = self.duration + duration
@@ -2690,6 +2695,7 @@ class MixedCut(Cut):
         duration: Seconds,
         direction: str = "both",
         preserve_id: bool = False,
+        pad_silence: bool = True,
     ) -> "MixedCut":
         """
         This raises a ValueError since extending a MixedCut is not defined.
@@ -2698,6 +2704,7 @@ class MixedCut(Cut):
         :param direction: string, 'left', 'right' or 'both'. Determines whether to extend on the left,
             right, or both sides. If 'both', extend on both sides by the duration specified in `duration`.
         :param preserve_id: bool. Should the extended cut keep the same ID or get a new, random one.
+        :param pad_silence: bool. See usage in `lhotse.cut.MonoCut.extend_by`.
         :return: a new MixedCut instance.
         """
         raise ValueError("The extend_by() method is not defined for a MixedCut.")
@@ -4325,7 +4332,7 @@ class CutSet(Serializable, AlgorithmMixin):
         duration: Seconds,
         direction: str = "both",
         preserve_id: bool = False,
-        pad_silence: bool = False,
+        pad_silence: bool = True,
     ) -> "CutSet":
         """
         Returns a new CutSet with cuts extended by `duration` amount.

--- a/test/cut/test_cut_extend_by.py
+++ b/test/cut/test_cut_extend_by.py
@@ -19,15 +19,21 @@ from lhotse.utils import LOG_EPSILON, uuid4
         "cut_duration",
         "extend_duration",
         "extend_direction",
+        "pad_silence",
         "expected_start",
         "expected_end",
     ],
     [
-        (0.0, 0.5, 0.3, "right", 0.0, 0.8),
-        (0.0, 0.5, 0.3, "both", 0.0, 0.8),
-        (0.2, 0.5, 0.3, "left", 0.0, 0.7),
-        (0.2, 0.5, 0.1, "both", 0.1, 0.8),
-        (0.0, 0.8, 0.3, "both", 0.0, 1.0),
+        (0.0, 0.5, 0.3, "right", False, 0.0, 0.8),
+        (0.0, 0.5, 0.3, "both", False, 0.0, 0.8),
+        (0.2, 0.5, 0.3, "left", False, 0.0, 0.7),
+        (0.2, 0.5, 0.1, "both", False, 0.1, 0.8),
+        (0.0, 0.8, 0.3, "both", False, 0.0, 1.0),
+        (0.0, 0.5, 0.3, "right", True, 0.0, 0.8),
+        (0.0, 0.5, 0.3, "both", True, 0.0, 1.1),
+        (0.2, 0.5, 0.3, "left", True, 0.0, 0.8),
+        (0.2, 0.5, 0.1, "both", True, 0.1, 0.8),
+        (0.0, 0.8, 0.3, "both", True, 0.0, 1.4),
     ],
 )
 def test_extend_by_cut(
@@ -35,11 +41,14 @@ def test_extend_by_cut(
     cut_duration,
     extend_duration,
     extend_direction,
+    pad_silence,
     expected_start,
     expected_end,
 ):
     cut = dummy_cut(int(uuid4()), start=cut_start, duration=cut_duration)
-    extended_cut = cut.extend_by(duration=extend_duration, direction=extend_direction)
+    extended_cut = cut.extend_by(
+        duration=extend_duration, direction=extend_direction, pad_silence=pad_silence
+    )
     assert isclose(extended_cut.start, expected_start)
     assert isclose(extended_cut.end, expected_end)
 

--- a/test/cut/test_cut_extend_by.py
+++ b/test/cut/test_cut_extend_by.py
@@ -57,7 +57,7 @@ def test_extend_by_cut(
 def test_extend_by_cut_preserve_id(preserve_id):
     cut = dummy_cut(int(uuid4()), start=0.0, duration=0.5)
     extended_cut = cut.extend_by(
-        duration=0.3, direction="right", preserve_id=preserve_id
+        duration=0.3, direction="right", preserve_id=preserve_id, pad_silence=False
     )
     if preserve_id:
         assert extended_cut.id == cut.id
@@ -71,14 +71,17 @@ def test_extend_by_cut_preserve_id(preserve_id):
         "cut_duration",
         "extend_duration",
         "extend_direction",
+        "pad_silence",
         "supervision_start",
         "supervision_duration",
         "expected_start",
         "expected_end",
     ],
     [
-        (0.2, 0.5, 0.2, "right", 0.1, 0.7, 0.1, 0.8),
-        (0.2, 0.5, 0.1, "both", 0.2, 0.8, 0.3, 1.1),
+        (0.2, 0.5, 0.2, "right", False, 0.1, 0.7, 0.1, 0.8),
+        (0.2, 0.5, 0.1, "both", False, 0.2, 0.8, 0.3, 1.1),
+        (0.2, 0.5, 0.2, "right", True, 0.1, 0.7, 0.1, 0.8),
+        (0.2, 0.5, 0.1, "both", True, 0.2, 0.8, 0.3, 1.1),
     ],
 )
 def test_extend_by_cut_with_supervision(
@@ -86,6 +89,7 @@ def test_extend_by_cut_with_supervision(
     cut_duration,
     extend_duration,
     extend_direction,
+    pad_silence,
     supervision_start,
     supervision_duration,
     expected_start,
@@ -105,7 +109,9 @@ def test_extend_by_cut_with_supervision(
     cut = dummy_cut(
         int(uuid4()), start=cut_start, duration=cut_duration, supervisions=supervisions
     )
-    extended_cut = cut.extend_by(duration=extend_duration, direction=extend_direction)
+    extended_cut = cut.extend_by(
+        duration=extend_duration, direction=extend_direction, pad_silence=pad_silence
+    )
     assert isclose(extended_cut.supervisions[0].start, expected_start)
     assert isclose(extended_cut.supervisions[0].end, expected_end)
 
@@ -180,7 +186,9 @@ def test_extend_by_cut_with_features(
             int(uuid4()), start=feature_start, duration=feature_duration
         ),
     )
-    extended_cut = cut.extend_by(duration=extend_duration, direction=extend_direction)
+    extended_cut = cut.extend_by(
+        duration=extend_duration, direction=extend_direction, pad_silence=False
+    )
     if expected:
         assert extended_cut.features == cut.features
     else:
@@ -195,9 +203,9 @@ def test_cut_set_extend_by():
         duration=0.3, direction="both", preserve_id=True
     )
     assert isclose(extended_cut_set[cut1.id].start, 0.0)
-    assert isclose(extended_cut_set[cut1.id].end, 0.8)
+    assert isclose(extended_cut_set[cut1.id].end, 1.1)
     assert isclose(extended_cut_set[cut2.id].start, 0.0)
-    assert isclose(extended_cut_set[cut2.id].end, 0.9)
+    assert isclose(extended_cut_set[cut2.id].end, 1.0)
 
 
 # `cut1` and `cut2` parameters are standard Pytest fixtures located in test/cut/conftest.py


### PR DESCRIPTION
This address https://github.com/lhotse-speech/lhotse/issues/779.

Currently, the `extend_by()` method only extends the cut to at most the boundaries of the recording. With this option set to true, we can now pad with silence to extend beyond the recording's boundaries.