### PR TITLE
AliMeeting recipe enhancement

### DIFF
--- a/lhotse/bin/modes/recipes/ali_meeting.py
+++ b/lhotse/bin/modes/recipes/ali_meeting.py
@@ -13,9 +13,19 @@ __all__ = ["ali_meeting"]
 @click.option(
     "--mic", type=click.Choice(["near", "far", "ihm", "sdm", "mdm"]), default="far"
 )
-def ali_meeting(corpus_dir: Pathlike, output_dir: Pathlike, mic: str):
+@click.option(
+    "--normalize-text",
+    type=click.Choice(["none", "m2met"], case_sensitive=False),
+    default="none",
+    help="Type of text normalization to apply (M2MeT style, by default)",
+)
+def ali_meeting(
+    corpus_dir: Pathlike, output_dir: Pathlike, mic: str, normalize_text: str
+):
     """AliMeeting data preparation."""
-    prepare_ali_meeting(corpus_dir, output_dir=output_dir, mic=mic)
+    prepare_ali_meeting(
+        corpus_dir, output_dir=output_dir, mic=mic, normalize_text=normalize_text
+    )
 
 
 @download.command(context_settings=dict(show_default=True))

--- a/lhotse/bin/modes/recipes/ali_meeting.py
+++ b/lhotse/bin/modes/recipes/ali_meeting.py
@@ -17,7 +17,7 @@ __all__ = ["ali_meeting"]
     "--normalize-text",
     type=click.Choice(["none", "m2met"], case_sensitive=False),
     default="none",
-    help="Type of text normalization to apply (M2MeT style, by default)",
+    help="Type of text normalization to apply (M2MeT style is from the official challenge)",
 )
 def ali_meeting(
     corpus_dir: Pathlike, output_dir: Pathlike, mic: str, normalize_text: str

--- a/lhotse/bin/modes/recipes/ali_meeting.py
+++ b/lhotse/bin/modes/recipes/ali_meeting.py
@@ -19,12 +19,26 @@ __all__ = ["ali_meeting"]
     default="none",
     help="Type of text normalization to apply (M2MeT style is from the official challenge)",
 )
+@click.option(
+    "--save-mono",
+    is_flag=True,
+    default=False,
+    help="If True and `mic` is sdm, extract first channel and save as new recording.",
+)
 def ali_meeting(
-    corpus_dir: Pathlike, output_dir: Pathlike, mic: str, normalize_text: str
+    corpus_dir: Pathlike,
+    output_dir: Pathlike,
+    mic: str,
+    normalize_text: str,
+    save_mono: bool,
 ):
     """AliMeeting data preparation."""
     prepare_ali_meeting(
-        corpus_dir, output_dir=output_dir, mic=mic, normalize_text=normalize_text
+        corpus_dir,
+        output_dir=output_dir,
+        mic=mic,
+        normalize_text=normalize_text,
+        save_mono=save_mono,
     )
 
 

--- a/lhotse/recipes/ali_meeting.py
+++ b/lhotse/recipes/ali_meeting.py
@@ -26,6 +26,7 @@ from tqdm import tqdm
 
 from lhotse import fix_manifests, validate_recordings_and_supervisions
 from lhotse.audio import AudioSource, Recording, RecordingSet
+from lhotse.recipes.utils import normalize_text_alimeeting
 from lhotse.supervision import SupervisionSegment, SupervisionSet
 from lhotse.utils import Pathlike, is_module_available, urlretrieve_progress
 
@@ -69,6 +70,7 @@ def prepare_ali_meeting(
     corpus_dir: Pathlike,
     output_dir: Optional[Pathlike] = None,
     mic: Optional[str] = "far",
+    normalize_text: str = "none",
 ) -> Dict[str, Dict[str, Union[RecordingSet, SupervisionSet]]]:
     """
     Returns the manifests which consist of the Recordings and Supervisions
@@ -77,6 +79,7 @@ def prepare_ali_meeting(
     :param mic: str, "near" or "far", specifies whether to prepare the near-field or far-field data. May
         also specify "ihm", "sdm", "mdm" (similar to AMI recipe), where "ihm" and "mdm" are the same as "near"
         and "far" respectively, and "sdm" is the same as "far" with a single channel.
+    :param normalize_text: str, the text normalization method, "m2met" or "none".
     :return: a Dict whose key is the dataset part, and the value is Dicts with the keys 'recordings' and 'supervisions'.
     """
     if not is_module_available("textgrid"):
@@ -167,7 +170,9 @@ def prepare_ali_meeting(
                             language="Chinese",
                             speaker=spk_id,
                             gender=gender,
-                            text=text.strip(),
+                            text=normalize_text_alimeeting(
+                                text.strip(), normalize=normalize_text
+                            ),
                         )
                         supervisions.append(segment)
 

--- a/lhotse/recipes/utils.py
+++ b/lhotse/recipes/utils.py
@@ -85,6 +85,42 @@ def manifests_exist(
     return True
 
 
+def normalize_text_alimeeting(text: str, normalize: str = "m2met") -> str:
+    """
+    Text normalization similar to M2MeT challenge baseline.
+    See: https://github.com/yufan-aslp/AliMeeting/blob/main/asr/local/text_normalize.pl
+    """
+    if normalize == "none":
+        return text
+    elif normalize == "m2met":
+        import re
+
+        text = text.replace("<sil>", "")
+        text = text.replace("<%>", "")
+        text = text.replace("<->", "")
+        text = text.replace("<$>", "")
+        text = text.replace("<#>", "")
+        text = text.replace("<_>", "")
+        text = text.replace("<space>", "")
+        text = text.replace("`", "")
+        text = text.replace("&", "")
+        text = text.replace(",", "")
+        if re.search("[a-zA-Z]", text):
+            text = text.upper()
+        text = text.replace("Ａ", "A")
+        text = text.replace("ａ", "A")
+        text = text.replace("ｂ", "B")
+        text = text.replace("ｃ", "C")
+        text = text.replace("ｋ", "K")
+        text = text.replace("ｔ", "T")
+        text = text.replace("，", "")
+        text = text.replace("丶", "")
+        text = text.replace("。", "")
+        text = text.replace("、", "")
+        text = text.replace("？", "")
+        return text
+
+
 def normalize_text_ami(text: str, normalize: str = "upper") -> str:
     """
     Text normalization similar to Kaldi's AMI recipe.


### PR DESCRIPTION
This PR makes 2 enhancements to the AliMeeting recipe:
1. Add text normalization based on the original M2MeT challenge baseline.
2. Add option to save single-channel recording when preparing "SDM" mic. This can address the slow feature extraction issue due to loading 8-channel recordings every time (see https://github.com/lhotse-speech/lhotse/issues/911).