### PR TITLE
More details in `cuts.describe()` + fix for `trim_to_unsupervised_segments()`

### DIFF
--- a/lhotse/cut/set.py
+++ b/lhotse/cut/set.py
@@ -60,6 +60,7 @@ from lhotse.utils import (
     fastcopy,
     ifnone,
     index_by_id_and_check,
+    is_module_available,
     split_manifest_lazy,
     split_sequence,
     uuid4,
@@ -676,6 +677,11 @@ class CutSet(Serializable, AlgorithmMixin):
             │ Total                │ 64:59:51              │ 74:33:09                   │ 100.00%       │ 100.00%              │
             ╘══════════════════════╧═══════════════════════╧════════════════════════════╧═══════════════╧══════════════════════╛
         """
+        if not is_module_available("tabulate"):
+            raise ValueError(
+                "Since Lhotse v1.11, this function requires the `tabulate` package to be "
+                "installed. Please run 'pip install tabulate' to continue."
+            )
         from tabulate import tabulate
 
         def convert_(seconds: float) -> Tuple[int, int, int]:

--- a/lhotse/utils.py
+++ b/lhotse/utils.py
@@ -180,6 +180,10 @@ class TimeSpan:
     start: Seconds
     end: Seconds
 
+    @property
+    def duration(self) -> Seconds:
+        return self.end - self.start
+
 
 # TODO: Ugh, Protocols are only in Python 3.8+...
 def overlaps(lhs: Any, rhs: Any) -> bool:

--- a/setup.py
+++ b/setup.py
@@ -150,6 +150,7 @@ install_requires = [
     "numpy>=1.18.1",
     "packaging",
     "pyyaml>=5.3.1",
+    "tabulate>=0.8.1",
     "tqdm",
 ]
 

--- a/test/cut/test_cut_set.py
+++ b/test/cut/test_cut_set.py
@@ -351,12 +351,12 @@ def test_trim_to_supervisions_mixed_cuts_keep_overlapping_true(
     assert sup.duration == 18
 
 
-@pytest.mark.skipif(
-    not is_module_available("pandas"), reason="Requires pandas to be installed."
-)
 @pytest.mark.parametrize("full", [True, False])
-def test_cut_set_describe_runs(cut_set, full):
+def test_cut_set_describe_runs(cut_set, full, capfd):
     cut_set.describe(full=full)
+    out, err = capfd.readouterr()
+    assert out != ""
+    assert err == ""
 
 
 def test_cut_map_supervisions(cut_set):

--- a/test/cut/test_cut_set.py
+++ b/test/cut/test_cut_set.py
@@ -354,8 +354,9 @@ def test_trim_to_supervisions_mixed_cuts_keep_overlapping_true(
 @pytest.mark.skipif(
     not is_module_available("pandas"), reason="Requires pandas to be installed."
 )
-def test_cut_set_describe_runs(cut_set):
-    cut_set.describe()
+@pytest.mark.parametrize("full", [True, False])
+def test_cut_set_describe_runs(cut_set, full):
+    cut_set.describe(full=full)
 
 
 def test_cut_map_supervisions(cut_set):


### PR DESCRIPTION
1. Added an optional `full:bool=False` parameter in `CutSet.describe()`. If set to True, it prints additional information about the cut set, such as the following for AMI:

```
Cut statistics:
╒═══════════════════════════╤══════════╕
│ Cuts count:               │ 133      │
├───────────────────────────┼──────────┤
│ Total duration (hh:mm:ss) │ 79:23:03 │
├───────────────────────────┼──────────┤
│ mean                      │ 2148.7   │
├───────────────────────────┼──────────┤
│ std                       │ 867.4    │
├───────────────────────────┼──────────┤
│ min                       │ 477.9    │
├───────────────────────────┼──────────┤
│ 25%                       │ 1509.8   │
├───────────────────────────┼──────────┤
│ 50%                       │ 2181.7   │
├───────────────────────────┼──────────┤
│ 75%                       │ 2439.9   │
├───────────────────────────┼──────────┤
│ 99%                       │ 5300.7   │
├───────────────────────────┼──────────┤
│ 99.5%                     │ 5355.3   │
├───────────────────────────┼──────────┤
│ 99.9%                     │ 5403.2   │
├───────────────────────────┼──────────┤
│ max                       │ 5415.2   │
├───────────────────────────┼──────────┤
│ Recordings available:     │ 133      │
├───────────────────────────┼──────────┤
│ Features available:       │ 0        │
├───────────────────────────┼──────────┤
│ Supervisions available:   │ 102222   │
╘═══════════════════════════╧══════════╛
Speech duration statistics:
╒══════════════════════════════╤══════════╤═══════════════════════════╕
│ Total speech duration        │ 64:59:51 │ 81.88% of recording       │
├──────────────────────────────┼──────────┼───────────────────────────┤
│ Total speaking time duration │ 74:33:09 │ 93.91% of recording       │
├──────────────────────────────┼──────────┼───────────────────────────┤
│ Total silence duration       │ 14:23:12 │ 18.12% of recording       │
├──────────────────────────────┼──────────┼───────────────────────────┤
│ Single-speaker duration      │ 56:18:24 │ 70.93% (86.63% of speech) │
├──────────────────────────────┼──────────┼───────────────────────────┤
│ Overlapped speech duration   │ 08:41:28 │ 10.95% (13.37% of speech) │
╘══════════════════════════════╧══════════╧═══════════════════════════╛
Speech duration statistics by number of speakers:
╒══════════════════════╤═══════════════════════╤════════════════════════════╤═══════════════╤══════════════════════╕
│ Number of speakers   │ Duration (hh:mm:ss)   │ Speaking time (hh:mm:ss)   │ % of speech   │ % of speaking time   │
╞══════════════════════╪═══════════════════════╪════════════════════════════╪═══════════════╪══════════════════════╡
│ 1                    │ 56:18:24              │ 56:18:24                   │ 86.63%        │ 75.53%               │
├──────────────────────┼───────────────────────┼────────────────────────────┼───────────────┼──────────────────────┤
│ 2                    │ 07:51:44              │ 15:43:28                   │ 12.10%        │ 21.09%               │
├──────────────────────┼───────────────────────┼────────────────────────────┼───────────────┼──────────────────────┤
│ 3                    │ 00:47:36              │ 02:22:47                   │ 1.22%         │ 3.19%                │
├──────────────────────┼───────────────────────┼────────────────────────────┼───────────────┼──────────────────────┤
│ 4                    │ 00:02:08              │ 00:08:31                   │ 0.05%         │ 0.19%                │
├──────────────────────┼───────────────────────┼────────────────────────────┼───────────────┼──────────────────────┤
│ Total                │ 64:59:51              │ 74:33:09                   │ 100.00%       │ 100.00%              │
╘══════════════════════╧═══════════════════════╧════════════════════════════╧═══════════════╧══════════════════════╛
```
In general, we differentiate "speech time" from "speaking time" even when `full` is False.

2. Fix an issue in `trim_to_unsupervised_segments()`. I think the current implementation did not work when overlapping supervisions were present in the cut.

This adds a dependency on the [tabulate](https://github.com/astanin/python-tabulate) package, but it is pretty light-weight so maybe it is okay to add it?