### PR TITLE
Fixed an erroneous assertion

### DIFF
--- a/lhotse/dataset/signal_transforms.py
+++ b/lhotse/dataset/signal_transforms.py
@@ -160,7 +160,7 @@ class SpecAugment(torch.nn.Module):
         super().__init__()
         assert 0 <= p <= 1
         assert num_feature_masks >= 0
-        assert num_frame_masks > 0
+        assert num_frame_masks >= 0
         assert features_mask_size > 0
         assert frames_mask_size > 0
         self.time_warp_factor = time_warp_factor


### PR DESCRIPTION
Fixed an erroneous assertion in SpecAugment which prevents ``num_frame_masks`` to be set to ``0`` to be disabled. 