### PR TITLE
Experimental Lhotse feature: corpus creation tools (``workflows``), starting with OpenAI Whisper support

### DIFF
--- a/lhotse/__init__.py
+++ b/lhotse/__init__.py
@@ -24,6 +24,7 @@ from .utils import (
     measure_overlap,
     streaming_shuffle,
 )
+from .workflows import *
 
 try:
     # Try to get Lhotse's version (should be created during running pip install / python setup.py ...)

--- a/lhotse/audio.py
+++ b/lhotse/audio.py
@@ -1546,7 +1546,7 @@ class CompositeAudioBackend(AudioBackend):
                         force_opus_sampling_rate=force_opus_sampling_rate,
                     )
                 except Exception as e:
-                    msg = f"Exception #{len(exceptions)}: "
+                    msg = f"Exception #{len(exceptions)} ({type(b)}): "
                     if verbose_audio_loading_exceptions():
                         exceptions.append(f"{msg}{traceback.format_exc()}")
                     else:

--- a/lhotse/bin/modes/__init__.py
+++ b/lhotse/bin/modes/__init__.py
@@ -6,3 +6,4 @@ from .kaldi import *
 from .manipulation import *
 from .recipes import *
 from .validate import *
+from .workflows import *

--- a/lhotse/bin/modes/workflows.py
+++ b/lhotse/bin/modes/workflows.py
@@ -1,0 +1,94 @@
+from pathlib import Path
+from typing import Optional
+
+import click
+from tqdm import tqdm
+
+from lhotse import CutSet, RecordingSet
+from lhotse.bin.modes.cli_base import cli
+from lhotse.utils import exactly_one_not_null
+
+
+@cli.group()
+def workflows():
+    """Workflows using corpus creation tools."""
+    pass
+
+
+@workflows.command()
+@click.argument("out_cuts", type=click.Path())
+@click.option(
+    "-m",
+    "--recordings-manifest",
+    type=click.Path(exists=True, dir_okay=False),
+    help="Path to an existing recording manifest.",
+)
+@click.option(
+    "-r",
+    "--recordings-dir",
+    type=click.Path(exists=True, file_okay=False),
+    help="Directory with recordings. We will create a RecordingSet for it automatically.",
+)
+@click.option(
+    "-e",
+    "--extension",
+    default="wav",
+    help="Audio file extension to search for. Used with RECORDINGS_DIR.",
+)
+@click.option(
+    "-n",
+    "--model-name",
+    default="base",
+    help="One of Whisper variants (base, medium, large, etc.)",
+)
+@click.option(
+    "-l",
+    "--language",
+    help="Language spoken in the audio. Inferred by default.",
+)
+@click.option(
+    "-d", "--device", default="cpu", help="Device on which to run the inference."
+)
+@click.option("-j", "--jobs", default=1, help="Number of jobs for audio scanning.")
+def annotate_with_whisper(
+    out_cuts: str,
+    recordings_manifest: Optional[str],
+    recordings_dir: Optional[str],
+    extension: str,
+    model_name: str,
+    language: Optional[str],
+    device: str,
+    jobs: int,
+):
+    """
+    Use OpenAI Whisper model to annotate either RECORDINGS_MANIFEST or RECORDINGS_DIR.
+    It will perform automatic segmentation, transcription, and language identification.
+
+    RECORDINGS_MANIFEST and RECORDINGS_DIR are mutually exclusive.
+
+    Note: this is an experimental feature of Lhotse, and is not guaranteed to yield
+    high quality of data.
+    """
+    from lhotse import annotate_with_whisper as annotate_with_whisper_
+
+    assert exactly_one_not_null(recordings_manifest, recordings_dir), (
+        "Options RECORDINGS_MANIFEST and RECORDINGS_DIR are mutually exclusive "
+        "and at least one is required."
+    )
+
+    if recordings_manifest is not None:
+        recordings = RecordingSet.from_file(recordings_manifest)
+    else:
+        recordings = RecordingSet.from_dir(
+            recordings_dir, pattern=f"*.{extension}", num_jobs=jobs
+        )
+
+    with CutSet.open_writer(out_cuts) as writer:
+        for cut in tqdm(
+            annotate_with_whisper_(
+                recordings, language=language, model_name=model_name, device=device
+            ),
+            total=len(recordings),
+            desc="Recordings",
+        ):
+            writer.write(cut, flush=True)

--- a/lhotse/qa.py
+++ b/lhotse/qa.py
@@ -1,7 +1,7 @@
 import logging
 from collections import defaultdict
 from math import isclose
-from typing import Any, Callable, Dict, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, Optional, Tuple, Union
 
 import numpy as np
 
@@ -163,12 +163,16 @@ def remove_missing_recordings_and_supervisions(
 
 
 def trim_supervisions_to_recordings(
-    recordings: RecordingSet, supervisions: SupervisionSet
+    recordings: Union[Recording, RecordingSet],
+    supervisions: Iterable[SupervisionSegment],
+    verbose: bool = True,
 ) -> SupervisionSet:
     """
     Return a new :class:`~lhotse.supervision.SupervisionSet` with supervisions that are
     not exceeding the duration of their corresponding :class:`~lhotse.audio.Recording`.
     """
+    if isinstance(recordings, Recording):
+        recordings = RecordingSet.from_recordings([recordings])
     if recordings.is_lazy:
         recordings = RecordingSet.from_recordings(iter(recordings))
 
@@ -184,11 +188,11 @@ def trim_supervisions_to_recordings(
             trimmed += 1
             s = s.trim(recordings[s.recording_id].duration)
         sups.append(s)
-    if removed:
+    if verbose and removed:
         logging.warning(
             f"Removed {removed} supervisions starting after the end of the recording."
         )
-    if trimmed:
+    if verbose and trimmed:
         logging.warning(
             f"Trimmed {trimmed} supervisions exceeding the end of the recording."
         )

--- a/lhotse/supervision.py
+++ b/lhotse/supervision.py
@@ -10,6 +10,7 @@ from lhotse.utils import (
     Pathlike,
     Seconds,
     TimeSpan,
+    add_durations,
     asdict_nonull,
     compute_num_samples,
     exactly_one_not_null,
@@ -311,7 +312,9 @@ class SupervisionSegment:
         return fastcopy(
             self,
             start=max(start, self.start),
-            duration=self.duration - end_exceeds_by - start_exceeds_by,
+            duration=add_durations(
+                self.duration, -end_exceeds_by, -start_exceeds_by, sampling_rate=48000
+            ),
             alignment={
                 type: [item.trim(end=end, start=start) for item in ali]
                 for type, ali in self.alignment.items()

--- a/lhotse/workflows/__init__.py
+++ b/lhotse/workflows/__init__.py
@@ -1,0 +1,1 @@
+from .whisper import annotate_with_whisper

--- a/lhotse/workflows/whisper.py
+++ b/lhotse/workflows/whisper.py
@@ -1,5 +1,4 @@
 import logging
-from itertools import pairwise
 from typing import Generator, List, Optional
 
 import torch
@@ -77,10 +76,12 @@ def _postprocess_timestamps(supervisions: List[SupervisionSegment]):
     Under a strong assumption that the input speech is non-overlapping, we can fix that
     by always truncating to the start timestamp of the next segment.
     """
+    from cytoolz import sliding_window
+
     if len(supervisions) < 2:
         return supervisions
     out = []
-    for cur, nxt in pairwise(supervisions):
+    for cur, nxt in sliding_window(2, supervisions):
         if cur.end > nxt.start:
             cur = cur.trim(end=nxt.start)
         out.append(cur)

--- a/lhotse/workflows/whisper.py
+++ b/lhotse/workflows/whisper.py
@@ -1,0 +1,88 @@
+import logging
+from itertools import pairwise
+from typing import Generator, List, Optional
+
+import torch
+
+from lhotse import MonoCut, RecordingSet, SupervisionSegment
+from lhotse.qa import trim_supervisions_to_recordings
+from lhotse.utils import is_module_available
+
+
+def annotate_with_whisper(
+    recordings: RecordingSet,
+    language: Optional[str] = None,
+    model_name: str = "base",
+    device: str = "cpu",
+) -> Generator[MonoCut, None, None]:
+    """
+    Use OpenAI Whisper model to annotate either RECORDINGS_MANIFEST or RECORDINGS_DIR.
+    It will perform automatic segmentation, transcription, and language identification.
+
+    Note: this is an experimental feature of Lhotse, and is not guaranteed to yield
+    high quality of data.
+
+    See the original repo for more details: https://github.com/openai/whisper
+
+    :param recordings: a ``RecordingSet`` object.
+    :param language: specify the language if known upfront, otherwise it will be auto-detected.
+    :param model_name: one of available Whisper variants (base, medium, large, etc.).
+    :param device: Where to run the inference (cpu, cuda, etc.).
+    :return: a generator of cuts (use ``CutSet.open_writer()`` to write them).
+    """
+    assert is_module_available("whisper"), (
+        "This function expects OpenAI Whisper to be installed. "
+        "You can install it via 'pip install git+https://github.com/openai/whisper.git' "
+        "(see https://github.com/openai/whisper for details)."
+    )
+
+    import whisper
+
+    model = whisper.load_model(model_name, device=device)
+
+    for recording in recordings:
+        if recording.num_channels > 1:
+            logging.warning(
+                f"Skipping recording '{recording.id}'. It has {recording.num_channels} channels, "
+                f"but we currently only support mono input."
+            )
+            continue
+        audio = torch.from_numpy(recording.resample(16000).load_audio()).squeeze(0)
+        result = whisper.transcribe(model=model, audio=audio, language=language)
+        supervisions = [
+            SupervisionSegment(
+                id=f"{recording.id}-{segment['id']:06d}",
+                recording_id=recording.id,
+                start=round(segment["start"], ndigits=8),
+                duration=round(segment["end"], ndigits=8),
+                text=segment["text"].strip(),
+                language=result["language"],
+            )
+            for segment in result["segments"]
+        ]
+        cut = recording.to_cut()
+        if supervisions:
+            supervisions = _postprocess_timestamps(supervisions)
+            cut.supervisions = list(
+                trim_supervisions_to_recordings(
+                    recordings=recordings, supervisions=supervisions, verbose=False
+                )
+            )
+        yield cut
+
+
+def _postprocess_timestamps(supervisions: List[SupervisionSegment]):
+    """
+    Whisper tends to have a lot of overlapping segments due to inaccurate end timestamps.
+    Under a strong assumption that the input speech is non-overlapping, we can fix that
+    by always truncating to the start timestamp of the next segment.
+    """
+    if len(supervisions) < 2:
+        return supervisions
+    out = []
+    for cur, nxt in pairwise(supervisions):
+        if cur.end > nxt.start:
+            cur = cur.trim(end=nxt.start)
+        out.append(cur)
+    out.append(nxt)
+    return out


### PR DESCRIPTION
It's actually a very experimental feature, but people seem to be getting satisfying results with running Whisper on podcasts, videos, their own speech, etc. So maybe it can be used for weak labeling of unlabeled datasets. I added a "dummy-friendly" interface in Lhotse that can create full CutSet manifest with multiple supervisions per cut from just a directory of recordings. It doesn't try to be super efficient (no dataloading, batching, etc.). 

Usage:

```bash
lhotse workflows annotate-with-whisper -r my_recordings -e flac cuts.jsonl.gz 
```

The results are saved to `cuts.jsonl.gz` (can be also `cuts.jsonl`).