### PR TITLE
Small changes in `trim_to_supervisions()`

### DIFF
--- a/lhotse/cut/base.py
+++ b/lhotse/cut/base.py
@@ -429,11 +429,16 @@ class Cut:
         as the supervision) or ignore the channels (in which case output cut has the same channels
         as the input cut).
 
+        .. hint:: If the resulting trimmed cut contains a single supervision, we set the cut id to
+            the ``id`` of this supervision, for better compatibility with downstream tools, e.g.
+            comparing the hypothesis of ASR with the reference in icefall.
+
+        .. hint:: If a MultiCut is trimmed and the resulting trimmed cut contains a single channel,
+            we convert it to a MonoCut.
+
         :param keep_overlapping: when ``False``, it will discard parts of other supervisions that overlap with the
             main supervision. In the illustration above, it would discard ``Sup2`` in ``Cut1`` and ``Sup1`` in ``Cut2``.
-            In this mode, we guarantee that there will always be exactly one supervision per cut, and we set the ``id``
-            of output cut to the ``id`` of this supervision, for better compatibility with downstream tools, e.g.
-            comparing the hypothesis of ASR with the reference in icefall.
+            In this mode, we guarantee that there will always be exactly one supervision per cut.
         :param min_duration: An optional duration in seconds; specifying this argument will extend the cuts
             that would have been shorter than ``min_duration`` with actual acoustic context in the recording/features.
             If there are supervisions present in the context, they are kept when ``keep_overlapping`` is true.
@@ -446,8 +451,6 @@ class Cut:
             the trimmed cut will have the same channels as the supervision.
         :return: a list of cuts.
         """
-        # TODO (@desh2608): This function should probably be implemented separately for each Cut type.
-
         from .mixed import MixedCut
         from .multi import MultiCut
         from .set import CutSet
@@ -472,10 +475,11 @@ class Cut:
                 keep_excessive_supervisions=keep_overlapping,
                 _supervisions_index=supervisions_index,
             )
+
             if not keep_overlapping:
                 # Ensure that there is exactly one supervision per cut.
                 trimmed = trimmed.filter_supervisions(lambda s: s.id == segment.id)
-                trimmed.id = segment.id
+
             if not keep_all_channels and not isinstance(trimmed, MixedCut):
                 # For MixedCut, we can't change the channels since it is defined by the
                 # number of channels in underlying tracks.
@@ -491,6 +495,11 @@ class Cut:
                 # If we have a single-channel MultiCut, we will convert it into a MonoCut.
                 if isinstance(trimmed, MultiCut) and trimmed.num_channels == 1:
                     trimmed = trimmed.to_mono()[0]
+
+            if len(trimmed.supervisions) == 1:
+                # If the trimmed cut contains a single supervision, we set the cut id to
+                # the id of this supervision.
+                trimmed.id = segment.id
             cuts.append(trimmed)
         return CutSet.from_cuts(cuts)
 

--- a/lhotse/cut/base.py
+++ b/lhotse/cut/base.py
@@ -444,7 +444,10 @@ class Cut:
             the trimmed cut will have the same channels as the supervision.
         :return: a list of cuts.
         """
+        # TODO (@desh2608): This function should probably be implemented separately for each Cut type.
+
         from .mixed import MixedCut
+        from .multi import MultiCut
         from .set import CutSet
 
         cuts = []
@@ -481,6 +484,10 @@ class Cut:
                     "to retain only 1 supervision per trimmed cut."
                 )
                 trimmed.channel = trimmed.supervisions[0].channel
+
+                # If we have a single-channel MultiCut, we will convert it into a MonoCut.
+                if isinstance(trimmed, MultiCut) and trimmed.num_channels == 1:
+                    trimmed = trimmed.to_mono()[0]
             cuts.append(trimmed)
         return CutSet.from_cuts(cuts)
 

--- a/lhotse/cut/multi.py
+++ b/lhotse/cut/multi.py
@@ -15,9 +15,11 @@ from lhotse.supervision import SupervisionSegment
 from lhotse.utils import (
     add_durations,
     fastcopy,
+    is_equal_or_contains,
     merge_items_with_delimiter,
     overlaps,
     rich_exception_info,
+    to_list,
 )
 
 
@@ -76,7 +78,7 @@ class MultiCut(DataCut):
 
     @property
     def num_channels(self) -> int:
-        return len(self.channel) if isinstance(self.channel, list) else 1
+        return len(to_list(self.channel))
 
     @rich_exception_info
     def load_features(
@@ -237,7 +239,7 @@ class MultiCut(DataCut):
             # Merge all supervisions into a single segment.
             all_channels = set()
             for s in sups:
-                c = set([s.channel] if isinstance(s.channel, int) else s.channel)
+                c = set(to_list(s.channel))
                 all_channels.update(c)
             all_channels = sorted(all_channels)
             sups_by_channel = {tuple(all_channels): sups}  # `set` is not hashable
@@ -370,10 +372,10 @@ class MultiCut(DataCut):
                 supervisions=[
                     fastcopy(s, channel=channel)
                     for s in self.supervisions
-                    if channel in s.channel
+                    if is_equal_or_contains(s.channel, channel)
                 ],
             )
-            for channel in self.channel
+            for channel in to_list(self.channel)
         ]
 
     @staticmethod

--- a/lhotse/utils.py
+++ b/lhotse/utils.py
@@ -661,6 +661,11 @@ def ifnone(item: Optional[Any], alt_item: Any) -> Any:
     return alt_item if item is None else item
 
 
+def to_list(item: Union[Any, Sequence[Any]]) -> List[Any]:
+    """Convert ``item`` to a list if it is not already a list."""
+    return item if isinstance(item, list) else [item]
+
+
 def lens_to_mask(lens: torch.IntTensor) -> torch.Tensor:
     """
     Create a 2-D mask tensor of shape (batch_size, max_length) and dtype float32

--- a/test/cut/test_cut_trim_to_supervisions.py
+++ b/test/cut/test_cut_trim_to_supervisions.py
@@ -274,8 +274,8 @@ def test_cut_trim_to_supervisions_extend_handles_end_of_recording(mono_cut):
         duration=10.0,
         channel=0,
         supervisions=[
-            SupervisionSegment(id="X", recording_id="X", start=0.0, duration=4.0),
-            SupervisionSegment(id="X", recording_id="X", start=7.0, duration=3.0),
+            SupervisionSegment(id="X1", recording_id="X", start=0.0, duration=4.0),
+            SupervisionSegment(id="X2", recording_id="X", start=7.0, duration=3.0),
         ],
         recording=Recording(
             id="X", sources=[], sampling_rate=8000, num_samples=80000, duration=10.0
@@ -287,6 +287,7 @@ def test_cut_trim_to_supervisions_extend_handles_end_of_recording(mono_cut):
     assert len(cuts) == 2
     c1, c2 = cuts
 
+    assert c1.id == "X1"
     assert c1.start == 0
     assert c1.duration == 4.0
     assert len(c1.supervisions) == 1
@@ -294,6 +295,7 @@ def test_cut_trim_to_supervisions_extend_handles_end_of_recording(mono_cut):
     assert c1_s1.start == 0.0
     assert c1_s1.duration == 4.0
 
+    assert c2.id == "X2"
     assert c2.start == 6.5
     assert c2.duration == 3.5
     assert len(c2.supervisions) == 1
@@ -324,6 +326,7 @@ def test_multi_cut_trim_to_supervisions_do_not_keep_all_channels(multi_cut):
     )
     assert len(cuts) == 2
     for cut, original_sup in zip(cuts, multi_cut.supervisions):
+        assert isinstance(cut, MonoCut)
         assert cut.start == original_sup.start
         assert cut.duration == original_sup.duration
         assert len(cut.supervisions) == 1


### PR DESCRIPTION
Makes 2 changes:
* If trimmed cut has exactly 1 supervision, cut id is set to supervision id (see [this comment](https://github.com/lhotse-speech/lhotse/pull/853#discussion_r997447028) for reference).
* If MultiCut is trimmed and resulting cut contains 1 channel, it is returned as MonoCut.