### PR TITLE
Fix save_audios

### DIFF
--- a/lhotse/cut/base.py
+++ b/lhotse/cut/base.py
@@ -629,8 +629,11 @@ class Cut:
             samples = augment_fn(samples, self.sampling_rate)
 
         torchaudio.save(
-            str(storage_path), torch.as_tensor(samples), sample_rate=self.sampling_rate,
-            encoding=encoding, bits_per_sample=bits_per_sample
+            str(storage_path),
+            torch.as_tensor(samples),
+            sample_rate=self.sampling_rate,
+            encoding=encoding,
+            bits_per_sample=bits_per_sample,
         )
         recording = Recording(
             id=storage_path.stem,

--- a/lhotse/cut/base.py
+++ b/lhotse/cut/base.py
@@ -600,12 +600,20 @@ class Cut:
     def save_audio(
         self,
         storage_path: Pathlike,
+        encoding: Optional[str] = None,
+        bits_per_sample: Optional[int] = None,
         augment_fn: Optional[AugmentFn] = None,
     ) -> "Cut":
         """
         Store this cut's waveform as audio recording to disk.
 
         :param storage_path: The path to location where we will store the audio recordings.
+        :param encoding: Audio encoding argument supported by ``torchaudio.save``. See
+            https://pytorch.org/audio/stable/backend.html#save (sox_io backend) and
+            https://pytorch.org/audio/stable/backend.html#id3 (soundfile backend) for more details.
+        :param bits_per_sample: Audio bits_per_sample argument supported by ``torchaudio.save``. See
+            https://pytorch.org/audio/stable/backend.html#save (sox_io backend) and
+            https://pytorch.org/audio/stable/backend.html#id3 (soundfile backend) for more details.
         :param augment_fn: an optional callable used for audio augmentation.
             Be careful with the types of augmentations used: if they modify
             the start/end/duration times of the cut and its supervisions,
@@ -621,7 +629,8 @@ class Cut:
             samples = augment_fn(samples, self.sampling_rate)
 
         torchaudio.save(
-            str(storage_path), torch.as_tensor(samples), sample_rate=self.sampling_rate
+            str(storage_path), torch.as_tensor(samples), sample_rate=self.sampling_rate,
+            encoding=encoding, bits_per_sample=bits_per_sample
         )
         recording = Recording(
             id=storage_path.stem,

--- a/lhotse/cut/set.py
+++ b/lhotse/cut/set.py
@@ -1971,7 +1971,7 @@ class CutSet(Serializable, AlgorithmMixin):
             # too many files in a single directory.
             subdir = Path(storage_path) / cut.id[:3]
             subdir.mkdir(exist_ok=True, parents=True)
-            return (subdir / (cut.id + "." + format))
+            return subdir / (cut.id + "." + format)
 
         # Non-parallel execution
         if executor is None and num_jobs == 1:

--- a/lhotse/cut/set.py
+++ b/lhotse/cut/set.py
@@ -1964,7 +1964,7 @@ class CutSet(Serializable, AlgorithmMixin):
             subdir = Path(storage_path) / cut.id[:3]
             subdir.mkdir(exist_ok=True, parents=True)
             # Adding default format to fix the issue that `cut.id` contains `.`.
-            return (subdir / cut.id / ".wav").with_suffix(f".{format}")
+            return (subdir / (cut.id + ".wav")).with_suffix(f".{format}")
 
         # Non-parallel execution
         if executor is None and num_jobs == 1:

--- a/lhotse/cut/set.py
+++ b/lhotse/cut/set.py
@@ -1911,6 +1911,8 @@ class CutSet(Serializable, AlgorithmMixin):
         self,
         storage_path: Pathlike,
         format: str = "wav",
+        encoding: Optional[str] = None,
+        bits_per_sample: Optional[int] = None,
         num_jobs: Optional[int] = None,
         executor: Optional[Executor] = None,
         augment_fn: Optional[AugmentFn] = None,
@@ -1924,6 +1926,12 @@ class CutSet(Serializable, AlgorithmMixin):
             characters of the cut's ID. The audio recording is then stored in the sub-directory
             using filename ``{cut.id}.{format}``
         :param format: Audio format argument supported by ``torchaudio.save``. Default is ``wav``.
+        :param encoding: Audio encoding argument supported by ``torchaudio.save``. See
+            https://pytorch.org/audio/stable/backend.html#save (sox_io backend) and
+            https://pytorch.org/audio/stable/backend.html#id3 (soundfile backend) for more details.
+        :param bits_per_sample: Audio bits_per_sample argument supported by ``torchaudio.save``. See
+            https://pytorch.org/audio/stable/backend.html#save (sox_io backend) and
+            https://pytorch.org/audio/stable/backend.html#id3 (soundfile backend) for more details.
         :param num_jobs: The number of parallel processes used to store the audio recordings.
             We will internally split the CutSet into this many chunks
             and process each chunk in parallel.
@@ -1963,8 +1971,7 @@ class CutSet(Serializable, AlgorithmMixin):
             # too many files in a single directory.
             subdir = Path(storage_path) / cut.id[:3]
             subdir.mkdir(exist_ok=True, parents=True)
-            # Adding default format to fix the issue that `cut.id` contains `.`.
-            return (subdir / (cut.id + ".wav")).with_suffix(f".{format}")
+            return (subdir / (cut.id + "." + format))
 
         # Non-parallel execution
         if executor is None and num_jobs == 1:
@@ -1976,6 +1983,8 @@ class CutSet(Serializable, AlgorithmMixin):
                 progress(
                     cut.save_audio(
                         storage_path=file_storage_path(cut, storage_path),
+                        encoding=encoding,
+                        bits_per_sample=bits_per_sample,
                         augment_fn=augment_fn,
                     )
                     for cut in self

--- a/lhotse/cut/set.py
+++ b/lhotse/cut/set.py
@@ -1963,7 +1963,8 @@ class CutSet(Serializable, AlgorithmMixin):
             # too many files in a single directory.
             subdir = Path(storage_path) / cut.id[:3]
             subdir.mkdir(exist_ok=True, parents=True)
-            return (subdir / cut.id).with_suffix(f".{format}")
+            # Adding default format to fix the issue that `cut.id` contains `.`.
+            return (subdir / cut.id / ".wav").with_suffix(f".{format}")
 
         # Non-parallel execution
         if executor is None and num_jobs == 1:

--- a/test/cut/test_cut_set.py
+++ b/test/cut/test_cut_set.py
@@ -525,12 +525,22 @@ def test_map_cut_set_rejects_noncut(cut_set_with_mixed_cut):
 def test_store_audio():
     cut_set = CutSet.from_json("test/fixtures/libri/cuts.json")
     with TemporaryDirectory() as tmpdir:
-        stored_cut_set = cut_set.save_audios(tmpdir)
-        for cut1, cut2 in zip(cut_set, stored_cut_set):
-            samples1 = cut1.load_audio()
-            samples2 = cut2.load_audio()
-            assert np.array_equal(samples1, samples2)
-        assert len(stored_cut_set) == len(cut_set)
+        for enc, bits in (("PCM_S", 16), ("PCM_F", 32), (None, 16), ("PCM_S", None), (None, None)):
+           stored_cut_set = cut_set.save_audios(tmpdir, encoding=enc, bits_per_sample=bits)
+           for cut1, cut2 in zip(cut_set, stored_cut_set):
+               samples1 = cut1.load_audio()
+               samples2 = cut2.load_audio()
+               assert np.array_equal(samples1, samples2)
+           assert len(stored_cut_set) == len(cut_set)
+
+    with TemporaryDirectory() as tmpdir:
+        for bits in (16, 24, None):
+            stored_cut_set = cut_set.save_audios(tmpdir, format="flac", bits_per_sample=bits)
+            for cut1, cut2 in zip(cut_set, stored_cut_set):
+                samples1 = cut1.load_audio()
+                samples2 = cut2.load_audio()
+                assert np.array_equal(samples1, samples2)
+            assert len(stored_cut_set) == len(cut_set)
 
 
 def test_cut_set_subset_cut_ids_preserves_order():

--- a/test/cut/test_cut_set.py
+++ b/test/cut/test_cut_set.py
@@ -525,17 +525,27 @@ def test_map_cut_set_rejects_noncut(cut_set_with_mixed_cut):
 def test_store_audio():
     cut_set = CutSet.from_json("test/fixtures/libri/cuts.json")
     with TemporaryDirectory() as tmpdir:
-        for enc, bits in (("PCM_S", 16), ("PCM_F", 32), (None, 16), ("PCM_S", None), (None, None)):
-           stored_cut_set = cut_set.save_audios(tmpdir, encoding=enc, bits_per_sample=bits)
-           for cut1, cut2 in zip(cut_set, stored_cut_set):
-               samples1 = cut1.load_audio()
-               samples2 = cut2.load_audio()
-               assert np.array_equal(samples1, samples2)
-           assert len(stored_cut_set) == len(cut_set)
+        for enc, bits in (
+            ("PCM_S", 16),
+            ("PCM_F", 32),
+            (None, 16),
+            ("PCM_S", None),
+            (None, None),
+        ):
+            stored_cut_set = cut_set.save_audios(
+                tmpdir, encoding=enc, bits_per_sample=bits
+            )
+            for cut1, cut2 in zip(cut_set, stored_cut_set):
+                samples1 = cut1.load_audio()
+                samples2 = cut2.load_audio()
+                assert np.array_equal(samples1, samples2)
+            assert len(stored_cut_set) == len(cut_set)
 
     with TemporaryDirectory() as tmpdir:
         for bits in (16, 24, None):
-            stored_cut_set = cut_set.save_audios(tmpdir, format="flac", bits_per_sample=bits)
+            stored_cut_set = cut_set.save_audios(
+                tmpdir, format="flac", bits_per_sample=bits
+            )
             for cut1, cut2 in zip(cut_set, stored_cut_set):
                 samples1 = cut1.load_audio()
                 samples2 = cut2.load_audio()


### PR DESCRIPTION
Someone reported this bug to me, she said she got error paths when she dumped speed_perb cuts.

![image](https://user-images.githubusercontent.com/11765074/203054930-67f18d7d-1d18-4e93-84bc-c3e7ab85fac2.png)

![image](https://user-images.githubusercontent.com/11765074/203054966-a45d7e5d-ccff-471b-a766-6d8622a08cc8.png)

I reproduced the issue as follows:

```
>>> from pathlib import Path
>>> base = Path("dir")
>>> (base / "cut-a-b-c").with_suffix(".wav")
PosixPath('dir/cut-a-b-c.wav')
>>> (base / "cut-a-b-c.wav").with_suffix(".wav")
PosixPath('dir/cut-a-b-c.wav')
>>> (base / "cut-a-b-c1.1").with_suffix(".wav")
PosixPath('dir/cut-a-b-c1.wav')
>>> (base / "cut-a-b-c1.1.wav").with_suffix(".wav")
PosixPath('dir/cut-a-b-c1.1.wav')
```