### PR TITLE
Allow retaining or trimming channels in trim_to_supervisions

### DIFF
--- a/lhotse/cut/base.py
+++ b/lhotse/cut/base.py
@@ -470,17 +470,17 @@ class Cut:
             if not keep_overlapping:
                 # Ensure that there is exactly one supervision per cut.
                 trimmed = trimmed.filter_supervisions(lambda s: s.id == segment.id)
-            if not keep_all_channels:
+            if not keep_all_channels and not isinstance(trimmed, MixedCut):
+                # For MixedCut, we can't change the channels since it is defined by the
+                # number of channels in underlying tracks.
+
                 # Ensure that all supervisions have the same channel.
                 assert len(set(s.channel for s in trimmed.supervisions)) == 1, (
                     "Trimmed cut has supervisions with different channels. Either set "
                     "`ignore_channel=True` to keep original channels or `keep_overlapping=False` "
                     "to retain only 1 supervision per trimmed cut."
                 )
-                if not isinstance(trimmed, MixedCut):
-                    # For MixedCut, we can't change the channels since it is defined by the
-                    # number of channels in underlying tracks.
-                    trimmed.channel = trimmed.supervisions[0].channel
+                trimmed.channel = trimmed.supervisions[0].channel
             cuts.append(trimmed)
         return CutSet.from_cuts(cuts)
 

--- a/lhotse/cut/base.py
+++ b/lhotse/cut/base.py
@@ -394,6 +394,7 @@ class Cut:
         keep_overlapping: bool = True,
         min_duration: Optional[Seconds] = None,
         context_direction: Literal["center", "left", "right", "random"] = "center",
+        ignore_channel: bool = False,
     ) -> "CutSet":  # noqa: F821
         """
         Splits the current :class:`.Cut` into as many cuts as there are supervisions (:class:`.SupervisionSegment`).
@@ -423,6 +424,11 @@ class Cut:
                     Sup2
                |-----------|
 
+        For the case of a multi-channel cut with multiple supervisions, we can either trim
+        while respecting the supervision channels (in which case output cut has the same channels
+        as the supervision) or ignore the channels (in which case output cut has the same channels
+        as the input cut).
+
         :param keep_overlapping: when ``False``, it will discard parts of other supervisions that overlap with the
             main supervision. In the illustration above, it would discard ``Sup2`` in ``Cut1`` and ``Sup1`` in ``Cut2``.
             In this mode, we guarantee that there will always be exactly one supervision per cut.
@@ -434,6 +440,8 @@ class Cut:
         :param context_direction: Which direction should the cut be expanded towards to include context.
             The value of "center" implies equal expansion to left and right;
             random uniformly samples a value between "left" and "right".
+        :param ignore_channel: If ``True``, the output cut will have the same channels as the input cut. By default,
+            the trimmed cut will have the same channels as the supervision.
         :return: a list of cuts.
         """
         from .set import CutSet
@@ -461,6 +469,14 @@ class Cut:
             if not keep_overlapping:
                 # Ensure that there is exactly one supervision per cut.
                 trimmed = trimmed.filter_supervisions(lambda s: s.id == segment.id)
+            if not ignore_channel:
+                # Ensure that all supervisions have the same channel.
+                assert len(set(s.channel for s in trimmed.supervisions)) == 1, (
+                    "Trimmed cut has supervisions with different channels. Either set "
+                    "`ignore_channel=True` to keep original channels or `keep_overlapping=False` "
+                    "to retain only 1 supervision per trimmed cut."
+                )
+                trimmed.channel = trimmed.supervisions[0].channel
             cuts.append(trimmed)
         return CutSet.from_cuts(cuts)
 

--- a/lhotse/cut/mixed.py
+++ b/lhotse/cut/mixed.py
@@ -124,6 +124,11 @@ class MixedCut(Cut):
         return round(max(track_durations), ndigits=8)
 
     @property
+    def channel(self) -> Union[int, List[int]]:
+        num_channels = self.num_channels
+        return list(range(num_channels)) if num_channels > 1 else 0
+
+    @property
     def has_features(self) -> bool:
         return self._first_non_padding_cut.has_features
 

--- a/lhotse/cut/mono.py
+++ b/lhotse/cut/mono.py
@@ -3,7 +3,7 @@ import warnings
 from dataclasses import dataclass
 from functools import reduce
 from operator import add
-from typing import Any, Callable, Iterable, List, Optional, Union
+from typing import Any, Callable, Iterable, List, Optional
 
 import numpy as np
 

--- a/lhotse/cut/mono.py
+++ b/lhotse/cut/mono.py
@@ -3,7 +3,7 @@ import warnings
 from dataclasses import dataclass
 from functools import reduce
 from operator import add
-from typing import Any, Callable, Iterable, List, Optional
+from typing import Any, Callable, Iterable, List, Optional, Union
 
 import numpy as np
 

--- a/lhotse/cut/multi.py
+++ b/lhotse/cut/multi.py
@@ -1,6 +1,6 @@
 import logging
 import warnings
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from functools import reduce
 from itertools import groupby
 from operator import add

--- a/lhotse/cut/multi.py
+++ b/lhotse/cut/multi.py
@@ -1,6 +1,6 @@
 import logging
 import warnings
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import reduce
 from itertools import groupby
 from operator import add
@@ -76,7 +76,7 @@ class MultiCut(DataCut):
 
     @property
     def num_channels(self) -> int:
-        return len(self.channel)
+        return len(self.channel) if isinstance(self.channel, list) else 1
 
     @rich_exception_info
     def load_features(

--- a/lhotse/cut/padding.py
+++ b/lhotse/cut/padding.py
@@ -63,6 +63,10 @@ class PaddingCut(Cut):
         return []
 
     @property
+    def channel(self) -> int:
+        return 0
+
+    @property
     def has_features(self) -> bool:
         return self.num_frames is not None
 

--- a/lhotse/cut/set.py
+++ b/lhotse/cut/set.py
@@ -669,7 +669,7 @@ class CutSet(Serializable, AlgorithmMixin):
         keep_overlapping: bool = True,
         min_duration: Optional[Seconds] = None,
         context_direction: Literal["center", "left", "right", "random"] = "center",
-        ignore_channel: bool = False,
+        keep_all_channels: bool = False,
         num_jobs: int = 1,
     ) -> "CutSet":
         """
@@ -714,7 +714,7 @@ class CutSet(Serializable, AlgorithmMixin):
         :param context_direction: Which direction should the cut be expanded towards to include context.
             The value of "center" implies equal expansion to left and right;
             random uniformly samples a value between "left" and "right".
-        :param ignore_channel: If ``True``, the output cut will have the same channels as the input cut. By default,
+        :param keep_all_channels: If ``True``, the output cut will have the same channels as the input cut. By default,
             the trimmed cut will have the same channels as the supervision.
         :param num_jobs: Number of parallel workers to process the cuts.
         :return: a ``CutSet``.
@@ -732,7 +732,7 @@ class CutSet(Serializable, AlgorithmMixin):
                             keep_overlapping=keep_overlapping,
                             min_duration=min_duration,
                             context_direction=context_direction,
-                            ignore_channel=ignore_channel,
+                            keep_all_channels=keep_all_channels,
                         ),
                     )
                 )
@@ -747,6 +747,7 @@ class CutSet(Serializable, AlgorithmMixin):
             keep_overlapping=keep_overlapping,
             min_duration=min_duration,
             context_direction=context_direction,
+            keep_all_channels=keep_all_channels,
         )
         return result
 
@@ -2698,13 +2699,17 @@ def _cut_into_windows_single(
 
 
 def _trim_to_supervisions_single(
-    cuts: CutSet, keep_overlapping, min_duration, context_direction, ignore_channel
+    cuts: CutSet,
+    keep_overlapping,
+    min_duration,
+    context_direction,
+    keep_all_channels,
 ) -> CutSet:
     return cuts.trim_to_supervisions(
         keep_overlapping=keep_overlapping,
         min_duration=min_duration,
         context_direction=context_direction,
-        ignore_channel=ignore_channel,
+        keep_all_channels=keep_all_channels,
     ).to_eager()
 
 

--- a/lhotse/cut/set.py
+++ b/lhotse/cut/set.py
@@ -669,6 +669,7 @@ class CutSet(Serializable, AlgorithmMixin):
         keep_overlapping: bool = True,
         min_duration: Optional[Seconds] = None,
         context_direction: Literal["center", "left", "right", "random"] = "center",
+        ignore_channel: bool = False,
         num_jobs: int = 1,
     ) -> "CutSet":
         """
@@ -697,6 +698,11 @@ class CutSet(Serializable, AlgorithmMixin):
                     Sup2
                |-----------|
 
+        For the case of a multi-channel cut with multiple supervisions, we can either trim
+        while respecting the supervision channels (in which case output cut has the same channels
+        as the supervision) or ignore the channels (in which case output cut has the same channels
+        as the input cut).
+
         :param keep_overlapping: when ``False``, it will discard parts of other supervisions that overlap with the
             main supervision. In the illustration above, it would discard ``Sup2`` in ``Cut1`` and ``Sup1`` in ``Cut2``.
             In this mode, we guarantee that there will always be exactly one supervision per cut.
@@ -708,6 +714,8 @@ class CutSet(Serializable, AlgorithmMixin):
         :param context_direction: Which direction should the cut be expanded towards to include context.
             The value of "center" implies equal expansion to left and right;
             random uniformly samples a value between "left" and "right".
+        :param ignore_channel: If ``True``, the output cut will have the same channels as the input cut. By default,
+            the trimmed cut will have the same channels as the supervision.
         :param num_jobs: Number of parallel workers to process the cuts.
         :return: a ``CutSet``.
         """
@@ -724,6 +732,7 @@ class CutSet(Serializable, AlgorithmMixin):
                             keep_overlapping=keep_overlapping,
                             min_duration=min_duration,
                             context_direction=context_direction,
+                            ignore_channel=ignore_channel,
                         ),
                     )
                 )
@@ -1646,7 +1655,7 @@ class CutSet(Serializable, AlgorithmMixin):
                         num_features=feat_mat.shape[1],
                         frame_shift=frame_shift,
                         sampling_rate=cut.sampling_rate,
-                        channels=0,
+                        channels=cut.channel,
                         storage_type=feats_writer.name,
                         storage_path=str(feats_writer.storage_path),
                         storage_key=storage_key,
@@ -2689,12 +2698,13 @@ def _cut_into_windows_single(
 
 
 def _trim_to_supervisions_single(
-    cuts: CutSet, keep_overlapping, min_duration, context_direction
+    cuts: CutSet, keep_overlapping, min_duration, context_direction, ignore_channel
 ) -> CutSet:
     return cuts.trim_to_supervisions(
         keep_overlapping=keep_overlapping,
         min_duration=min_duration,
         context_direction=context_direction,
+        ignore_channel=ignore_channel,
     ).to_eager()
 
 

--- a/test/cut/test_cut_trim_to_supervisions.py
+++ b/test/cut/test_cut_trim_to_supervisions.py
@@ -302,8 +302,10 @@ def test_cut_trim_to_supervisions_extend_handles_end_of_recording(mono_cut):
     assert c2_s1.duration == 3.0
 
 
-def test_multi_cut_trim_to_supervisions_ignore_channel(multi_cut):
-    cuts = multi_cut.trim_to_supervisions(keep_overlapping=False, ignore_channel=True)
+def test_multi_cut_trim_to_supervisions_keep_all_channels(multi_cut):
+    cuts = multi_cut.trim_to_supervisions(
+        keep_overlapping=False, keep_all_channels=True
+    )
     assert len(cuts) == 2
     for cut, original_sup in zip(cuts, multi_cut.supervisions):
         assert cut.start == original_sup.start
@@ -316,8 +318,10 @@ def test_multi_cut_trim_to_supervisions_ignore_channel(multi_cut):
         assert cut.channel == multi_cut.channel
 
 
-def test_multi_cut_trim_to_supervisions_no_ignore_channel(multi_cut):
-    cuts = multi_cut.trim_to_supervisions(keep_overlapping=False, ignore_channel=False)
+def test_multi_cut_trim_to_supervisions_do_not_keep_all_channels(multi_cut):
+    cuts = multi_cut.trim_to_supervisions(
+        keep_overlapping=False, keep_all_channels=False
+    )
     assert len(cuts) == 2
     for cut, original_sup in zip(cuts, multi_cut.supervisions):
         assert cut.start == original_sup.start
@@ -330,8 +334,8 @@ def test_multi_cut_trim_to_supervisions_no_ignore_channel(multi_cut):
         assert cut.channel == original_sup.channel
 
 
-def test_multi_cut_trim_to_supervisions_no_ignore_channel_raises(multi_cut):
+def test_multi_cut_trim_to_supervisions_do_not_keep_all_channels_raises(multi_cut):
     with pytest.raises(AssertionError):
         cuts = multi_cut.trim_to_supervisions(
-            keep_overlapping=True, ignore_channel=False
+            keep_overlapping=True, keep_all_channels=False
         )


### PR DESCRIPTION
Consider AMI IHM as an example. For each session, we create a multi-cut with 4 channels (1 channel per speaker), and each supervision segment corresponds to one of the 4 channels (based on who the speaker is). If we then want to use this data to train an ASR system, we can call `trim_to_supervisions()`. Currently, the resulting cuts would still contain 4 channels. This PR allows the user to trim the channels to the supervisions (by default), or ignore channel while trimming.