### PR TITLE
Shar: tracking epochs in shard iterator with option for shard re-shuffling each epoch

### DIFF
--- a/lhotse/shar/readers/lazy.py
+++ b/lhotse/shar/readers/lazy.py
@@ -224,6 +224,7 @@ class LazySharIterator(ImitatesDict):
                     setattr(cut, field, maybe_manifest)
 
                 cut.shard_origin = shard["cuts"]
+                cut.shar_epoch = self.epoch
                 if cut_map_fn is not None:
                     cut = cut_map_fn(cut)
                 yield cut

--- a/lhotse/shar/readers/lazy.py
+++ b/lhotse/shar/readers/lazy.py
@@ -1,6 +1,6 @@
 import random
 from pathlib import Path
-from typing import Callable, Dict, Generator, Optional, Sequence, Tuple
+from typing import Callable, Dict, Generator, List, Optional, Sequence, Tuple
 
 from lhotse.cut import Cut
 from lhotse.lazy import (
@@ -92,6 +92,10 @@ class LazySharIterator(ImitatesDict):
         on each node given the same seed).
     :param seed: When ``shuffle_shards`` is ``True``, we use this number to
         seed the RNG.
+    :param stateful_shuffle: bool, by default ``False``. When ``True``, every
+        time this object is fully iterated, it increments an internal epoch counter
+        and triggers shard reshuffling with RNG seeded by ``seed`` + ``epoch``.
+        Doesn't have any effect when ``shuffle_shards`` is ``False``.
     :param cut_map_fns: optional sequence of callables that accept cuts and return cuts.
         It's expected to have the same length as the number of shards, so each function
         corresponds to a specific shard.
@@ -106,6 +110,7 @@ class LazySharIterator(ImitatesDict):
         in_dir: Optional[Pathlike] = None,
         split_for_dataloading: bool = False,
         shuffle_shards: bool = False,
+        stateful_shuffle: bool = False,
         seed: int = 42,
         cut_map_fns: Optional[Sequence[Callable[[Cut], Cut]]] = None,
     ) -> None:
@@ -114,6 +119,11 @@ class LazySharIterator(ImitatesDict):
         ), "To read Lhotse Shar format, provide either 'in_dir' or 'fields' argument."
 
         self.split_for_dataloading = split_for_dataloading
+        self.shuffle_shards = shuffle_shards
+        self.stateful_shuffle = stateful_shuffle
+        self.seed = seed
+        self.epoch = 0
+
         self._len = None
         if in_dir is not None:
             self._init_from_dir(in_dir)
@@ -132,9 +142,6 @@ class LazySharIterator(ImitatesDict):
         ]
 
         self.cut_map_fns = ifnone(cut_map_fns, [None] * self.num_shards)
-
-        if shuffle_shards:
-            random.Random(seed).shuffle(self.shards)
 
     def _init_from_inputs(self, fields: Optional[Dict[str, Sequence[str]]] = None):
         assert (
@@ -164,16 +171,28 @@ class LazySharIterator(ImitatesDict):
                 p for p in all_paths if p.name.split(".")[0] == field
             )
 
-    @property
-    def shards_for_dataloading(self):
+    def _maybe_split_for_dataloading(self, shards: List[Dict]) -> List[Dict]:
         from .utils import split_by_node, split_by_worker
 
-        return split_by_worker(split_by_node(self.shards))
+        if self.split_for_dataloading:
+            return split_by_worker(split_by_node(shards))
+        else:
+            return shards
+
+    def _maybe_shuffle_shards(self, shards: List[Dict]) -> List[Dict]:
+        if self.shuffle_shards:
+            shards = shards.copy()
+            seed = self.seed
+            if self.stateful_shuffle:
+                seed += self.epoch
+            random.Random(seed).shuffle(shards)
+        return shards
 
     def __iter__(self):
-        shards = (
-            self.shards_for_dataloading if self.split_for_dataloading else self.shards
-        )
+        shards = self.shards
+        shards = self._maybe_shuffle_shards(shards)
+        shards = self._maybe_split_for_dataloading(shards)
+
         for shard, cut_map_fn in zip(shards, self.cut_map_fns):
             # Iterate over cuts for the current shard
             cuts = LazyManifestIterator(shard["cuts"])
@@ -208,6 +227,8 @@ class LazySharIterator(ImitatesDict):
                 if cut_map_fn is not None:
                     cut = cut_map_fn(cut)
                 yield cut
+
+        self.epoch += 1
 
     def __len__(self) -> int:
         if self._len is None:

--- a/test/shar/test_read_lazy.py
+++ b/test/shar/test_read_lazy.py
@@ -17,6 +17,9 @@ def test_shar_lazy_reader_from_dir(cuts: CutSet, shar_dir: Path):
     # Actual test
     for c_test, c_ref in zip(cuts_iter, cuts):
         assert c_test.id == c_ref.id
+        assert c_test.has_custom("shard_origin")
+        assert c_test.has_custom("shar_epoch")
+        assert c_test.shar_epoch == 0
         np.testing.assert_allclose(c_ref.load_audio(), c_test.load_audio(), rtol=1e-3)
         np.testing.assert_allclose(
             c_ref.load_custom_recording(), c_test.load_custom_recording(), rtol=1e-3


### PR DESCRIPTION
This change is to implement Dan's idea about infinite iteration with re-shuffling of shards at the start of each epoch. I will write a more detailed example/tutorial some time later, but the basic idea is the following snippet:

```python
cuts = (
    CutSet.from_shar(in_dir=shar_dir, shuffle_shards=True, stateful_shuffle=True)
    .repeat()
    .shuffle(buffer_size=10000)
)
```

yields an infinite `CutSet` that has two levels of shuffling: 
- shard-level: the shards are re-shuffled every time it exhausts the underlying finite CutSet
- cut-level: the cuts are shuffled across shards using a buffer

The rest of the dataloading workflow is identical as with WebDataset. The DataLoader will never stop yielding data so epochs need to be tracked differently. To make it possible, cuts iterated this way have an attached custom field called `shar_epoch`. In practice when the epoch is incremented, you'd still keep seeing cuts from the previous epoch for a number of steps until they are completely flushed out of the shuffling buffer. If that's undesirable, call `.shuffle()` first and then `.repeat()`, but it'll be a bit less random.