### PR TITLE
Small changes to make channel attribute hashable

### DIFF
--- a/lhotse/bin/modes/cut.py
+++ b/lhotse/bin/modes/cut.py
@@ -54,6 +54,9 @@ def simple(
     Either RECORDING_MANIFEST or FEATURE_MANIFEST has to be provided.
     When SUPERVISION_MANIFEST is provided, the cuts time span will correspond to that of the supervision segments.
     Otherwise, that time span corresponds to the one found in features, if available, otherwise recordings.
+
+    .. hint::
+        ``--force-eager`` must be used when the RECORDING_MANIFEST is not sorted by recording ID.
     """
     supervision_set, feature_set, recording_set = [
         load_manifest_lazy_or_eager(p) if p is not None else None
@@ -112,12 +115,20 @@ def simple(
             The value of "center" implies equal expansion to left and right;
             random uniformly samples a value between "left" and "right".""",
 )
+@click.option(
+    "--keep-all-channels/--discard-extra-channels",
+    type=bool,
+    default=False,
+    help="""If ``True``, the output cut will have the same channels as the input cut. By default,
+            the trimmed cut will have the same channels as the supervision.""",
+)
 def trim_to_supervisions(
     cuts: Pathlike,
     output_cuts: Pathlike,
     keep_overlapping: bool,
     min_duration: Optional[float],
     context_direction: str,
+    keep_all_channels: bool,
 ):
     """
     Splits each input cut into as many cuts as there are supervisions.
@@ -154,6 +165,7 @@ def trim_to_supervisions(
             keep_overlapping=keep_overlapping,
             min_duration=min_duration,
             context_direction=context_direction,
+            keep_all_channels=keep_all_channels,
         ):
             writer.write(cut)
 

--- a/lhotse/cut/base.py
+++ b/lhotse/cut/base.py
@@ -24,6 +24,7 @@ from lhotse.utils import (
     fastcopy,
     ifnone,
     overlaps,
+    to_hashable,
 )
 
 # One of the design principles for Cuts is a maximally "lazy" implementation, e.g. when mixing Cuts,
@@ -485,7 +486,9 @@ class Cut:
                 # number of channels in underlying tracks.
 
                 # Ensure that all supervisions have the same channel.
-                assert len(set(s.channel for s in trimmed.supervisions)) == 1, (
+                assert (
+                    len(set(to_hashable(s.channel) for s in trimmed.supervisions)) == 1
+                ), (
                     "Trimmed cut has supervisions with different channels. Either set "
                     "`ignore_channel=True` to keep original channels or `keep_overlapping=False` "
                     "to retain only 1 supervision per trimmed cut."

--- a/lhotse/qa.py
+++ b/lhotse/qa.py
@@ -384,7 +384,7 @@ def validate_cut(c: Cut, read_data: bool = False) -> None:
     # Conditions related to recording
     if c.has_recording:
         validate_recording(c.recording)
-        assert c.channel in c.recording.channel_ids
+        assert is_equal_or_contains(c.recording.channel_ids, c.channel)
         if read_data:
             # We are not passing "read_data" to "validate_recording" to avoid loading audio twice;
             # we'll just validate the subset of the recording relevant for the cut.

--- a/lhotse/utils.py
+++ b/lhotse/utils.py
@@ -624,8 +624,12 @@ def is_none_or_gt(value, threshold) -> bool:
     return value is None or value > threshold
 
 
-def is_equal_or_contains(value: Union[T, Sequence[T]], other: T) -> bool:
-    return value == other or (isinstance(value, Sequence) and other in value)
+def is_equal_or_contains(
+    value: Union[T, Sequence[T]], other: Union[T, Sequence[T]]
+) -> bool:
+    value = to_list(value)
+    other = to_list(other)
+    return set(other).issubset(set(value))
 
 
 def is_module_available(*modules: str) -> bool:
@@ -664,6 +668,11 @@ def ifnone(item: Optional[Any], alt_item: Any) -> Any:
 def to_list(item: Union[Any, Sequence[Any]]) -> List[Any]:
     """Convert ``item`` to a list if it is not already a list."""
     return item if isinstance(item, list) else [item]
+
+
+def to_hashable(item: Any) -> Any:
+    """Convert ``item`` to a hashable type if it is not already hashable."""
+    return tuple(item) if isinstance(item, list) else item
 
 
 def lens_to_mask(lens: torch.IntTensor) -> torch.Tensor:

--- a/test/cut/test_cut_trim_to_supervisions.py
+++ b/test/cut/test_cut_trim_to_supervisions.py
@@ -39,7 +39,7 @@ def mono_cut():
 
 
 @pytest.fixture
-def multi_cut():
+def multi_cut_with_single_channel_supervisions():
     """
     Scenario::
                   ╔══════════════════════════════  MultiCut  ═════════════════╗
@@ -75,6 +75,47 @@ def multi_cut():
             duration=5.5,
             text="Hey, John. How are you?",
             channel=1,
+        ),
+    ]
+    return MultiCut(
+        id="rec1-cut1",
+        start=0.0,
+        duration=10.0,
+        channel=[0, 1],
+        recording=rec,
+        supervisions=sups,
+    )
+
+
+@pytest.fixture
+def multi_cut_with_multi_channel_supervisions():
+    """
+    This is the same as multi_cut, but the supervisions are shared between both channels.
+    """
+    rec = Recording(
+        id="rec1",
+        duration=10.0,
+        sampling_rate=8000,
+        num_samples=80000,
+        sources=[],
+        channel_ids=[0, 1],
+    )
+    sups = [
+        SupervisionSegment(
+            id="sup1",
+            recording_id="rec1",
+            start=0.0,
+            duration=5.0,
+            text="Hello this is John.",
+            channel=[0, 1],
+        ),
+        SupervisionSegment(
+            id="sup2",
+            recording_id="rec1",
+            start=4.5,
+            duration=5.5,
+            text="Hey, John. How are you?",
+            channel=[0, 1],
         ),
     ]
     return MultiCut(
@@ -304,7 +345,10 @@ def test_cut_trim_to_supervisions_extend_handles_end_of_recording(mono_cut):
     assert c2_s1.duration == 3.0
 
 
-def test_multi_cut_trim_to_supervisions_keep_all_channels(multi_cut):
+def test_multi_cut_trim_to_supervisions_keep_all_channels(
+    multi_cut_with_single_channel_supervisions,
+):
+    multi_cut = multi_cut_with_single_channel_supervisions
     cuts = multi_cut.trim_to_supervisions(
         keep_overlapping=False, keep_all_channels=True
     )
@@ -320,7 +364,10 @@ def test_multi_cut_trim_to_supervisions_keep_all_channels(multi_cut):
         assert cut.channel == multi_cut.channel
 
 
-def test_multi_cut_trim_to_supervisions_do_not_keep_all_channels(multi_cut):
+def test_multi_cut_trim_to_supervisions_do_not_keep_all_channels(
+    multi_cut_with_single_channel_supervisions,
+):
+    multi_cut = multi_cut_with_single_channel_supervisions
     cuts = multi_cut.trim_to_supervisions(
         keep_overlapping=False, keep_all_channels=False
     )
@@ -337,7 +384,30 @@ def test_multi_cut_trim_to_supervisions_do_not_keep_all_channels(multi_cut):
         assert cut.channel == original_sup.channel
 
 
-def test_multi_cut_trim_to_supervisions_do_not_keep_all_channels_raises(multi_cut):
+def test_multi_cut_with_multi_channel_sup_trim_to_supervisions_do_not_keep_all_channels(
+    multi_cut_with_multi_channel_supervisions,
+):
+    multi_cut = multi_cut_with_multi_channel_supervisions
+    cuts = multi_cut.trim_to_supervisions(
+        keep_overlapping=False, keep_all_channels=False
+    )
+    assert len(cuts) == 2
+    for cut, original_sup in zip(cuts, multi_cut.supervisions):
+        assert isinstance(cut, MultiCut)
+        assert cut.start == original_sup.start
+        assert cut.duration == original_sup.duration
+        assert len(cut.supervisions) == 1
+        (sup,) = cut.supervisions
+        assert sup.start == 0
+        assert sup.duration == cut.duration
+        assert sup.text == original_sup.text
+        assert cut.channel == original_sup.channel
+
+
+def test_multi_cut_trim_to_supervisions_do_not_keep_all_channels_raises(
+    multi_cut_with_single_channel_supervisions,
+):
+    multi_cut = multi_cut_with_single_channel_supervisions
     with pytest.raises(AssertionError):
         cuts = multi_cut.trim_to_supervisions(
             keep_overlapping=True, keep_all_channels=False

--- a/test/cut/test_cut_trim_to_supervisions.py
+++ b/test/cut/test_cut_trim_to_supervisions.py
@@ -39,7 +39,7 @@ def mono_cut():
 
 
 @pytest.fixture
-def multi_cut_with_single_channel_supervisions():
+def multi_cut():
     """
     Scenario::
                   ╔══════════════════════════════  MultiCut  ═════════════════╗
@@ -345,10 +345,7 @@ def test_cut_trim_to_supervisions_extend_handles_end_of_recording(mono_cut):
     assert c2_s1.duration == 3.0
 
 
-def test_multi_cut_trim_to_supervisions_keep_all_channels(
-    multi_cut_with_single_channel_supervisions,
-):
-    multi_cut = multi_cut_with_single_channel_supervisions
+def test_multi_cut_trim_to_supervisions_keep_all_channels(multi_cut):
     cuts = multi_cut.trim_to_supervisions(
         keep_overlapping=False, keep_all_channels=True
     )
@@ -364,10 +361,7 @@ def test_multi_cut_trim_to_supervisions_keep_all_channels(
         assert cut.channel == multi_cut.channel
 
 
-def test_multi_cut_trim_to_supervisions_do_not_keep_all_channels(
-    multi_cut_with_single_channel_supervisions,
-):
-    multi_cut = multi_cut_with_single_channel_supervisions
+def test_multi_cut_trim_to_supervisions_do_not_keep_all_channels(multi_cut):
     cuts = multi_cut.trim_to_supervisions(
         keep_overlapping=False, keep_all_channels=False
     )
@@ -404,10 +398,7 @@ def test_multi_cut_with_multi_channel_sup_trim_to_supervisions_do_not_keep_all_c
         assert cut.channel == original_sup.channel
 
 
-def test_multi_cut_trim_to_supervisions_do_not_keep_all_channels_raises(
-    multi_cut_with_single_channel_supervisions,
-):
-    multi_cut = multi_cut_with_single_channel_supervisions
+def test_multi_cut_trim_to_supervisions_do_not_keep_all_channels_raises(multi_cut):
     with pytest.raises(AssertionError):
         cuts = multi_cut.trim_to_supervisions(
             keep_overlapping=True, keep_all_channels=False


### PR DESCRIPTION
Some comparisons require the channel attribute to be hashable (of `Tuple` type). This PR adds a utility function to convert channel to tuple. Other small changes, e.g., CLI option for keeping all channels in trim_to_supervisions.