### PR TITLE
Fix checkpoints of samplers that were iterated over more than once within the same epoch

### DIFF
--- a/lhotse/dataset/sampling/base.py
+++ b/lhotse/dataset/sampling/base.py
@@ -511,6 +511,9 @@ class SamplingDiagnostics:
             self.stats_per_epoch = {}
             self.set_epoch(self.current_epoch)
 
+    def reset_current_epoch(self) -> None:
+        self.stats_per_epoch[self.current_epoch] = EpochDiagnostics(self.current_epoch)
+
     def set_epoch(self, epoch: int) -> None:
         self.current_epoch = epoch
         if epoch not in self.stats_per_epoch:

--- a/lhotse/dataset/sampling/bucketing.py
+++ b/lhotse/dataset/sampling/bucketing.py
@@ -276,6 +276,11 @@ class BucketingSampler(CutSampler):
         # Restored state with load_state_dict()? Skip resetting.
         if self._just_restored_state:
             return self
+        # Why reset the current epoch?
+        # Either we are iterating the epoch for the first time and it's a no-op,
+        # or we are iterating the same epoch again, in which case setting more steps
+        # than are actually available per epoch would have broken the checkpoint restoration.
+        self.diagnostics.reset_current_epoch()
         # Reset the state to the beginning of the epoch.
         self.bucket_rng.seed(self.seed + self.epoch)
         for b in self.bucket_samplers:

--- a/lhotse/dataset/sampling/cut_pairs.py
+++ b/lhotse/dataset/sampling/cut_pairs.py
@@ -184,6 +184,11 @@ class CutPairsSampler(CutSampler):
         # Restored state with load_state_dict()? Skip resetting only this once.
         if self._just_restored_state:
             return self
+        # Why reset the current epoch?
+        # Either we are iterating the epoch for the first time and it's a no-op,
+        # or we are iterating the same epoch again, in which case setting more steps
+        # than are actually available per epoch would have broken the checkpoint restoration.
+        self.diagnostics.reset_current_epoch()
         # Reset the state to the beginning of the epoch.
         if self.shuffle:
             self.source_cuts.shuffle(self.seed + self.epoch)

--- a/lhotse/dataset/sampling/dynamic.py
+++ b/lhotse/dataset/sampling/dynamic.py
@@ -168,6 +168,11 @@ class DynamicCutSampler(CutSampler):
     def __iter__(self) -> "DynamicCutSampler":
         if self._just_restored_state:
             return self
+        # Why reset the current epoch?
+        # Either we are iterating the epoch for the first time and it's a no-op,
+        # or we are iterating the same epoch again, in which case setting more steps
+        # than are actually available per epoch would have broken the checkpoint restoration.
+        self.diagnostics.reset_current_epoch()
         self.rng = random.Random(self.seed + self.epoch)
         # Initiate iteration
         self.cuts_iter = [iter(cs) for cs in self.cuts]

--- a/lhotse/dataset/sampling/dynamic_bucketing.py
+++ b/lhotse/dataset/sampling/dynamic_bucketing.py
@@ -194,6 +194,11 @@ class DynamicBucketingSampler(CutSampler):
         if self._just_restored_state:
             return self
         self.rng = random.Random(self.seed + self.epoch)
+        # Why reset the current epoch?
+        # Either we are iterating the epoch for the first time and it's a no-op,
+        # or we are iterating the same epoch again, in which case setting more steps
+        # than are actually available per epoch would have broken the checkpoint restoration.
+        self.diagnostics.reset_current_epoch()
         # Initiate iteration
         self.cuts_iter = [iter(cs) for cs in self.cuts]
         # Optionally shuffle

--- a/lhotse/dataset/sampling/simple.py
+++ b/lhotse/dataset/sampling/simple.py
@@ -162,6 +162,11 @@ class SimpleCutSampler(CutSampler):
         # Restored state with load_state_dict()? Skip resetting only this once.
         if self._just_restored_state:
             return self
+        # Why reset the current epoch?
+        # Either we are iterating the epoch for the first time and it's a no-op,
+        # or we are iterating the same epoch again, in which case setting more steps
+        # than are actually available per epoch would have broken the checkpoint restoration.
+        self.diagnostics.reset_current_epoch()
         # Reset the state to the beginning of the epoch.
         if self.shuffle:
             self.data_source.shuffle(self.seed + self.epoch)


### PR DESCRIPTION
I finally realized what was the issue that multiple people ran into: Icefall recipes use `find_pessimistic_batches` utility to iterate over the sampler in epoch 0, which incremented sampler's total_cuts and total_batches in the first epoch. These stats were never reset as the training iterated over epoch 0 again, leading to a large offset. If somebody stored the checkpoint in epoch 0, they were never able to resume from it, because the sampler would raise StopIteration trying to skip a number of batches greater than the size of an epoch. Users who saved the checkpoints in later epochs did not experience this issue, making it harder to pinpoint, especially with smaller datasets. 

Resolves #785 