### PR TITLE
Shar: tarfiles now also contain metadata

### DIFF
--- a/lhotse/array.py
+++ b/lhotse/array.py
@@ -82,14 +82,14 @@ class Array:
         """
         return fastcopy(self, storage_path=str(Path(path) / self.storage_path))
 
-    def move_to_memory(self) -> "Array":
+    def move_to_memory(self, lilcom: bool = False) -> "Array":
         from lhotse.features.io import get_memory_writer
 
         if self.storage_type in ("memory_lilcom", "memory_writer"):
             return self  # nothing to do
 
         arr = self.load()
-        if issubclass(arr.dtype.type, np.float):
+        if issubclass(arr.dtype.type, np.float) and lilcom:
             writer = get_memory_writer("memory_lilcom")()
         else:
             writer = get_memory_writer("memory_raw")()
@@ -247,6 +247,7 @@ class TemporalArray:
         self,
         start: Seconds = 0,
         duration: Optional[Seconds] = None,
+        lilcom: bool = False,
     ) -> "TemporalArray":
         from lhotse.features.io import get_memory_writer
 
@@ -254,7 +255,7 @@ class TemporalArray:
             return self  # nothing to do
 
         arr = self.load(start=start, duration=duration)
-        if issubclass(arr.dtype.type, np.float):
+        if issubclass(arr.dtype.type, np.float) and lilcom:
             writer = get_memory_writer("memory_lilcom")()
         else:
             writer = get_memory_writer("memory_raw")()

--- a/lhotse/cut/set.py
+++ b/lhotse/cut/set.py
@@ -376,6 +376,158 @@ class CutSet(Serializable, AlgorithmMixin):
 
         return CutSet(cuts=LazyWebdatasetIterator(path, **wds_kwargs))
 
+    @staticmethod
+    def from_shar(
+        fields: Optional[Dict[str, Sequence[Pathlike]]] = None,
+        in_dir: Optional[Pathlike] = None,
+        split_for_dataloading: bool = False,
+        shuffle_shards: bool = False,
+        seed: int = 42,
+    ) -> "CutSet":
+        """
+        Reads cuts and their corresponding data from multiple shards,
+        also recognized as the Lhotse Shar format.
+        Each shard is numbered and represented as a collection of one text manifest and
+        one or more binary tarfiles.
+        Each tarfile contains a single type of data, e.g., recordings, features, or custom fields.
+
+        Given an example directory named ``some_dir`, its expected layout is
+        ``some_dir/cuts.000000.jsonl.gz``, ``some_dir/recording.000000.tar``,
+        ``some_dir/features.000000.tar``, and then the same names but numbered with ``000001``, etc.
+        There may also be other files if the cuts have custom data attached to them.
+
+        The main idea behind Lhotse Shar format is to optimize dataloading with sequential reads,
+        while keeping the data composition more flexible than e.g. WebDataset tar archives do.
+        To achieve this, Lhotse Shar keeps each data type in a separate archive, along a single
+        CutSet JSONL manifest.
+        This way, the metadata can be investigated without iterating through the binary data.
+        The format also allows iteration over a subset of fields, or extension of existing data
+        with new fields.
+
+        As you iterate over cuts from ``LazySharIterator``, it keeps a file handle open for the
+        JSONL manifest and all of the tar files that correspond to the current shard.
+        The tar files are read item by item together, and their binary data is attached to
+        the cuts.
+        It can be normally accessed using methods such as ``cut.load_audio()``.
+
+        We can simply load a directory created by :class:`~lhotse.shar.writers.shar.SharWriter`.
+        Example::
+
+        >>> cuts = LazySharIterator(in_dir="some_dir")
+        ... for cut in cuts:
+        ...     print("Cut", cut.id, "has duration of", cut.duration)
+        ...     audio = cut.load_audio()
+        ...     fbank = cut.load_features()
+
+        :class:`.LazySharIterator` can also be initialized from a dict, where the keys
+        indicate fields to be read, and the values point to actual shard locations.
+        This is useful when only a subset of data is needed, or it is stored in different
+        locations. Example::
+
+        >>> cuts = LazySharIterator({
+        ...     "cuts": ["some_dir/cuts.000000.jsonl.gz"],
+        ...     "recording": ["another_dir/recording.000000.tar"],
+        ...     "features": ["yet_another_dir/features.000000.tar"],
+        ... })
+        ... for cut in cuts:
+        ...     print("Cut", cut.id, "has duration of", cut.duration)
+        ...     audio = cut.load_audio()
+        ...     fbank = cut.load_features()
+
+        We also support providing shell commands as shard sources, inspired by WebDataset.
+        Example::
+
+        >>> cuts = LazySharIterator({
+        ...     "cuts": ["pipe:curl https://my.page/cuts.000000.jsonl.gz"],
+        ...     "recording": ["pipe:curl https://my.page/recording.000000.tar"],
+        ... })
+        ... for cut in cuts:
+        ...     print("Cut", cut.id, "has duration of", cut.duration)
+        ...     audio = cut.load_audio()
+
+        :param fields: a dict whose keys specify which fields to load,
+            and values are lists of shards (either paths or shell commands).
+            The field "cuts" pointing to CutSet shards always has to be present.
+        :param in_dir: path to a directory created with ``SharWriter`` with
+            all the shards in a single place. Can be used instead of ``fields``.
+        :param split_for_dataloading: bool, by default ``False`` which does nothing.
+            Setting it to ``True`` is intended for PyTorch training with multiple
+            dataloader workers and possibly multiple DDP nodes.
+            It results in each node+worker combination receiving a unique subset
+            of shards from which to read data to avoid data duplication.
+        :param shuffle_shards: bool, by default ``False``. When ``True``, the shards
+            are shuffled (in case of multi-node training, the shuffling is the same
+            on each node given the same seed).
+        :param seed: When ``shuffle_shards`` is ``True``, we use this number to
+            seed the RNG.
+
+        See also: :class:`~lhotse.shar.readers.lazy.LazySharIterator`,
+            :meth:`~lhotse.cut.set.CutSet.to_shar`.
+        """
+        from lhotse.shar import LazySharIterator
+
+        return CutSet(
+            cuts=LazySharIterator(
+                fields=fields,
+                in_dir=in_dir,
+                split_for_dataloading=split_for_dataloading,
+                shuffle_shards=shuffle_shards,
+                seed=seed,
+            )
+        )
+
+    def to_shar(
+        self,
+        output_dir: Pathlike,
+        fields: Dict[str, str],
+        shard_size: Optional[int] = 1000,
+        warn_unused_fields: bool = True,
+    ) -> None:
+        """
+        Writes cuts and their corresponding data into multiple shards,
+        also recognized as the Lhotse Shar format.
+        Each shard is numbered and represented as a collection of one text manifest and
+        one or more binary tarfiles.
+        Each tarfile contains a single type of data, e.g., recordings, features, or custom fields.
+
+        The main idea behind Lhotse Shar format is to optimize dataloading with sequential reads,
+        while keeping the data composition more flexible than e.g. WebDataset tar archives do.
+        To achieve this, Lhotse Shar keeps each data type in a separate archive, along a single
+        CutSet JSONL manifest.
+        This way, the metadata can be investigated without iterating through the binary data.
+        The format also allows iteration over a subset of fields, or extension of existing data
+        with new fields.
+
+        The user has to specify which fields should be saved, and what compression to use for each of them.
+        Currently we support ``wav``, ``flac``, and ``mp3`` compression for ``recording`` and custom audio fields,
+        and ``lilcom`` or ``numpy`` for ``features`` and custom array fields.
+
+        Example::
+
+            >>> cuts = CutSet(...)  # cuts have 'recording' and 'features'
+            >>> cuts.to_shar("some_dir", shard_size=100, fields={"recording": "mp3", "features": "lilcom"})
+
+        It would create a directory ``some_dir`` with files such as ``some_dir/cuts.000000.jsonl.gz``,
+        ``some_dir/recording.000000.tar``, ``some_dir/features.000000.tar``,
+        and then the same names but numbered with ``000001``, etc.
+
+        When ``shard_size`` is set to ``None``, we will disable automatic sharding and the
+        shard number suffix will be omitted from the file names.
+
+        See also: :class:`~lhotse.shar.writers.shar.SharWriter`,
+            :meth:`~lhotse.cut.set.CutSet.to_shar`.
+        """
+        from lhotse.shar import SharWriter
+
+        with SharWriter(
+            output_dir=output_dir,
+            fields=fields,
+            shard_size=shard_size,
+            warn_unused_fields=warn_unused_fields,
+        ) as writer:
+            for cut in self:
+                writer.write(cut)
+
     def to_dicts(self) -> Iterable[dict]:
         return (cut.to_dict() for cut in self)
 

--- a/lhotse/cut/set.py
+++ b/lhotse/cut/set.py
@@ -482,7 +482,7 @@ class CutSet(Serializable, AlgorithmMixin):
         fields: Dict[str, str],
         shard_size: Optional[int] = 1000,
         warn_unused_fields: bool = True,
-    ) -> None:
+    ) -> Dict[str, List[str]]:
         """
         Writes cuts and their corresponding data into multiple shards,
         also recognized as the Lhotse Shar format.
@@ -505,11 +505,14 @@ class CutSet(Serializable, AlgorithmMixin):
         Example::
 
             >>> cuts = CutSet(...)  # cuts have 'recording' and 'features'
-            >>> cuts.to_shar("some_dir", shard_size=100, fields={"recording": "mp3", "features": "lilcom"})
+            >>> output_paths = cuts.to_shar(
+            ...     "some_dir", shard_size=100, fields={"recording": "mp3", "features": "lilcom"}
+            ... )
 
         It would create a directory ``some_dir`` with files such as ``some_dir/cuts.000000.jsonl.gz``,
         ``some_dir/recording.000000.tar``, ``some_dir/features.000000.tar``,
         and then the same names but numbered with ``000001``, etc.
+        The function returns a dict that maps field names to lists of saved shard paths.
 
         When ``shard_size`` is set to ``None``, we will disable automatic sharding and the
         shard number suffix will be omitted from the file names.
@@ -527,6 +530,8 @@ class CutSet(Serializable, AlgorithmMixin):
         ) as writer:
             for cut in self:
                 writer.write(cut)
+
+        return writer.output_paths
 
     def to_dicts(self) -> Iterable[dict]:
         return (cut.to_dict() for cut in self)

--- a/lhotse/features/base.py
+++ b/lhotse/features/base.py
@@ -483,6 +483,7 @@ class Features:
         self,
         start: Seconds = 0,
         duration: Optional[Seconds] = None,
+        lilcom: bool = False,
     ) -> "Features":
         from lhotse.features.io import get_memory_writer
 
@@ -490,7 +491,7 @@ class Features:
             return self  # nothing to do
 
         arr = self.load(start=start, duration=duration)
-        if issubclass(arr.dtype.type, np.floating):
+        if issubclass(arr.dtype.type, np.floating) and lilcom:
             writer = get_memory_writer("memory_lilcom")()
         else:
             writer = get_memory_writer("memory_raw")()

--- a/lhotse/serialization.py
+++ b/lhotse/serialization.py
@@ -2,6 +2,8 @@ import itertools
 import json
 import sys
 import warnings
+from codecs import StreamReader, StreamWriter
+from io import BytesIO, StringIO
 from pathlib import Path
 from typing import Any, Dict, Generator, Iterable, Optional, Type, Union
 
@@ -35,6 +37,9 @@ def open_best(path: Pathlike, mode: str = "r"):
             raise ValueError(
                 f"Cannot open stream for '-' with mode other 'r' or 'w' (got: '{mode}')"
             )
+
+    if isinstance(path, (BytesIO, StringIO, StreamWriter, StreamReader)):
+        return path
 
     if str(path).startswith("pipe:"):
         return open_pipe(path[5:], mode)

--- a/lhotse/shar/readers/__init__.py
+++ b/lhotse/shar/readers/__init__.py
@@ -1,2 +1,3 @@
 from .datapipes import load_shar_datapipe
 from .lazy import LazySharIterator
+from .tar import TarIterator

--- a/lhotse/shar/readers/datapipes.py
+++ b/lhotse/shar/readers/datapipes.py
@@ -64,6 +64,8 @@ class CutsReader(IterDataPipe):
 
 class SharReader(IterDataPipe):
     def __init__(self, *component_datapipes: IterDataPipe) -> None:
+        raise NotImplementedError("We don't support this yet.")
+
         self.dps = sorted(
             component_datapipes, key=lambda dp: isinstance(dp, CutsReader), reverse=True
         )
@@ -83,6 +85,7 @@ class SharReader(IterDataPipe):
 
     def __iter__(self):
         for cut, *items in self.zipped:
+            # TODO: add support for changes in Shar that require pairwise iteration over items in tarfiles
             for tarpath, tarstream in items:
                 tarpath = Path(tarpath)
                 item_id = tarpath.stem

--- a/lhotse/shar/readers/lazy.py
+++ b/lhotse/shar/readers/lazy.py
@@ -187,10 +187,6 @@ class LazySharIterator(ImitatesDict):
                 for field, path in tarpaths.items()
             }
 
-            # f = list(tars.values())[0]
-            # for x in f:
-            #     print(f.extractfile(x).read())
-
             # *tardata contains all fields for a single cut (recording, features, array, etc.)
             for cut, *tardata in zip(
                 cuts, *map(iterate_tarfile_pairwise, tars.values())
@@ -207,13 +203,13 @@ class LazySharIterator(ImitatesDict):
                     tars.values(),
                     tardata,
                 ):
+                    assert (
+                        data_path.stem == cut.id
+                    ), f"Mismatched IDs: cut ID is '{cut.id}' but found data with name '{data_path}'"
                     manifest = deserialize_item(
                         decode_json_line(manifest_bytes.decode("utf-8"))
                     )
                     setattr(cut, field, manifest)
-                    assert (
-                        data_path.stem == cut.id
-                    ), f"Mismatched IDs: cut ID is '{cut.id}' but found data with name '{data_path}'"
                     fill_shar_placeholder(
                         cut,
                         field=field,

--- a/lhotse/shar/readers/lazy.py
+++ b/lhotse/shar/readers/lazy.py
@@ -173,11 +173,7 @@ class LazySharIterator(ImitatesDict):
             tarpaths = {field: path for field, path in shard.items() if field != "cuts"}
 
             # Open every tarfile so it's ready for streaming
-            tars = {
-                # field: tarfile.open(fileobj=open_best(path, mode="rb"), mode="r|*")
-                field: TarIterator(path)
-                for field, path in tarpaths.items()
-            }
+            tars = {field: TarIterator(path) for field, path in tarpaths.items()}
 
             # *tardata contains all fields for a single cut (recording, features, array, etc.)
             for cut, *tardata in zip(cuts, *tars.values()):

--- a/lhotse/shar/readers/tar.py
+++ b/lhotse/shar/readers/tar.py
@@ -1,0 +1,79 @@
+import tarfile
+from pathlib import Path
+from typing import Generator, Optional, Tuple, Union
+
+from lhotse import Features, Recording
+from lhotse.array import Array, TemporalArray
+from lhotse.serialization import decode_json_line, deserialize_item, open_best
+from lhotse.shar.readers.utils import fill_shar_placeholder
+from lhotse.utils import Pathlike
+
+Manifest = Union[Recording, Array, TemporalArray, Features]
+
+
+class TarIterator:
+    """
+    TarIterator is a convenience class for reading arrays/audio stored in Lhotse Shar tar files.
+    It is specific to Lhotse Shar format and expects the tar file to have the following structure:
+    - each file is stored in a separate tar member
+    - the file name is the key of the array
+    - every array has two corresponding files:
+        - the metadata: the file extension is ``.json`` and the file contains
+            a Lhotse manifest (Recording, Array, TemporalArray, Features)
+            for the data item.
+        - the data: the file extension is the format of the array,
+            and the file contents are the serialized array (possibly compressed).
+        - the data file can be empty in case some cut did not contain that field.
+            In that case, the data file has extension ``.nodata`` and the manifest file
+            has extension ``.nometa``.
+        - these files are saved one after another, the data is first, and the metadata follows.
+
+    Iterating over TarReader yields tuples of ``(Optional[manifest], filename)`` where
+    ``manifest`` is a Lhotse manifest with binary data attached to it, and ``filename``
+    is the name of the data file inside tar archive.
+    """
+
+    def __init__(self, source: Pathlike) -> None:
+        self.source = source
+
+    def __iter__(
+        self,
+    ) -> Generator[Tuple[Optional[Manifest], Path], None, None]:
+        with tarfile.open(fileobj=open_best(self.source, mode="rb"), mode="r|*") as tar:
+            for ((data, data_path), (meta, meta_path)) in iterate_tarfile_pairwise(tar):
+                if meta is not None:
+                    meta = deserialize_item(decode_json_line(meta.decode("utf-8")))
+                    fill_shar_placeholder(manifest=meta, data=data, tarpath=data_path)
+                yield meta, data_path
+
+
+def iterate_tarfile_pairwise(
+    tar_file: tarfile.TarFile,
+) -> Generator[Tuple[Optional[bytes], Optional[Manifest], Path, Path], None, None]:
+    result = []
+    for tarinfo in tar_file:
+        if len(result) == 2:
+            yield tuple(result)
+            result = []
+        result.append(parse_tarinfo(tarinfo, tar_file))
+
+    if len(result) == 2:
+        yield tuple(result)
+
+    if len(result) == 1:
+        raise RuntimeError(
+            "Uneven number of files in the tarfile (expected to iterate pairs of binary data + JSON metadata."
+        )
+
+
+def parse_tarinfo(
+    tarinfo: tarfile.TarInfo, tar_file: tarfile.TarFile
+) -> Tuple[Optional[bytes], Path]:
+    """
+    Parse a tarinfo object and return the data it points to as well as the internal path.
+    """
+    path = Path(tarinfo.path)
+    if path.suffix == ".nodata" or path.suffix == ".nometa":
+        return None, path
+    data = tar_file.extractfile(tarinfo).read()
+    return data, path

--- a/lhotse/shar/writers/array.py
+++ b/lhotse/shar/writers/array.py
@@ -26,8 +26,13 @@ class ArrayTarWriter:
         ...     w.write("fbank1", fbank1_array)
         ...     w.write("fbank2", fbank2_array)  # etc.
 
-
     It would create files such as ``some_dir/fbank.000000.tar``, ``some_dir/fbank.000001.tar``, etc.
+
+    It's also possible to use ``ArrayTarWriter`` with automatic sharding disabled::
+
+        >>> with ArrayTarWriter("some_dir/fbank.tar", shard_size=None, compression="numpy") as w:
+        ...     w.write("fbank1", fbank1_array)
+        ...     w.write("fbank2", fbank2_array)  # etc.
 
     See also: :class:`~lhotse.shar.writers.tar.TarWriter`, :class:`~lhotse.shar.writers.audio.AudioTarWriter`
     """

--- a/lhotse/shar/writers/array.py
+++ b/lhotse/shar/writers/array.py
@@ -62,6 +62,10 @@ class ArrayTarWriter:
     def output_paths(self) -> List[str]:
         return self.tar_writer.output_paths
 
+    def write_placeholder(self, key: str) -> None:
+        self.tar_writer.write(f"{key}.nodata", BytesIO())
+        self.tar_writer.write(f"{key}.nometa", BytesIO(), count=False)
+
     def write(
         self,
         key: str,

--- a/lhotse/shar/writers/array.py
+++ b/lhotse/shar/writers/array.py
@@ -1,7 +1,7 @@
 import codecs
 import json
 from io import BytesIO
-from typing import Optional, Union
+from typing import List, Union
 
 import lilcom
 import numpy as np
@@ -9,7 +9,6 @@ from typing_extensions import Literal
 
 from lhotse import Features
 from lhotse.array import Array, TemporalArray
-from lhotse.serialization import save_to_jsonl
 from lhotse.shar.writers.tar import TarWriter
 
 
@@ -53,6 +52,10 @@ class ArrayTarWriter:
 
     def close(self):
         self.tar_writer.close()
+
+    @property
+    def output_paths(self) -> List[str]:
+        return self.tar_writer.output_paths
 
     def write(
         self,

--- a/lhotse/shar/writers/audio.py
+++ b/lhotse/shar/writers/audio.py
@@ -66,6 +66,10 @@ class AudioTarWriter:
     def output_paths(self) -> List[str]:
         return self.tar_writer.output_paths
 
+    def write_placeholder(self, key: str) -> None:
+        self.tar_writer.write(f"{key}.nodata", BytesIO())
+        self.tar_writer.write(f"{key}.nometa", BytesIO(), count=False)
+
     def write(
         self,
         key: str,

--- a/lhotse/shar/writers/audio.py
+++ b/lhotse/shar/writers/audio.py
@@ -1,8 +1,8 @@
 import codecs
 import json
 from functools import partial
-from io import BytesIO, StringIO
-from typing import Optional
+from io import BytesIO
+from typing import List
 
 import numpy as np
 import torch
@@ -10,7 +10,6 @@ import torchaudio
 from typing_extensions import Literal
 
 from lhotse import Recording
-from lhotse.serialization import save_to_jsonl
 from lhotse.shar.writers.tar import TarWriter
 
 
@@ -56,6 +55,10 @@ class AudioTarWriter:
 
     def close(self):
         self.tar_writer.close()
+
+    @property
+    def output_paths(self) -> List[str]:
+        return self.tar_writer.output_paths
 
     def write(
         self,

--- a/lhotse/shar/writers/audio.py
+++ b/lhotse/shar/writers/audio.py
@@ -29,6 +29,12 @@ class AudioTarWriter:
 
     It would create files such as ``some_dir/audio.000000.tar``, ``some_dir/audio.000001.tar``, etc.
 
+    It's also possible to use ``AudioTarWriter`` with automatic sharding disabled::
+
+        >>> with AudioTarWriter("some_dir/audio.tar", shard_size=None, format="flac") as w:
+        ...     w.write("audio1", audio1_array)
+        ...     w.write("audio2", audio2_array)  # etc.
+
     See also: :class:`~lhotse.shar.writers.tar.TarWriter`, :class:`~lhotse.shar.writers.array.ArrayTarWriter`
     """
 

--- a/lhotse/shar/writers/cut.py
+++ b/lhotse/shar/writers/cut.py
@@ -1,4 +1,5 @@
-from typing import List
+import logging
+from typing import List, Optional
 
 from lhotse import CutSet
 from lhotse.cut import Cut
@@ -20,10 +21,19 @@ class CutShardWriter:
     See also: :class:`~lhotse.shar.writers.tar.TarWriter`
     """
 
-    def __init__(self, pattern: str, shard_size: int = 1000):
+    def __init__(self, pattern: str, shard_size: Optional[int] = 1000):
         self.pattern = pattern
+        if not self.sharding_enabled and shard_size is not None:
+            logging.warning(
+                "Sharding is disabled because `pattern` doesn't contain a formatting marker (e.g., '%06d'), "
+                "but shard_size is not None - ignoring shard_size."
+            )
         self.shard_size = shard_size
         self.reset()
+
+    @property
+    def sharding_enabled(self) -> bool:
+        return "%" in self.pattern
 
     def reset(self):
         self.fname = None
@@ -45,15 +55,21 @@ class CutShardWriter:
     def _next_stream(self):
         self.close()
 
-        self.fname = self.pattern % self.num_shards
+        if self.sharding_enabled:
+            self.fname = self.pattern % self.num_shards
+            self.num_shards += 1
+        else:
+            self.fname = self.pattern
+
         self.stream = CutSet.open_writer(self.fname)
 
-        self.num_shards += 1
         self.num_items = 0
 
     @property
     def output_paths(self) -> List[str]:
-        return [self.pattern % i for i in range(self.num_shards)]
+        if self.sharding_enabled:
+            return [self.pattern % i for i in range(self.num_shards)]
+        return [self.pattern]
 
     def write(self, cut: Cut, flush: bool = False) -> None:
         if (
@@ -61,7 +77,8 @@ class CutShardWriter:
             self.num_items_total == 0
             or (
                 # desired shard size achieved
-                self.num_items > 0
+                self.sharding_enabled
+                and self.num_items > 0
                 and self.num_items % self.shard_size == 0
             )
         ):

--- a/lhotse/shar/writers/cut.py
+++ b/lhotse/shar/writers/cut.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from lhotse import CutSet
 from lhotse.cut import Cut
 
@@ -43,14 +45,17 @@ class CutShardWriter:
     def _next_stream(self):
         self.close()
 
-        # TODO: support gopen-like capabilities
         self.fname = self.pattern % self.num_shards
         self.stream = CutSet.open_writer(self.fname)
 
         self.num_shards += 1
         self.num_items = 0
 
-    def write(self, cut: Cut, flush: bool = False) -> bool:
+    @property
+    def output_paths(self) -> List[str]:
+        return [self.pattern % i for i in range(self.num_shards)]
+
+    def write(self, cut: Cut, flush: bool = False) -> None:
         if (
             # the first item written
             self.num_items_total == 0
@@ -65,6 +70,3 @@ class CutShardWriter:
         self.stream.write(cut, flush=flush)
         self.num_items += 1
         self.num_items_total += 1
-
-    def open_manifest(self):
-        raise NotImplemented

--- a/lhotse/shar/writers/shar.py
+++ b/lhotse/shar/writers/shar.py
@@ -1,6 +1,6 @@
 import warnings
 from functools import partial
-from typing import Any, Callable, Dict, Type, TypeVar, Union
+from typing import Any, Callable, Dict, List, Type, TypeVar, Union
 
 from typing_extensions import Literal
 
@@ -69,7 +69,7 @@ class SharWriter:
         self.warn_unused_fields = warn_unused_fields
 
         self.writers = {
-            "cut": CutShardWriter(
+            "cuts": CutShardWriter(
                 pattern=f"{self.output_dir}/cuts.%06d.jsonl.gz", shard_size=shard_size
             ),
         }
@@ -78,6 +78,10 @@ class SharWriter:
             self.writers[field] = writer_type(
                 pattern=f"{self.output_dir}/{field}.%06d.tar", shard_size=shard_size
             )
+
+    @property
+    def output_paths(self) -> Dict[str, List[str]]:
+        return {k: w.output_paths for k, w in self.writers.items()}
 
     def __enter__(self):
         for w in self.writers.values():
@@ -141,7 +145,7 @@ class SharWriter:
                 cut = fastcopy(cut, custom=cut.custom.copy())
                 setattr(cut, key, placeholder_obj)
 
-        self.writers["cut"].write(cut)
+        self.writers["cuts"].write(cut)
 
 
 Manifest = TypeVar("Manifest", Recording, Features, Array, TemporalArray)

--- a/lhotse/shar/writers/shar.py
+++ b/lhotse/shar/writers/shar.py
@@ -74,7 +74,7 @@ class SharWriter:
 
         self.writers = {
             "cuts": CutShardWriter(
-                pattern=f"{self.output_dir}/cuts{self.shard_suffix}.jsonl.gz",
+                pattern=_create_cuts_output_url(self.output_dir, self.shard_suffix),
                 shard_size=self.shard_size,
             ),
         }
@@ -220,3 +220,12 @@ def resolve_writer(
         name_or_callable in opts
     ), f"Unknown field type (got: '{name_or_callable}', we support only: {', '.join(opts)}"
     return opts[name_or_callable]
+
+
+def _create_cuts_output_url(base_output_url: str, shard_suffix: str) -> str:
+
+    # special case where we want to ensure the CutSet actually gets gzipped
+    if base_output_url.startswith("pipe:"):
+        base_output_url = base_output_url.replace("pipe:", "pipe:gzip -c | ")
+
+    return f"{base_output_url}/cuts{shard_suffix}.jsonl.gz"

--- a/lhotse/shar/writers/tar.py
+++ b/lhotse/shar/writers/tar.py
@@ -66,8 +66,8 @@ class TarWriter:
         self.num_shards += 1
         self.num_items = 0
 
-    def write(self, key: str, data: BytesIO):
-        if (
+    def write(self, key: str, data: BytesIO, count: bool = True):
+        if count and (
             # the first item written
             self.num_items_total == 0
             or (
@@ -82,5 +82,6 @@ class TarWriter:
         data.seek(0)
         ti.size = len(data.getvalue())
         self.tarstream.addfile(ti, data)
-        self.num_items += 1
-        self.num_items_total += 1
+        if count:
+            self.num_items += 1
+            self.num_items_total += 1

--- a/lhotse/shar/writers/tar.py
+++ b/lhotse/shar/writers/tar.py
@@ -1,5 +1,6 @@
 import tarfile
 from io import BytesIO
+from typing import List
 
 from lhotse.serialization import open_best
 
@@ -65,6 +66,10 @@ class TarWriter:
 
         self.num_shards += 1
         self.num_items = 0
+
+    @property
+    def output_paths(self) -> List[str]:
+        return [self.pattern % i for i in range(self.num_shards)]
 
     def write(self, key: str, data: BytesIO, count: bool = True):
         if count and (

--- a/lhotse/shar/writers/tar.py
+++ b/lhotse/shar/writers/tar.py
@@ -1,6 +1,7 @@
+import logging
 import tarfile
 from io import BytesIO
-from typing import List
+from typing import List, Optional
 
 from lhotse.serialization import open_best
 
@@ -23,16 +24,34 @@ class TarWriter:
 
     It would create files such as ``some_dir/data.000000.tar``, ``some_dir/data.000001.tar``, etc.
 
+    It's also possible to use ``TarWriter`` with automatic sharding disabled::
+
+        >>> with TarWriter("some_dir/data.tar", shard_size=None) as w:
+        ...     w.write("blob1", binary_blob1)
+        ...     w.write("blob2", binary_blob2)  # etc.
+
     This class is heavily inspired by the WebDataset library:
     https://github.com/webdataset/webdataset
     """
 
-    def __init__(self, pattern: str, shard_size: int):
+    def __init__(self, pattern: str, shard_size: Optional[int]):
         self.pattern = pattern
-        assert "%" in self.pattern
+        if self.sharding_enabled and shard_size is None:
+            raise RuntimeError(
+                "shard_size must be specified when sharding is enabled via a formatting marker such as '%06d'"
+            )
+        if not self.sharding_enabled and shard_size is not None:
+            logging.warning(
+                "Sharding is disabled because `pattern` doesn't contain a formatting marker (e.g., '%06d'), "
+                "but shard_size is not None - ignoring shard_size."
+            )
         self.shard_size = shard_size
         self.gzip = pattern.endswith(".gz")
         self.reset()
+
+    @property
+    def sharding_enabled(self) -> bool:
+        return "%" in self.pattern
 
     def reset(self):
         self.fname = None
@@ -58,18 +77,24 @@ class TarWriter:
     def _next_stream(self):
         self.close()
 
-        self.fname = self.pattern % self.num_shards
+        if self.sharding_enabled:
+            self.fname = self.pattern % self.num_shards
+            self.num_shards += 1
+        else:
+            self.fname = self.pattern
+
         self.stream = open_best(self.fname, "wb")
         self.tarstream = tarfile.open(
             fileobj=self.stream, mode="w|gz" if self.gzip else "w|"
         )
 
-        self.num_shards += 1
         self.num_items = 0
 
     @property
     def output_paths(self) -> List[str]:
-        return [self.pattern % i for i in range(self.num_shards)]
+        if self.sharding_enabled:
+            return [self.pattern % i for i in range(self.num_shards)]
+        return [self.pattern]
 
     def write(self, key: str, data: BytesIO, count: bool = True):
         if count and (
@@ -77,7 +102,8 @@ class TarWriter:
             self.num_items_total == 0
             or (
                 # desired shard size achieved
-                self.num_items > 0
+                self.sharding_enabled
+                and self.num_items > 0
                 and self.num_items % self.shard_size == 0
             )
         ):

--- a/test/shar/test_missing_values.py
+++ b/test/shar/test_missing_values.py
@@ -1,0 +1,46 @@
+import pytest
+
+from lhotse import CutSet
+from lhotse.testing.dummies import DummyManifest
+
+
+@pytest.mark.parametrize("drop_everything", [True, False])
+def test_cut_set_from_shar(tmp_path, drop_everything):
+    # Prepare data -- it needs to have missing values for some cuts
+    cuts = DummyManifest(CutSet, begin_id=0, end_id=20, with_data=True)
+    cuts[0].recording = None
+    cuts[0].features = None
+    cuts[0].custom_indexes = None
+    cuts[0].custom_recording = None
+    cuts[0].custom_features = None
+    if drop_everything:
+        cuts[0].custom_embedding = None
+
+    # Prepare system under test
+    cuts.to_shar(
+        tmp_path,
+        fields={
+            "recording": "wav",
+            "features": "lilcom",
+            "custom_embedding": "numpy",
+            "custom_features": "lilcom",
+            "custom_indexes": "numpy",
+            "custom_recording": "wav",
+        },
+        shard_size=10,
+    )
+    cuts_shar = CutSet.from_shar(in_dir=tmp_path).to_eager()
+
+    assert not cuts_shar[0].has_recording
+    assert not cuts_shar[0].has_features
+    assert not cuts_shar[0].has_custom("custom_indexes")
+    assert not cuts_shar[0].has_custom("custom_recording")
+    assert not cuts_shar[0].has_custom("custom_features")
+    assert cuts_shar[0].has_custom("custom_embedding") == (not drop_everything)
+    for cut in cuts_shar.subset(last=19):
+        assert cut.has_recording
+        assert cut.has_features
+        assert cut.has_custom("custom_indexes")
+        assert cut.has_custom("custom_recording")
+        assert cut.has_custom("custom_features")
+        assert cut.has_custom("custom_embedding")

--- a/test/shar/test_read_datapipe.py
+++ b/test/shar/test_read_datapipe.py
@@ -9,6 +9,7 @@ from lhotse.shar import load_shar_datapipe
 dp = pytest.importorskip("torchdata")
 
 
+@pytest.mark.skip(reason="We don't support datapipes for now.")
 def test_shar_datapipe_reader(cuts: CutSet, shar_dir: Path):
     # Prepare system under test
     cuts_iter = load_shar_datapipe(shar_dir)

--- a/test/shar/test_read_lazy.py
+++ b/test/shar/test_read_lazy.py
@@ -54,7 +54,8 @@ def test_shar_lazy_reader_from_fields(cuts: CutSet, shar_dir: Path):
         np.testing.assert_allclose(c_ref.load_audio(), c_test.load_audio(), rtol=1e-3)
 
 
-@pytest.mark.skipif(os.name == "nt", reason="This test cannot run on Windows.")
+# @pytest.mark.skipif(os.name == "nt", reason="This test cannot run on Windows.")
+@pytest.mark.skip(reason="We don't support datapipes for now.")
 def test_shar_lazy_reader_from_fields_using_pipes(cuts: CutSet, shar_dir: Path):
     # Prepare system under test
     cuts_iter = LazySharIterator(

--- a/test/shar/test_read_lazy.py
+++ b/test/shar/test_read_lazy.py
@@ -54,8 +54,7 @@ def test_shar_lazy_reader_from_fields(cuts: CutSet, shar_dir: Path):
         np.testing.assert_allclose(c_ref.load_audio(), c_test.load_audio(), rtol=1e-3)
 
 
-# @pytest.mark.skipif(os.name == "nt", reason="This test cannot run on Windows.")
-@pytest.mark.skip(reason="We don't support datapipes for now.")
+@pytest.mark.skipif(os.name == "nt", reason="This test cannot run on Windows.")
 def test_shar_lazy_reader_from_fields_using_pipes(cuts: CutSet, shar_dir: Path):
     # Prepare system under test
     cuts_iter = LazySharIterator(

--- a/test/shar/test_read_lazy.py
+++ b/test/shar/test_read_lazy.py
@@ -33,6 +33,31 @@ def test_shar_lazy_reader_from_dir(cuts: CutSet, shar_dir: Path):
         )
 
 
+def test_cut_set_from_shar(cuts: CutSet, shar_dir: Path):
+    # Prepare system under test
+    cuts_iter = CutSet.from_shar(in_dir=shar_dir)
+
+    # Actual test
+    for c_test, c_ref in zip(cuts_iter, cuts):
+        assert c_test.id == c_ref.id
+        np.testing.assert_allclose(c_ref.load_audio(), c_test.load_audio(), rtol=1e-3)
+        np.testing.assert_allclose(
+            c_ref.load_custom_recording(), c_test.load_custom_recording(), rtol=1e-3
+        )
+        np.testing.assert_almost_equal(
+            c_ref.load_features(), c_test.load_features(), decimal=1
+        )
+        np.testing.assert_almost_equal(
+            c_ref.load_custom_features(), c_test.load_custom_features(), decimal=1
+        )
+        np.testing.assert_almost_equal(
+            c_ref.load_custom_embedding(), c_test.load_custom_embedding(), decimal=1
+        )
+        np.testing.assert_almost_equal(
+            c_ref.load_custom_indexes(), c_test.load_custom_indexes(), decimal=1
+        )
+
+
 def test_shar_lazy_reader_from_fields(cuts: CutSet, shar_dir: Path):
     # Prepare system under test
     cuts_iter = LazySharIterator(

--- a/test/shar/test_write.py
+++ b/test/shar/test_write.py
@@ -169,6 +169,80 @@ def test_shar_writer(tmp_path: Path):
             cut.load_custom_recording()
 
 
+def test_cut_set_to_shar(tmp_path: Path):
+    # Prepare data
+    cuts = DummyManifest(CutSet, begin_id=0, end_id=20, with_data=True)
+
+    # Prepare system under test
+    output_paths = cuts.to_shar(
+        tmp_path,
+        fields={
+            "recording": "wav",
+            "features": "lilcom",
+            "custom_embedding": "numpy",
+            "custom_features": "lilcom",
+            "custom_indexes": "numpy",
+            "custom_recording": "wav",
+        },
+        shard_size=10,
+    )
+
+    # Post-conditions
+
+    assert output_paths == {
+        "cuts": [
+            str(tmp_path / "cuts.000000.jsonl.gz"),
+            str(tmp_path / "cuts.000001.jsonl.gz"),
+        ],
+        "recording": [
+            str(tmp_path / "recording.000000.tar"),
+            str(tmp_path / "recording.000001.tar"),
+        ],
+        "features": [
+            str(tmp_path / "features.000000.tar"),
+            str(tmp_path / "features.000001.tar"),
+        ],
+        "custom_embedding": [
+            str(tmp_path / "custom_embedding.000000.tar"),
+            str(tmp_path / "custom_embedding.000001.tar"),
+        ],
+        "custom_features": [
+            str(tmp_path / "custom_features.000000.tar"),
+            str(tmp_path / "custom_features.000001.tar"),
+        ],
+        "custom_indexes": [
+            str(tmp_path / "custom_indexes.000000.tar"),
+            str(tmp_path / "custom_indexes.000001.tar"),
+        ],
+        "custom_recording": [
+            str(tmp_path / "custom_recording.000000.tar"),
+            str(tmp_path / "custom_recording.000001.tar"),
+        ],
+    }
+
+    # - we created 2 shards with cutsets and a separate file for each data field
+    for fname in (
+        "cuts.000000.jsonl.gz",
+        "cuts.000001.jsonl.gz",
+        "recording.000000.tar",
+        "recording.000001.tar",
+        "features.000000.tar",
+        "features.000001.tar",
+        "custom_embedding.000000.tar",
+        "custom_embedding.000001.tar",
+        "custom_features.000000.tar",
+        "custom_features.000001.tar",
+        "custom_indexes.000000.tar",
+        "custom_indexes.000001.tar",
+        "custom_recording.000000.tar",
+        "custom_recording.000001.tar",
+    ):
+        assert (tmp_path / fname).is_file()
+
+    # - we didn't create a third shard
+    assert not (tmp_path / "cuts.000002.jsonl.gz").exists()
+
+
 def test_shar_writer_not_sharded(tmp_path: Path):
     # Prepare data
     cuts = DummyManifest(CutSet, begin_id=0, end_id=20, with_data=True)

--- a/test/shar/test_write.py
+++ b/test/shar/test_write.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 
 from lhotse import CutSet
-from lhotse.shar import SharWriter, TarWriter
+from lhotse.shar import CutShardWriter, SharWriter, TarWriter
 from lhotse.testing.dummies import DummyManifest
 
 
@@ -16,6 +16,38 @@ def test_tar_writer(tmp_path: Path):
     assert writer.output_paths == [str(tmp_path / "test.000000.tar")]
 
     with tarfile.open(tmp_path / "test.000000.tar") as f:
+        f2 = f.extractfile(f.getmember("test.txt"))
+        assert f2.read() == b"test"
+
+
+def test_tar_writer_not_sharded(tmp_path: Path, caplog):
+    with TarWriter(str(tmp_path / "test.tar"), shard_size=None) as writer:
+        writer.write("test.txt", BytesIO(b"test"))
+
+    assert (
+        "Sharding is disabled because `pattern` doesn't contain a formatting marker (e.g., '%06d'), "
+        "but shard_size is not None - ignoring shard_size."
+    ) not in caplog.text
+
+    assert writer.output_paths == [str(tmp_path / "test.tar")]
+
+    with tarfile.open(tmp_path / "test.tar") as f:
+        f2 = f.extractfile(f.getmember("test.txt"))
+        assert f2.read() == b"test"
+
+
+def test_tar_writer_not_sharded_with_shard_size(tmp_path: Path, caplog):
+    with TarWriter(str(tmp_path / "test.tar"), shard_size=10) as writer:
+        writer.write("test.txt", BytesIO(b"test"))
+
+    assert (
+        "Sharding is disabled because `pattern` doesn't contain a formatting marker (e.g., '%06d'), "
+        "but shard_size is not None - ignoring shard_size."
+    ) in caplog.text
+
+    assert writer.output_paths == [str(tmp_path / "test.tar")]
+
+    with tarfile.open(tmp_path / "test.tar") as f:
         f2 = f.extractfile(f.getmember("test.txt"))
         assert f2.read() == b"test"
 
@@ -112,6 +144,98 @@ def test_shar_writer(tmp_path: Path):
     # - the cuts do not have any data actually attached to them,
     #   so it's impossible to load it if we open it as a normal CutSet
     for cut in CutSet.from_file(tmp_path / "cuts.000000.jsonl.gz"):
+        assert cut.recording.sources[0].type == "shar"
+        with pytest.raises(RuntimeError):
+            cut.load_audio()
+
+        assert cut.features.storage_type == "shar"
+        with pytest.raises(RuntimeError):
+            cut.load_features()
+
+        assert cut.custom_embedding.storage_type == "shar"
+        with pytest.raises(RuntimeError):
+            cut.load_custom_embedding()
+
+        assert cut.custom_features.array.storage_type == "shar"
+        with pytest.raises(RuntimeError):
+            cut.load_custom_features()
+
+        assert cut.custom_indexes.array.storage_type == "shar"
+        with pytest.raises(RuntimeError):
+            cut.load_custom_indexes()
+
+        assert cut.custom_recording.sources[0].type == "shar"
+        with pytest.raises(RuntimeError):
+            cut.load_custom_recording()
+
+
+def test_shar_writer_not_sharded(tmp_path: Path):
+    # Prepare data
+    cuts = DummyManifest(CutSet, begin_id=0, end_id=20, with_data=True)
+
+    # Prepare system under test
+    writer = SharWriter(
+        tmp_path,
+        fields={
+            "recording": "wav",
+            "features": "lilcom",
+            "custom_embedding": "numpy",
+            "custom_features": "lilcom",
+            "custom_indexes": "numpy",
+            "custom_recording": "wav",
+        },
+        shard_size=None,
+    )
+
+    # Actual test
+    with writer:
+        for c in cuts:
+            writer.write(c)
+
+    # Post-conditions
+
+    assert writer.output_paths == {
+        "cuts": [
+            str(tmp_path / "cuts.jsonl.gz"),
+        ],
+        "recording": [
+            str(tmp_path / "recording.tar"),
+        ],
+        "features": [
+            str(tmp_path / "features.tar"),
+        ],
+        "custom_embedding": [
+            str(tmp_path / "custom_embedding.tar"),
+        ],
+        "custom_features": [
+            str(tmp_path / "custom_features.tar"),
+        ],
+        "custom_indexes": [
+            str(tmp_path / "custom_indexes.tar"),
+        ],
+        "custom_recording": [
+            str(tmp_path / "custom_recording.tar"),
+        ],
+    }
+
+    # - we created 2 shards with cutsets and a separate file for each data field
+    for fname in (
+        "cuts.jsonl.gz",
+        "recording.tar",
+        "features.tar",
+        "custom_embedding.tar",
+        "custom_features.tar",
+        "custom_indexes.tar",
+        "custom_recording.tar",
+    ):
+        assert (tmp_path / fname).is_file()
+
+    # - we didn't create a shard
+    assert not (tmp_path / "cuts.000000.jsonl.gz").exists()
+
+    # - the cuts do not have any data actually attached to them,
+    #   so it's impossible to load it if we open it as a normal CutSet
+    for cut in CutSet.from_file(tmp_path / "cuts.jsonl.gz"):
         assert cut.recording.sources[0].type == "shar"
         with pytest.raises(RuntimeError):
             cut.load_audio()

--- a/test/shar/test_write.py
+++ b/test/shar/test_write.py
@@ -13,6 +13,8 @@ def test_tar_writer(tmp_path: Path):
     with TarWriter(str(tmp_path / "test.%06d.tar"), shard_size=10) as writer:
         writer.write("test.txt", BytesIO(b"test"))
 
+    assert writer.output_paths == [str(tmp_path / "test.000000.tar")]
+
     with tarfile.open(tmp_path / "test.000000.tar") as f:
         f2 = f.extractfile(f.getmember("test.txt"))
         assert f2.read() == b"test"
@@ -21,6 +23,8 @@ def test_tar_writer(tmp_path: Path):
 def test_tar_writer_pipe(tmp_path: Path):
     with TarWriter(f"pipe:cat > {tmp_path}/test.%06d.tar", shard_size=10) as writer:
         writer.write("test.txt", BytesIO(b"test"))
+
+    assert writer.output_paths == [f"pipe:cat > {tmp_path}/test.000000.tar"]
 
     with tarfile.open(tmp_path / "test.000000.tar") as f:
         f2 = f.extractfile(f.getmember("test.txt"))
@@ -51,6 +55,37 @@ def test_shar_writer(tmp_path: Path):
             writer.write(c)
 
     # Post-conditions
+
+    assert writer.output_paths == {
+        "cuts": [
+            str(tmp_path / "cuts.000000.jsonl.gz"),
+            str(tmp_path / "cuts.000001.jsonl.gz"),
+        ],
+        "recording": [
+            str(tmp_path / "recording.000000.tar"),
+            str(tmp_path / "recording.000001.tar"),
+        ],
+        "features": [
+            str(tmp_path / "features.000000.tar"),
+            str(tmp_path / "features.000001.tar"),
+        ],
+        "custom_embedding": [
+            str(tmp_path / "custom_embedding.000000.tar"),
+            str(tmp_path / "custom_embedding.000001.tar"),
+        ],
+        "custom_features": [
+            str(tmp_path / "custom_features.000000.tar"),
+            str(tmp_path / "custom_features.000001.tar"),
+        ],
+        "custom_indexes": [
+            str(tmp_path / "custom_indexes.000000.tar"),
+            str(tmp_path / "custom_indexes.000001.tar"),
+        ],
+        "custom_recording": [
+            str(tmp_path / "custom_recording.000000.tar"),
+            str(tmp_path / "custom_recording.000001.tar"),
+        ],
+    }
 
     # - we created 2 shards with cutsets and a separate file for each data field
     for fname in (

--- a/test/shar/test_write.py
+++ b/test/shar/test_write.py
@@ -378,3 +378,30 @@ def test_shar_writer_pipe(tmp_path: Path):
         "custom_recording.000001.tar",
     ):
         assert (tmp_path / fname).is_file()
+
+    # - the cuts do not have any data actually attached to them,
+    #   so it's impossible to load it if we open it as a normal CutSet
+    for cut in CutSet.from_file(tmp_path / "cuts.000000.jsonl.gz"):
+        assert cut.recording.sources[0].type == "shar"
+        with pytest.raises(RuntimeError):
+            cut.load_audio()
+
+        assert cut.features.storage_type == "shar"
+        with pytest.raises(RuntimeError):
+            cut.load_features()
+
+        assert cut.custom_embedding.storage_type == "shar"
+        with pytest.raises(RuntimeError):
+            cut.load_custom_embedding()
+
+        assert cut.custom_features.array.storage_type == "shar"
+        with pytest.raises(RuntimeError):
+            cut.load_custom_features()
+
+        assert cut.custom_indexes.array.storage_type == "shar"
+        with pytest.raises(RuntimeError):
+            cut.load_custom_indexes()
+
+        assert cut.custom_recording.sources[0].type == "shar"
+        with pytest.raises(RuntimeError):
+            cut.load_custom_recording()


### PR DESCRIPTION
This change is related to continued development of Lhotse Shar. It allows to add new fields to a CutSet dynamically. E.g.:

- when somebody converts cuts with audio to Shar, they will have a directory like:

```
cuts.000000.jsonl.gz cuts.000001.jsonl.gz recording.000000.tar recording.000001.tar
```

- then if somebody reads these cuts using `LazySharIterator`, computes some custom features `my_features`, and saves to Shar again, they will get:

```
cuts.000000.jsonl.gz cuts.000001.jsonl.gz my_features.000000.tar my_features.000001.tar
```

This change allows to use the cuts from the step 1 to be read together with `recordings` from step 1 and `my_features` from step 2. Previously the code would complain about missing `my_features` manifest in cuts.