### PR TITLE
Update supervisions channels in multi-channel recipes

### DIFF
--- a/lhotse/qa.py
+++ b/lhotse/qa.py
@@ -14,7 +14,7 @@ from lhotse.audio import (
 from lhotse.cut import Cut, CutSet, MixedCut, MonoCut, PaddingCut
 from lhotse.features import Features, FeatureSet
 from lhotse.supervision import SupervisionSegment, SupervisionSet
-from lhotse.utils import compute_num_frames, overlaps, is_equal_or_contains
+from lhotse.utils import compute_num_frames, is_equal_or_contains, overlaps
 
 _VALIDATORS: Dict[str, Callable] = {}
 

--- a/lhotse/recipes/aishell4.py
+++ b/lhotse/recipes/aishell4.py
@@ -132,7 +132,7 @@ def prepare_aishell4(
                             recording_id=idx,
                             start=start,
                             duration=round(end - start, 4),
-                            channel=0,
+                            channel=recording.channel_ids,
                             language="Chinese",
                             speaker=spk_id,
                             text=text.strip(),

--- a/lhotse/recipes/ali_meeting.py
+++ b/lhotse/recipes/ali_meeting.py
@@ -156,7 +156,7 @@ def prepare_ali_meeting(
                             recording_id=recording.id,
                             start=start,
                             duration=round(end - start, 4),
-                            channel=0,
+                            channel=0 if mic == "near" else list(range(8)),
                             language="Chinese",
                             speaker=spk_id,
                             gender=gender,

--- a/lhotse/recipes/ami.py
+++ b/lhotse/recipes/ami.py
@@ -550,7 +550,7 @@ def prepare_supervision_other(
                         recording_id=recording.id,
                         start=seg_info.start_time,
                         duration=duration,
-                        channel=0,
+                        channel=recording.channel_ids,
                         language="English",
                         speaker=seg_info.speaker,
                         gender=seg_info.gender,

--- a/lhotse/recipes/aspire.py
+++ b/lhotse/recipes/aspire.py
@@ -158,6 +158,9 @@ def prepare_aspire(
                     speaker=speaker,
                     text=seg.text,
                     language="English",
+                    channel=0
+                    if mic == "single"
+                    else recording_set[session].channel_ids,
                 )
                 for i, seg in enumerate(segs)
             ]

--- a/lhotse/recipes/icsi.py
+++ b/lhotse/recipes/icsi.py
@@ -469,7 +469,7 @@ def prepare_supervision_other(
                         recording_id=recording.id,
                         start=seg_info.start_time,
                         duration=duration,
-                        channel=source.channels[0],
+                        channel=recording.channel_ids,
                         language="English",
                         speaker=seg_info.speaker,
                         gender=seg_info.gender,

--- a/lhotse/recipes/libricss.py
+++ b/lhotse/recipes/libricss.py
@@ -143,8 +143,6 @@ def prepare_libricss(
     """
     assert type in ["mdm", "sdm", "ihm-mix", "ihm"]
 
-    manifests = {}
-
     corpus_dir = Path(corpus_dir)
     corpus_dir = (
         corpus_dir / "for_release" if corpus_dir.stem != "for_release" else corpus_dir
@@ -175,7 +173,7 @@ def prepare_libricss(
             for idx, seg in enumerate(
                 parse_transcript(session / "transcription" / "meeting_info.txt")
             ):
-                if type == "ihm-mix" or "sdm":
+                if type == "ihm-mix" or type == "sdm":
                     channel = 0
                 elif type == "ihm":
                     channel = SPK_TO_CHANNEL_MAP[session.name][seg[2]]


### PR DESCRIPTION
In https://github.com/lhotse-speech/lhotse/pull/822, we updated the `channel` attribute of `SupervisionSegment` to be able to represent a single channel or a list of channels. This PR updates the existing multi-channel recipes to use this capability. For example, in the AMI "mdm" setting, each supervision segment is shared across all the channels.