### PR TITLE
Downloading the AMI dataset using CLI will trigger TypeError

### DIFF
--- a/lhotse/bin/modes/recipes/ami.py
+++ b/lhotse/bin/modes/recipes/ami.py
@@ -108,7 +108,7 @@ def ami(
     """AMI download."""
     download_ami(
         target_dir,
-        annotations_dir=annotations,
+        annotations=annotations,
         mic=mic,
         url=url,
         force_download=force_download,


### PR DESCRIPTION
Using the wrong keyword when calling the "download_ami" function triggers this error:

```
TypeError: download_ami() got an unexpected keyword argument 'annotations_dir'
```