### PR TITLE
Add room and source RNG seeds option for `reverb_rir`

### DIFF
--- a/lhotse/audio.py
+++ b/lhotse/audio.py
@@ -718,6 +718,7 @@ class Recording:
     def reverb_rir(
         self,
         rir_recording: Optional["Recording"] = None,
+        rir_generator: Optional[Callable] = None,
         normalize_output: bool = True,
         early_only: bool = False,
         affix_id: bool = True,
@@ -729,6 +730,7 @@ class Recording:
         generate an RIR using a fast random generator (https://arxiv.org/abs/2208.04101).
 
         :param rir_recording: The impulse response to be used.
+        :param rir_generator: A callable that generates an impulse response.
         :param normalize_output: When true, output will be normalized to have energy as input.
         :param early_only: When true, only the early reflections (first 50 ms) will be used.
         :param affix_id: When true, we will modify the ``Recording.id`` field
@@ -1117,6 +1119,7 @@ class RecordingSet(Serializable, AlgorithmMixin):
     def reverb_rir(
         self,
         rir_recordings: Optional["RecordingSet"] = None,
+        rir_generator: Optional[Callable] = None,
         normalize_output: bool = True,
         early_only: bool = False,
         affix_id: bool = True,
@@ -1128,6 +1131,7 @@ class RecordingSet(Serializable, AlgorithmMixin):
         generate a set of impulse responses using a fast random generator (https://arxiv.org/abs/2208.04101).
 
         :param rir_recordings: The impulse responses to be used.
+        :param rir_generator: A function that generates a random impulse response.
         :param normalize_output: When true, output will be normalized to have energy as input.
         :param early_only: When true, only the early reflections (first 50 ms) will be used.
         :param affix_id: When true, we will modify the ``Recording.id`` field
@@ -1141,6 +1145,7 @@ class RecordingSet(Serializable, AlgorithmMixin):
         return RecordingSet.from_recordings(
             r.reverb_rir(
                 rir_recording=random.choice(rir_recordings) if rir_recordings else None,
+                rir_generator=rir_generator,
                 normalize_output=normalize_output,
                 early_only=early_only,
                 affix_id=affix_id,

--- a/lhotse/audio.py
+++ b/lhotse/audio.py
@@ -718,11 +718,12 @@ class Recording:
     def reverb_rir(
         self,
         rir_recording: Optional["Recording"] = None,
-        rir_generator: Optional[Callable] = None,
         normalize_output: bool = True,
         early_only: bool = False,
         affix_id: bool = True,
         rir_channels: Optional[List[int]] = None,
+        room_rng_seed: Optional[int] = None,
+        source_rng_seed: Optional[int] = None,
     ) -> "Recording":
         """
         Return a new ``Recording`` that will lazily apply reverberation based on provided
@@ -730,7 +731,6 @@ class Recording:
         generate an RIR using a fast random generator (https://arxiv.org/abs/2208.04101).
 
         :param rir_recording: The impulse response to be used.
-        :param rir_generator: A callable that generates an impulse response.
         :param normalize_output: When true, output will be normalized to have energy as input.
         :param early_only: When true, only the early reflections (first 50 ms) will be used.
         :param affix_id: When true, we will modify the ``Recording.id`` field
@@ -738,6 +738,8 @@ class Recording:
         :param rir_channels: The channels of the impulse response to be used (in case of multi-channel
             impulse responses). By default, only the first channel is used. If no RIR is
             provided, we will generate one with as many channels as this argument specifies.
+        :param room_rng_seed: The seed to be used for the room configuration.
+        :param source_rng_seed: The seed to be used for the source position.
         :return: the perturbed ``Recording``.
         """
 
@@ -757,6 +759,17 @@ class Recording:
             # Case 2
             new_channel_ids = list(range(len(rir_channels)))
 
+        if rir_recording is None:
+            from lhotse.augmentation.utils import FastRandomRIRGenerator
+
+            rir_generator = FastRandomRIRGenerator(
+                sr=self.sampling_rate,
+                room_seed=room_rng_seed,
+                source_seed=source_rng_seed,
+            )
+        else:
+            rir_generator = None
+
         transforms = self.transforms.copy() if self.transforms is not None else []
         transforms.append(
             ReverbWithImpulseResponse(
@@ -764,6 +777,7 @@ class Recording:
                 normalize_output=normalize_output,
                 early_only=early_only,
                 rir_channels=rir_channels if rir_channels is not None else [0],
+                rir_generator=rir_generator,
             ).to_dict()
         )
         return fastcopy(
@@ -1119,11 +1133,12 @@ class RecordingSet(Serializable, AlgorithmMixin):
     def reverb_rir(
         self,
         rir_recordings: Optional["RecordingSet"] = None,
-        rir_generator: Optional[Callable] = None,
         normalize_output: bool = True,
         early_only: bool = False,
         affix_id: bool = True,
         rir_channels: List[int] = [0],
+        room_rng_seed: Optional[int] = None,
+        source_rng_seed: Optional[int] = None,
     ) -> "RecordingSet":
         """
         Return a new ``RecordingSet`` that will lazily apply reverberation based on provided
@@ -1131,7 +1146,6 @@ class RecordingSet(Serializable, AlgorithmMixin):
         generate a set of impulse responses using a fast random generator (https://arxiv.org/abs/2208.04101).
 
         :param rir_recordings: The impulse responses to be used.
-        :param rir_generator: A function that generates a random impulse response.
         :param normalize_output: When true, output will be normalized to have energy as input.
         :param early_only: When true, only the early reflections (first 50 ms) will be used.
         :param affix_id: When true, we will modify the ``Recording.id`` field
@@ -1139,17 +1153,20 @@ class RecordingSet(Serializable, AlgorithmMixin):
         :param rir_channels: The channels to be used for the RIRs (if multi-channel). Uses first
             channel by default. If no RIR is provided, we will generate one with as many channels
             as this argument specifies.
+        :param room_rng_seed: The seed to be used for the room configuration.
+        :param source_rng_seed: The seed to be used for the source positions.
         :return: a ``RecordingSet`` containing the perturbed ``Recording`` objects.
         """
         rir_recordings = list(rir_recordings)
         return RecordingSet.from_recordings(
             r.reverb_rir(
                 rir_recording=random.choice(rir_recordings) if rir_recordings else None,
-                rir_generator=rir_generator,
                 normalize_output=normalize_output,
                 early_only=early_only,
                 affix_id=affix_id,
                 rir_channels=rir_channels,
+                room_rng_seed=room_rng_seed,
+                source_rng_seed=source_rng_seed,
             )
             for r in self
         )

--- a/lhotse/augmentation/__init__.py
+++ b/lhotse/augmentation/__init__.py
@@ -1,5 +1,5 @@
 from .common import AugmentFn
 from .torchaudio import *
 from .transform import AudioTransform
-from .utils import convolve1d, generate_fast_random_rir
+from .utils import FastRandomRIRGenerator, convolve1d
 from .wpe import DereverbWPE, dereverb_wpe_torch

--- a/lhotse/augmentation/torchaudio.py
+++ b/lhotse/augmentation/torchaudio.py
@@ -348,6 +348,10 @@ class ReverbWithImpulseResponse(AudioTransform):
             # Pass a shallow copy of the RIR dict since `from_dict()` pops the `sources` key.
             self.rir = Recording.from_dict(self.rir.copy())
 
+        assert (
+            self.rir is not None or self.rir_generator is not None
+        ), "Either `rir` or `rir_generator` must be provided."
+
         if self.rir is not None:
             assert all(
                 c < self.rir.num_channels for c in self.rir_channels
@@ -391,8 +395,6 @@ class ReverbWithImpulseResponse(AudioTransform):
 
         # Generate a random RIR if not provided.
         if self.rir is None:
-            if self.rir_generator is None:
-                self.rir_generator = FastRandomRIRGenerator(sr=sampling_rate)
             rir_ = self.rir_generator(nsource=1)
         else:
             rir_ = (

--- a/lhotse/augmentation/utils.py
+++ b/lhotse/augmentation/utils.py
@@ -85,7 +85,8 @@ class FastRandomRIRGenerator:
         a: float = -2.0,
         b: float = 2.0,
         tau: float = 0.2,
-        direct_dist: Optional[torch.FloatTensor] = None,
+        room_seed: Optional[int] = None,
+        source_seed: Optional[int] = None,
     ):
         """
         The fast random approximation of room impulse response (FRA-RIR) method.
@@ -95,21 +96,26 @@ class FastRandomRIRGenerator:
         :param alpha: controlling the probability distribution to sample the distance of the virtual sound sources from. Default: 0.25.
         :param a, b: controlling the random pertubation added to each virtual sound source. Default: -2, 2.
         :param tau: controlling the relationship between the distance and the number of reflections of each virtual sound source. Default: 0.25.
-        :param direct_dist: the distance between the virtual sound sources and the receiver. Default: None.
+        :param room_seed: random seed for room configuration.
+        :param source_seed: random seed for virtual sound sources.
         """
         self.sr = sr
         self.direct_range = direct_range
+        self.max_T60 = max_T60
         self.alpha = alpha
         self.a = a
         self.b = b
         self.tau = tau
-        self.direct_dist = direct_dist
-
-        # sample T60 of the room
-        self.T60 = torch.FloatTensor(1).uniform_(0.1, max_T60)[0].data
-
-        # sample room-related statistics for calculating the reflection coefficient R
-        self.R = torch.FloatTensor(1).uniform_(0.1, 1.2)[0].data
+        self.room_rng = (
+            np.random.default_rng(room_seed)
+            if source_seed is not None
+            else np.random.default_rng()
+        )
+        self.source_rng = (
+            np.random.default_rng(source_seed)
+            if source_seed is not None
+            else np.random.default_rng()
+        )
 
     def __call__(self, nsource: int = 1) -> np.ndarray:
         """
@@ -130,11 +136,17 @@ class FastRandomRIRGenerator:
 
         eps = np.finfo(np.float16).eps
 
+        # sample T60 of the room
+        T60 = torch.from_numpy(self.room_rng.uniform(0.1, self.max_T60, size=(1,)))[
+            0
+        ].data
+
+        # sample room-related statistics for calculating the reflection coefficient R
+        R = torch.from_numpy(self.room_rng.uniform(0.1, 1.2, size=(1,)))[0].data
+
         # sample distance between the sound sources and the receiver (d_0) if not given
-        direct_dist = (
-            torch.FloatTensor(nsource).uniform_(0.2, 12)
-            if self.direct_dist is None
-            else self.direct_dist
+        direct_dist = torch.from_numpy(
+            self.source_rng.uniform(0.2, 12.0, size=(nsource,))
         )
 
         # number of virtual sound sources
@@ -147,14 +159,14 @@ class FastRandomRIRGenerator:
         direct_idx = torch.ceil(direct_dist * sample_sr / velocity).long()
 
         # length of the RIR filter based on the sampled T60
-        rir_length = int(np.ceil(sample_sr * self.T60))
+        rir_length = int(np.ceil(sample_sr * T60))
 
         # calculate the reflection coefficient based on the Eyring's empirical equation
-        reflect_coef = (1 - (1 - torch.exp(-0.16 * self.R / self.T60)).pow(2)).sqrt()
+        reflect_coef = (1 - (1 - torch.exp(-0.16 * R / T60)).pow(2)).sqrt()
 
         # randomly sample the propagation distance for all the virtual sound sources
         dist_range = [
-            torch.linspace(1.0, velocity * self.T60 / direct_dist[i] - 1, image)
+            torch.linspace(1.0, velocity * T60 / direct_dist[i] - 1, image)
             for i in range(nsource)
         ]
         # a simple quadratic function
@@ -172,18 +184,18 @@ class FastRandomRIRGenerator:
         # sample the number of reflections (can be nonintegers)
         # calculate the maximum number of reflections
         reflect_max = (
-            torch.log10(velocity * self.T60) - torch.log10(direct_dist) - 3
+            torch.log10(velocity * T60) - torch.log10(direct_dist) - 3
         ) / torch.log10(reflect_coef + eps)
         # calculate the number of reflections based on the assumption that
         # virtual sound sources which have longer propagation distances may reflect more frequently
-        reflect_ratio = (dist / (velocity * self.T60)).pow(2) * (
+        reflect_ratio = (dist / (velocity * T60)).pow(2) * (
             reflect_max.view(nsource, -1) - 1
         ) + 1
         # add a random pertubation based on the assumption that
         # virtual sound sources which have similar propagation distances can have different routes and reflection patterns
-        reflect_pertub = torch.FloatTensor(nsource, image).uniform_(
-            self.a, self.b
-        ) * dist_ratio.pow(self.tau)
+        reflect_pertub = torch.from_numpy(
+            self.source_rng.uniform(self.a, self.b, size=(nsource, image))
+        ) * (dist_ratio.pow(self.tau))
         # all virtual sound sources should reflect for at least once
         reflect_ratio = torch.maximum(reflect_ratio + reflect_pertub, torch.ones(1))
 

--- a/lhotse/augmentation/utils.py
+++ b/lhotse/augmentation/utils.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 import numpy as np
 import torch
@@ -85,6 +85,7 @@ class FastRandomRIRGenerator:
         a: float = -2.0,
         b: float = 2.0,
         tau: float = 0.2,
+        direct_dist: Optional[torch.FloatTensor] = None,
     ):
         """
         The fast random approximation of room impulse response (FRA-RIR) method.
@@ -94,6 +95,7 @@ class FastRandomRIRGenerator:
         :param alpha: controlling the probability distribution to sample the distance of the virtual sound sources from. Default: 0.25.
         :param a, b: controlling the random pertubation added to each virtual sound source. Default: -2, 2.
         :param tau: controlling the relationship between the distance and the number of reflections of each virtual sound source. Default: 0.25.
+        :param direct_dist: the distance between the virtual sound sources and the receiver. Default: None.
         """
         self.sr = sr
         self.direct_range = direct_range
@@ -101,6 +103,7 @@ class FastRandomRIRGenerator:
         self.a = a
         self.b = b
         self.tau = tau
+        self.direct_dist = direct_dist
 
         # sample T60 of the room
         self.T60 = torch.FloatTensor(1).uniform_(0.1, max_T60)[0].data
@@ -127,8 +130,12 @@ class FastRandomRIRGenerator:
 
         eps = np.finfo(np.float16).eps
 
-        # sample distance between the sound sources and the receiver (d_0)
-        direct_dist = torch.FloatTensor(nsource).uniform_(0.2, 12)
+        # sample distance between the sound sources and the receiver (d_0) if not given
+        direct_dist = (
+            torch.FloatTensor(nsource).uniform_(0.2, 12)
+            if self.direct_dist is None
+            else self.direct_dist
+        )
 
         # number of virtual sound sources
         image = self.sr * 2

--- a/lhotse/augmentation/utils.py
+++ b/lhotse/augmentation/utils.py
@@ -75,134 +75,145 @@ def convolve1d(signal: torch.Tensor, kernel: torch.Tensor) -> torch.Tensor:
 
 
 # The following is based on: https://github.com/yluo42/FRA-RIR/blob/main/FRA-RIR.py
-def generate_fast_random_rir(
-    nsource: int = 1,
-    sr: int = 16000,
-    direct_range: List = [-6, 50],
-    max_T60: float = 0.8,
-    alpha: float = 0.25,
-    a: float = -2.0,
-    b: float = 2.0,
-    tau: float = 0.2,
-) -> np.ndarray:
-    """
-    The fast random approximation of room impulse response (FRA-RIR) method.
-    :param nsource: number of sources (RIR filters) to simulate. Default: 1.
-    :param sr: target sample rate. Default: 16000.
-    :param direct_range: the context range (at milliseconds) at the first peak of the RIR filter to define the direct-path RIR. Default: [-6, 50] ms.
-    :param max_T60: the maximum range of T60 to sample from. Default: 0.8.
-    :param alpha: controlling the probability distribution to sample the distance of the virtual sound sources from. Default: 0.25.
-    :param a, b: controlling the random pertubation added to each virtual sound source. Default: -2, 2.
-    :param tau: controlling the relationship between the distance and the number of reflections of each virtual sound source. Default: 0.25.
-    :return: simulated RIR filter for all sources, shape: (nsource, nsample)
-    """
-    from torchaudio.functional import highpass_biquad
+class FastRandomRIRGenerator:
+    def __init__(
+        self,
+        sr: int = 16000,
+        direct_range: List = [-6, 50],
+        max_T60: float = 0.8,
+        alpha: float = 0.25,
+        a: float = -2.0,
+        b: float = 2.0,
+        tau: float = 0.2,
+    ):
+        """
+        The fast random approximation of room impulse response (FRA-RIR) method.
+        :param sr: target sample rate. Default: 16000.
+        :param direct_range: the context range (at milliseconds) at the first peak of the RIR filter to define the direct-path RIR. Default: [-6, 50] ms.
+        :param max_T60: the maximum range of T60 to sample from. Default: 0.8.
+        :param alpha: controlling the probability distribution to sample the distance of the virtual sound sources from. Default: 0.25.
+        :param a, b: controlling the random pertubation added to each virtual sound source. Default: -2, 2.
+        :param tau: controlling the relationship between the distance and the number of reflections of each virtual sound source. Default: 0.25.
+        """
+        self.sr = sr
+        self.direct_range = direct_range
+        self.alpha = alpha
+        self.a = a
+        self.b = b
+        self.tau = tau
 
-    from lhotse.augmentation.torchaudio import get_or_create_resampler
+        # sample T60 of the room
+        self.T60 = torch.FloatTensor(1).uniform_(0.1, max_T60)[0].data
 
-    # the sample rate at which the original RIR filter is generated
-    ratio = 64
-    sample_sr = sr * ratio
+        # sample room-related statistics for calculating the reflection coefficient R
+        self.R = torch.FloatTensor(1).uniform_(0.1, 1.2)[0].data
 
-    # two resampling operations
-    resample1 = get_or_create_resampler(sample_sr, sample_sr // int(np.sqrt(ratio)))
-    resample2 = get_or_create_resampler(sample_sr // int(np.sqrt(ratio)), sr)
+    def __call__(self, nsource: int = 1) -> np.ndarray:
+        """
+        :param nsource: number of sources (RIR filters) to simulate. Default: 1.
+        :return: simulated RIR filter for all sources, shape: (nsource, nsample)
+        """
+        from torchaudio.functional import highpass_biquad
 
-    eps = np.finfo(np.float16).eps
+        from lhotse.augmentation.torchaudio import get_or_create_resampler
 
-    # sample distance between the sound sources and the receiver (d_0)
-    direct_dist = torch.FloatTensor(nsource).uniform_(0.2, 12)
+        # the sample rate at which the original RIR filter is generated
+        ratio = 64
+        sample_sr = self.sr * ratio
 
-    # sample T60 of the room
-    T60 = torch.FloatTensor(1).uniform_(0.1, max_T60)[0].data
+        # two resampling operations
+        resample1 = get_or_create_resampler(sample_sr, sample_sr // int(np.sqrt(ratio)))
+        resample2 = get_or_create_resampler(sample_sr // int(np.sqrt(ratio)), self.sr)
 
-    # sample room-related statistics for calculating the reflection coefficient R
-    R = torch.FloatTensor(1).uniform_(0.1, 1.2)[0].data
+        eps = np.finfo(np.float16).eps
 
-    # number of virtual sound sources
-    image = sr * 2
+        # sample distance between the sound sources and the receiver (d_0)
+        direct_dist = torch.FloatTensor(nsource).uniform_(0.2, 12)
 
-    # sound velocity
-    velocity = 340.0
+        # number of virtual sound sources
+        image = self.sr * 2
 
-    # indices of direct-path signals based on the sampled d_0
-    direct_idx = torch.ceil(direct_dist * sample_sr / velocity).long()
+        # sound velocity
+        velocity = 340.0
 
-    # length of the RIR filter based on the sampled T60
-    rir_length = int(np.ceil(sample_sr * T60))
+        # indices of direct-path signals based on the sampled d_0
+        direct_idx = torch.ceil(direct_dist * sample_sr / velocity).long()
 
-    # calculate the reflection coefficient based on the Eyring's empirical equation
-    reflect_coef = (1 - (1 - torch.exp(-0.16 * R / T60)).pow(2)).sqrt()
+        # length of the RIR filter based on the sampled T60
+        rir_length = int(np.ceil(sample_sr * self.T60))
 
-    # randomly sample the propagation distance for all the virtual sound sources
-    dist_range = [
-        torch.linspace(1.0, velocity * T60 / direct_dist[i] - 1, image)
-        for i in range(nsource)
-    ]
-    # a simple quadratic function
-    dist_prob = torch.linspace(alpha, 1.0, image).pow(2)
-    dist_prob = dist_prob / dist_prob.sum()
-    dist_select_idx = dist_prob.multinomial(
-        num_samples=image * nsource, replacement=True
-    ).view(nsource, image)
-    # the distance is sampled as a ratio between d_0 and each virtual sound sources
-    dist_ratio = torch.stack(
-        [dist_range[i][dist_select_idx[i]] for i in range(nsource)], 0
-    )
-    dist = direct_dist.view(-1, 1) * dist_ratio
+        # calculate the reflection coefficient based on the Eyring's empirical equation
+        reflect_coef = (1 - (1 - torch.exp(-0.16 * self.R / self.T60)).pow(2)).sqrt()
 
-    # sample the number of reflections (can be nonintegers)
-    # calculate the maximum number of reflections
-    reflect_max = (
-        torch.log10(velocity * T60) - torch.log10(direct_dist) - 3
-    ) / torch.log10(reflect_coef + eps)
-    # calculate the number of reflections based on the assumption that
-    # virtual sound sources which have longer propagation distances may reflect more frequently
-    reflect_ratio = (dist / (velocity * T60)).pow(2) * (
-        reflect_max.view(nsource, -1) - 1
-    ) + 1
-    # add a random pertubation based on the assumption that
-    # virtual sound sources which have similar propagation distances can have different routes and reflection patterns
-    reflect_pertub = torch.FloatTensor(nsource, image).uniform_(a, b) * dist_ratio.pow(
-        tau
-    )
-    # all virtual sound sources should reflect for at least once
-    reflect_ratio = torch.maximum(reflect_ratio + reflect_pertub, torch.ones(1))
+        # randomly sample the propagation distance for all the virtual sound sources
+        dist_range = [
+            torch.linspace(1.0, velocity * self.T60 / direct_dist[i] - 1, image)
+            for i in range(nsource)
+        ]
+        # a simple quadratic function
+        dist_prob = torch.linspace(self.alpha, 1.0, image).pow(2)
+        dist_prob = dist_prob / dist_prob.sum()
+        dist_select_idx = dist_prob.multinomial(
+            num_samples=image * nsource, replacement=True
+        ).view(nsource, image)
+        # the distance is sampled as a ratio between d_0 and each virtual sound sources
+        dist_ratio = torch.stack(
+            [dist_range[i][dist_select_idx[i]] for i in range(nsource)], 0
+        )
+        dist = direct_dist.view(-1, 1) * dist_ratio
 
-    # calculate the rescaled dirac comb as RIR filter
-    dist = torch.cat([direct_dist.reshape(-1, 1), dist], 1)
-    reflect_ratio = torch.cat([torch.zeros(nsource, 1), reflect_ratio], 1)
-    rir = torch.zeros(nsource, rir_length)
-    delta_idx = torch.minimum(
-        torch.ceil(dist * sample_sr / velocity), torch.ones(1) * rir_length - 1
-    ).long()
-    delta_decay = reflect_coef.pow(reflect_ratio) / dist
-    for i in range(nsource):
-        rir[i][delta_idx[i]] += delta_decay[i]
+        # sample the number of reflections (can be nonintegers)
+        # calculate the maximum number of reflections
+        reflect_max = (
+            torch.log10(velocity * self.T60) - torch.log10(direct_dist) - 3
+        ) / torch.log10(reflect_coef + eps)
+        # calculate the number of reflections based on the assumption that
+        # virtual sound sources which have longer propagation distances may reflect more frequently
+        reflect_ratio = (dist / (velocity * self.T60)).pow(2) * (
+            reflect_max.view(nsource, -1) - 1
+        ) + 1
+        # add a random pertubation based on the assumption that
+        # virtual sound sources which have similar propagation distances can have different routes and reflection patterns
+        reflect_pertub = torch.FloatTensor(nsource, image).uniform_(
+            self.a, self.b
+        ) * dist_ratio.pow(self.tau)
+        # all virtual sound sources should reflect for at least once
+        reflect_ratio = torch.maximum(reflect_ratio + reflect_pertub, torch.ones(1))
 
-    # a binary mask for direct-path RIR
-    direct_mask = torch.zeros(nsource, rir_length).float()
-    for i in range(nsource):
-        direct_mask[
-            i,
-            max(direct_idx[i] + sample_sr * direct_range[0] // 1000, 0) : min(
-                direct_idx[i] + sample_sr * direct_range[1] // 1000, rir_length
-            ),
-        ] = 1.0
-    rir_direct = rir * direct_mask
+        # calculate the rescaled dirac comb as RIR filter
+        dist = torch.cat([direct_dist.reshape(-1, 1), dist], 1)
+        reflect_ratio = torch.cat([torch.zeros(nsource, 1), reflect_ratio], 1)
+        rir = torch.zeros(nsource, rir_length)
+        delta_idx = torch.minimum(
+            torch.ceil(dist * sample_sr / velocity), torch.ones(1) * rir_length - 1
+        ).long()
+        delta_decay = reflect_coef.pow(reflect_ratio) / dist
+        for i in range(nsource):
+            rir[i][delta_idx[i]] += delta_decay[i]
 
-    # downsample
-    all_rir = torch.stack([rir, rir_direct], 1).view(nsource * 2, -1)
-    rir_downsample = resample1(all_rir)
+        # a binary mask for direct-path RIR
+        direct_mask = torch.zeros(nsource, rir_length).float()
+        for i in range(nsource):
+            direct_mask[
+                i,
+                max(direct_idx[i] + sample_sr * self.direct_range[0] // 1000, 0) : min(
+                    direct_idx[i] + sample_sr * self.direct_range[1] // 1000, rir_length
+                ),
+            ] = 1.0
+        rir_direct = rir * direct_mask
 
-    # apply high-pass filter
-    rir_hp = highpass_biquad(rir_downsample, sample_sr // int(np.sqrt(ratio)), 80.0)
+        # downsample
+        all_rir = torch.stack([rir, rir_direct], 1).view(nsource * 2, -1)
+        rir_downsample = resample1(all_rir)
 
-    # downsample again
-    rir = resample2(rir_hp).float().view(nsource, 2, -1)
+        # apply high-pass filter
+        rir_hp = highpass_biquad(rir_downsample, sample_sr // int(np.sqrt(ratio)), 80.0)
 
-    # RIR filter and direct-path RIR filter at target sample rate
-    rir_filter = rir[:, 0]  # nsource, nsample
+        # downsample again
+        rir = resample2(rir_hp).float().view(nsource, 2, -1)
 
-    # convert to numpy array
-    return rir_filter.numpy()
+        # RIR filter and direct-path RIR filter at target sample rate
+        rir_filter = rir[:, 0]  # nsource, nsample
+
+        # convert to numpy array
+        return rir_filter.numpy()

--- a/lhotse/cut/data.py
+++ b/lhotse/cut/data.py
@@ -911,11 +911,12 @@ class DataCut(Cut, metaclass=ABCMeta):
     def reverb_rir(
         self,
         rir_recording: Optional["Recording"] = None,
-        rng_seed: Optional[int] = None,
         normalize_output: bool = True,
         early_only: bool = False,
         affix_id: bool = True,
         rir_channels: List[int] = [0],
+        room_rng_seed: Optional[int] = None,
+        source_rng_seed: Optional[int] = None,
     ) -> "DataCut":
         ...
 

--- a/lhotse/cut/data.py
+++ b/lhotse/cut/data.py
@@ -911,6 +911,7 @@ class DataCut(Cut, metaclass=ABCMeta):
     def reverb_rir(
         self,
         rir_recording: Optional["Recording"] = None,
+        rng_seed: Optional[int] = None,
         normalize_output: bool = True,
         early_only: bool = False,
         affix_id: bool = True,

--- a/lhotse/cut/mono.py
+++ b/lhotse/cut/mono.py
@@ -84,6 +84,7 @@ class MonoCut(DataCut):
         early_only: bool = False,
         affix_id: bool = True,
         rir_channels: List[int] = [0],
+        rir_generator: Optional[Callable] = None,
     ) -> DataCut:
         """
         Return a new ``DataCut`` that will convolve the audio with the provided impulse response.
@@ -102,6 +103,7 @@ class MonoCut(DataCut):
             by affixing it with "_rvb".
         :param rir_channels: The channels of the impulse response to use. First channel is used by default.
             If multiple channels are specified, this will produce a MultiCut instead of a MonoCut.
+        :param rir_generator: A callable that generates a random impulse response.
         :return: a modified copy of the current ``MonoCut``.
         """
         # Pre-conditions
@@ -124,10 +126,16 @@ class MonoCut(DataCut):
             # Set rir_channels to 0 since we can only generate a single-channel RIR.
             rir_channels = [0]
 
+            if rir_generator is None:
+                from lhotse.augmentation.utils import FastRandomRIRGenerator
+
+                rir_generator = FastRandomRIRGenerator(sr=self.sampling_rate)
+
         if len(rir_channels) == 1:
             # reverberation will return a MonoCut
             recording_rvb = self.recording.reverb_rir(
                 rir_recording=rir_recording,
+                rir_generator=rir_generator,
                 normalize_output=normalize_output,
                 early_only=early_only,
                 affix_id=affix_id,
@@ -155,6 +163,7 @@ class MonoCut(DataCut):
             # with a single channel of the RIR
             recording_rvb = self.recording.reverb_rir(
                 rir_recording=rir_recording,
+                rir_generator=rir_generator,
                 normalize_output=normalize_output,
                 early_only=early_only,
                 affix_id=affix_id,

--- a/lhotse/cut/multi.py
+++ b/lhotse/cut/multi.py
@@ -130,6 +130,7 @@ class MultiCut(DataCut):
     def reverb_rir(
         self,
         rir_recording: Optional["Recording"] = None,
+        rir_generator: Optional[Callable] = None,
         normalize_output: bool = True,
         early_only: bool = False,
         affix_id: bool = True,
@@ -145,6 +146,7 @@ class MultiCut(DataCut):
         At the moment we do not support simulation of multi-channel impulse responses.
 
         :param rir_recording: The impulse response to use for convolving.
+        :param rir_generator: A callable that generates a random impulse response.
         :param normalize_output: When true, output will be normalized to have energy as input.
         :param early_only: When true, only the early reflections (first 50 ms) will be used.
         :param affix_id: When true, we will modify the ``MonoCut.id`` field
@@ -171,6 +173,11 @@ class MultiCut(DataCut):
                 "Please provide an impulse response."
             )
             rir_channels = [0]
+
+            if rir_generator is None:
+                from lhotse.augmentation.utils import FastRandomRIRGenerator
+
+                rir_generator = FastRandomRIRGenerator(sr=self.sampling_rate)
         else:
             assert all(
                 c < rir_recording.num_channels for c in rir_channels
@@ -178,6 +185,7 @@ class MultiCut(DataCut):
 
         recording_rvb = self.recording.reverb_rir(
             rir_recording=rir_recording,
+            rir_generator=rir_generator,
             normalize_output=normalize_output,
             early_only=early_only,
             affix_id=affix_id,

--- a/lhotse/cut/multi.py
+++ b/lhotse/cut/multi.py
@@ -172,12 +172,6 @@ class MultiCut(DataCut):
                 "We do not support reverberation simulation for multi-channel recordings. "
                 "Please provide an impulse response."
             )
-            rir_channels = [0]
-
-            if rir_generator is None:
-                from lhotse.augmentation.utils import FastRandomRIRGenerator
-
-                rir_generator = FastRandomRIRGenerator(sr=self.sampling_rate)
         else:
             assert all(
                 c < rir_recording.num_channels for c in rir_channels

--- a/lhotse/cut/set.py
+++ b/lhotse/cut/set.py
@@ -1508,6 +1508,7 @@ class CutSet(Serializable, AlgorithmMixin):
     def reverb_rir(
         self,
         rir_recordings: Optional["RecordingSet"] = None,
+        rir_generator: Optional[Callable] = None,
         normalize_output: bool = True,
         early_only: bool = False,
         affix_id: bool = True,
@@ -1523,6 +1524,7 @@ class CutSet(Serializable, AlgorithmMixin):
         generator (https://arxiv.org/abs/2208.04101).
 
         :param rir_recordings: RecordingSet containing the room impulse responses.
+        :param rir_generator: A callable that generates a random RIR.
         :param normalize_output: When true, output will be normalized to have energy as input.
         :param early_only: When true, only the early reflections (first 50 ms) will be used.
         :param affix_id: Should we modify the ID (useful if both versions of the same
@@ -1536,6 +1538,7 @@ class CutSet(Serializable, AlgorithmMixin):
         return self.map(
             lambda cut: cut.reverb_rir(
                 rir_recording=random.choice(rir_recordings) if rir_recordings else None,
+                rir_generator=rir_generator,
                 normalize_output=normalize_output,
                 early_only=early_only,
                 affix_id=affix_id,

--- a/lhotse/cut/set.py
+++ b/lhotse/cut/set.py
@@ -1508,7 +1508,6 @@ class CutSet(Serializable, AlgorithmMixin):
     def reverb_rir(
         self,
         rir_recordings: Optional["RecordingSet"] = None,
-        rir_generator: Optional[Callable] = None,
         normalize_output: bool = True,
         early_only: bool = False,
         affix_id: bool = True,
@@ -1524,7 +1523,6 @@ class CutSet(Serializable, AlgorithmMixin):
         generator (https://arxiv.org/abs/2208.04101).
 
         :param rir_recordings: RecordingSet containing the room impulse responses.
-        :param rir_generator: A callable that generates a random RIR.
         :param normalize_output: When true, output will be normalized to have energy as input.
         :param early_only: When true, only the early reflections (first 50 ms) will be used.
         :param affix_id: Should we modify the ID (useful if both versions of the same
@@ -1538,7 +1536,6 @@ class CutSet(Serializable, AlgorithmMixin):
         return self.map(
             lambda cut: cut.reverb_rir(
                 rir_recording=random.choice(rir_recordings) if rir_recordings else None,
-                rir_generator=rir_generator,
                 normalize_output=normalize_output,
                 early_only=early_only,
                 affix_id=affix_id,

--- a/lhotse/utils.py
+++ b/lhotse/utils.py
@@ -1,8 +1,10 @@
 import functools
+import hashlib
 import inspect
 import logging
 import math
 import random
+import sys
 import uuid
 import warnings
 from contextlib import AbstractContextManager, contextmanager
@@ -707,6 +709,13 @@ def to_list(item: Union[Any, Sequence[Any]]) -> List[Any]:
 def to_hashable(item: Any) -> Any:
     """Convert ``item`` to a hashable type if it is not already hashable."""
     return tuple(item) if isinstance(item, list) else item
+
+
+def hash_str_to_int(s: str, max_value: Optional[int] = None) -> int:
+    """Hash a string to an integer in the range [0, max_value)."""
+    if max_value is None:
+        max_value = sys.maxsize
+    return int(hashlib.sha1(s.encode("utf-8")).hexdigest(), 16) % max_value
 
 
 def lens_to_mask(lens: torch.IntTensor) -> torch.Tensor:

--- a/test/augmentation/test_torchaudio.py
+++ b/test/augmentation/test_torchaudio.py
@@ -122,7 +122,11 @@ def test_reverb_does_not_change_num_samples(mono_audio, mono_rir, early_only):
 
 
 def test_reverb_with_fast_rir_does_not_change_num_samples(mono_audio):
-    augment_fn = ReverbWithImpulseResponse(rir=None)
+    from lhotse.augmentation.utils import FastRandomRIRGenerator
+
+    augment_fn = ReverbWithImpulseResponse(
+        rir=None, rir_generator=FastRandomRIRGenerator()
+    )
     for _ in range(10):
         augmented_audio = augment_fn(mono_audio, sampling_rate=SAMPLING_RATE)
         assert augmented_audio.shape == (1, 16000)

--- a/test/cut/test_cut_augmentation.py
+++ b/test/cut/test_cut_augmentation.py
@@ -395,6 +395,43 @@ def test_mixed_cut_start01_reverb_rir(cut_with_supervision_start01, rir):
     )
 
 
+def test_mixed_cut_start01_reverb_rir_with_fast_random(
+    cut_with_supervision_start01, rir
+):
+    mixed_rvb = cut_with_supervision_start01.append(
+        cut_with_supervision_start01
+    ).reverb_rir()
+    assert mixed_rvb.start == 0  # MixedCut always starts at 0
+    assert mixed_rvb.duration == cut_with_supervision_start01.duration * 2
+    assert mixed_rvb.end == cut_with_supervision_start01.duration * 2
+    assert mixed_rvb.num_samples == cut_with_supervision_start01.num_samples * 2
+
+    assert (
+        mixed_rvb.supervisions[0].start
+        == cut_with_supervision_start01.supervisions[0].start
+    )
+    assert (
+        mixed_rvb.supervisions[0].duration
+        == cut_with_supervision_start01.supervisions[0].duration
+    )
+    assert (
+        mixed_rvb.supervisions[0].end
+        == cut_with_supervision_start01.supervisions[0].end
+    )
+    assert mixed_rvb.supervisions[1].start == (
+        cut_with_supervision_start01.duration
+        + cut_with_supervision_start01.supervisions[0].start
+    )
+    assert (
+        mixed_rvb.supervisions[1].duration
+        == cut_with_supervision_start01.supervisions[0].duration
+    )
+    assert mixed_rvb.supervisions[1].end == (
+        cut_with_supervision_start01.duration
+        + cut_with_supervision_start01.supervisions[0].end
+    )
+
+
 @pytest.mark.parametrize(
     "rir_channels, expected_num_tracks",
     [([0], 2), ([0, 1], 2), ([0, 1, 2], None)],


### PR DESCRIPTION
Currently when calling `MixedCut.reverb_rir()` without passing an explicit RIR, each track in the MixedCut would get convolved with an RIR generated with different room configurations. This PR fixes that issue by allowing an `rir_generator` Callable to be passed to the underlying cuts.