### PR TITLE
Message when calling len() on LazyFilter

### DIFF
--- a/lhotse/features/base.py
+++ b/lhotse/features/base.py
@@ -18,7 +18,7 @@ from lhotse.audio import Recording
 from lhotse.augmentation import AugmentFn
 from lhotse.features.io import FeaturesWriter, get_reader
 from lhotse.lazy import AlgorithmMixin
-from lhotse.serialization import Serializable, load_yaml, save_to_yaml
+from lhotse.serialization import LazyMixin, Serializable, load_yaml, save_to_yaml
 from lhotse.utils import (
     Pathlike,
     Seconds,
@@ -594,10 +594,12 @@ class FeatureSet(Serializable, AlgorithmMixin):
         return self.features
 
     @staticmethod
-    def from_features(features: Iterable[Features]) -> "FeatureSet":
-        # NOTE: here we use list comprehension instead of list() because the latter
-        # would not work if features is a lazy generator.
-        return FeatureSet([f for f in features])
+    def from_features(features: Union[Iterable[Features], LazyMixin]) -> "FeatureSet":
+        return (
+            FeatureSet([f for f in features])
+            if isinstance(features, LazyMixin)
+            else FeatureSet(list(features))
+        )
 
     from_items = from_features
 

--- a/lhotse/features/base.py
+++ b/lhotse/features/base.py
@@ -593,12 +593,11 @@ class FeatureSet(Serializable, AlgorithmMixin):
         """Alias property for ``self.features``"""
         return self.features
 
-    def to_eager(self) -> "FeatureSet":
-        return FeatureSet(list(self))
-
     @staticmethod
     def from_features(features: Iterable[Features]) -> "FeatureSet":
-        return FeatureSet(list(features))  # just for consistency with other *Sets
+        # NOTE: here we use list comprehension instead of list() because the latter
+        # would not work if features is a lazy generator.
+        return FeatureSet([f for f in features])
 
     from_items = from_features
 

--- a/lhotse/lazy.py
+++ b/lhotse/lazy.py
@@ -427,6 +427,14 @@ class LazyFlattener(ImitatesDict):
     def __add__(self, other) -> "LazyIteratorChain":
         return LazyIteratorChain(self, other)
 
+    def __len__(self) -> int:
+        raise NotImplementedError(
+            "LazyFlattener does not support __len__ because it would require "
+            "iterating over the whole iterator, which is not possible in a lazy fashion. "
+            "If you really need to know the length, convert to eager mode first using "
+            "`.to_eager()`. Note that this will require loading the whole iterator into memory."
+        )
+
 
 class LazyRepeater(ImitatesDict):
     """

--- a/lhotse/lazy.py
+++ b/lhotse/lazy.py
@@ -363,10 +363,16 @@ class LazyFilter(ImitatesDict):
     def __iter__(self):
         return filter(self.predicate, self.iterator)
 
-    # note: no __len__
-
     def __add__(self, other) -> "LazyIteratorChain":
         return LazyIteratorChain(self, other)
+
+    def __len__(self) -> int:
+        raise NotImplementedError(
+            "LazyFilter does not support __len__ because it would require "
+            "iterating over the whole iterator, which is not possible in a lazy fashion. "
+            "If you really need to know the length, convert to eager mode first using "
+            "`.to_eager()`. Note that this will require loading the whole iterator into memory."
+        )
 
 
 class LazyMapper(ImitatesDict):

--- a/test/test_lazy.py
+++ b/test/test_lazy.py
@@ -71,7 +71,9 @@ def test_filter(manifest_type):
 
     with as_lazy(data) as lazy_data:
         lazy_result = lazy_data.filter(predicate)
-        assert list(lazy_result) == list(expected)
+        with pytest.raises(NotImplementedError):
+            assert list(lazy_result) == list(expected)
+        assert list(lazy_result.to_eager()) == list(expected)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Currently, when `len()` is called on an object of type `LazyFilter` (which is the case when a filter is applied on a lazily loaded manifest), it will throw a `TypeError`:
```python
TypeError: object of type 'LazyFilter' has no len()
```

After this change, we instead show an informative message:
```python
NotImplementedError: LazyFilter does not support __len__ because it would require iterating over the whole iterator, which is not possible in a lazy fashion. If you really need to know the length, convert
 to eager mode first using `.to_eager()`. Note that this will require loading the whole iterator into memory.
 ```