### PR TITLE
More similar mean batch duration across nodes with DynamicBucketingSampler in multi-GPU training

### DIFF
--- a/lhotse/utils.py
+++ b/lhotse/utils.py
@@ -806,3 +806,8 @@ def streaming_shuffle(
         yield sample
     for sample in buf:
         yield sample
+
+
+def quantize(val: float, n: int) -> int:
+    """Quantize a value to the nearest integer k in the range [0, n-1] that satisfies val * n >= k."""
+    return min(math.floor(val * n), n - 1)

--- a/test/dataset/sampling/test_dynamic_bucketing.py
+++ b/test/dataset/sampling/test_dynamic_bucketing.py
@@ -48,7 +48,7 @@ def test_dynamic_bucketing_drop_last_false():
             c.duration = 2
     rng = random.Random(0)
 
-    sampler = DynamicBucketer(cuts, duration_bins=[2], max_duration=5, rng=rng)
+    sampler = DynamicBucketer(cuts, duration_bins=[2], max_duration=5, bucket_rng=rng)
     batches = [b for b in sampler]
     sampled_cuts = [c for b in batches for c in b]
 
@@ -84,7 +84,7 @@ def test_dynamic_bucketing_drop_last_true():
     rng = random.Random(0)
 
     sampler = DynamicBucketer(
-        cuts, duration_bins=[2], max_duration=5, rng=rng, drop_last=True
+        cuts, duration_bins=[2], max_duration=5, bucket_rng=rng, drop_last=True
     )
     batches = [b for b in sampler]
     sampled_cuts = [c for b in batches for c in b]

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -18,6 +18,7 @@ from lhotse.utils import (
     compute_start_duration_for_extended_cut,
     overlaps,
     overspans,
+    quantize,
 )
 
 
@@ -165,3 +166,37 @@ def test_add_durations():
 )
 def test_compute_num_windows(params, expected_n_win):
     assert compute_num_windows(params[0], params[1], params[2]) == expected_n_win
+
+
+@pytest.mark.parametrize(
+    ["val", "n", "expected"],
+    [
+        (0, 1, 0),
+        (0.1, 1, 0),
+        (0.5, 1, 0),
+        (0.7, 1, 0),
+        (1.0, 1, 0),
+        (0, 2, 0),
+        (0.1, 2, 0),
+        (0.5, 2, 1),
+        (0.7, 2, 1),
+        (1.0, 2, 1),
+        (0, 3, 0),
+        (0.1, 3, 0),
+        (0.5, 3, 1),
+        (0.7, 3, 2),
+        (1.0, 3, 2),
+        (0, 10, 0),
+        (0.1, 10, 1),
+        (0.5, 10, 5),
+        (0.7, 10, 7),
+        (1.0, 10, 9),
+        (0, 30, 0),
+        (0.1, 30, 3),
+        (0.5, 30, 15),
+        (0.7, 30, 21),
+        (1.0, 30, 29),
+    ],
+)
+def test_quantize(val, n, expected):
+    assert quantize(val, n) == expected


### PR DESCRIPTION
Resolves https://github.com/lhotse-speech/lhotse/discussions/857

I don't think it's really possible to have the same duration buckets used on each GPU node, because every node may see a subset of data and have a different set of buckets ready for sampling (ready == able to yield at least one batch):

https://github.com/lhotse-speech/lhotse/blob/ff29065b76415e5c7221ca49578cff3101c6f887/lhotse/dataset/sampling/dynamic_bucketing.py#L360-L372

But I figured out that we can do the next best thing and instead of sampling the bucket index directly, we would sample a random value `v` in [0.0, 1.0) and quantize it to the first integer `k` that satisfies `k >= v * num_ready_buckets` in each node (note that each node may have a different `num_ready_buckets`). Then we select the bucket at index `k` -- since the buckets are sorted by duration, we will have a better chance than random at selecting buckets with similar durations on every node. It's still not a guarantee, and I'm not sure if it's possible to select the optimal buckets on every node without introducing inter-node communication (which gets ugly). Note this whole approach can work because the RNGs are seeded with the combination of seed + epoch, and we assume the sampler seed is identical on every node (usually true e.g. in Icefall recipes).

@david20181 would you be willing to give it a run and let me know if this accelerated your training? Since you already have the setup to measure this, it would make my life easier..