### PR TITLE
Remove 'NonPositiveEnergyError' exception when mix audio

### DIFF
--- a/lhotse/audio.py
+++ b/lhotse/audio.py
@@ -1322,7 +1322,7 @@ class AudioMixer:
         """
         if audio.size == 0:
             return  # do nothing for empty arrays
-        
+
         if self.reference_energy <= 0.0:
             return
 
@@ -1341,7 +1341,9 @@ class AudioMixer:
                 # we need to take a square root of the energy ratio.
                 gain = sqrt(target_energy / added_audio_energy)
             else :
-                logging.warning("Non-positive energy audio track to mix, will not scale it with snr.")
+                logging.warning(
+                    "Non-positive energy audio track to mix, will not scale it with snr."
+                )
         self.tracks.append(gain * audio)
         self.offsets.append(num_samples_offset)
         # We cannot mix 2 multi-channel audios with different number of channels.

--- a/lhotse/audio.py
+++ b/lhotse/audio.py
@@ -1340,7 +1340,7 @@ class AudioMixer:
                 # whereas the energy ratio applies to power quantities. To compute the gain correctly,
                 # we need to take a square root of the energy ratio.
                 gain = sqrt(target_energy / added_audio_energy)
-            else :
+            else:
                 logging.warning(
                     "Non-positive energy audio track to mix, will not scale it with snr."
                 )

--- a/lhotse/features/mixer.py
+++ b/lhotse/features/mixer.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Optional
 
 import numpy as np

--- a/lhotse/features/mixer.py
+++ b/lhotse/features/mixer.py
@@ -181,7 +181,7 @@ class FeatureMixer:
             if added_feats_energy > 0.0:
                 target_energy = self.reference_energy * (10.0 ** (-snr / 10))
                 gain = target_energy / added_feats_energy
-            else :
+            else:
                 logging.warning(
                     "Non-positive energy audio feature to mix, will not scale it with snr."
                 )

--- a/lhotse/features/mixer.py
+++ b/lhotse/features/mixer.py
@@ -59,10 +59,6 @@ class FeatureMixer:
             self.reference_energy = feature_extractor.compute_energy(base_feats)
         else:
             self.reference_energy = reference_energy
-        if self.reference_energy <= 0.0:
-            logging.warning(
-                f"To perform mix, energy must be non-zero and non-negative (got {self.reference_energy}), ignore mix operation."
-            )
 
     @property
     def num_features(self):
@@ -121,9 +117,6 @@ class FeatureMixer:
         if len(feats) == 0:
             return  # do nothing for empty arrays
 
-        if self.reference_energy <= 0.0:
-            return
-
         assert offset >= 0.0, "Negative offset in mixing is not supported."
 
         assert (
@@ -175,7 +168,7 @@ class FeatureMixer:
 
         # When SNR is requested, find what gain is needed to satisfy the SNR
         gain = 1.0
-        if snr is not None:
+        if snr is not None and self.reference_energy > 0.0:
             # Compute the added signal energy before it was padded
             added_feats_energy = self.feature_extractor.compute_energy(feats)
             if added_feats_energy > 0.0:

--- a/lhotse/features/mixer.py
+++ b/lhotse/features/mixer.py
@@ -174,9 +174,5 @@ class FeatureMixer:
             if added_feats_energy > 0.0:
                 target_energy = self.reference_energy * (10.0 ** (-snr / 10))
                 gain = target_energy / added_feats_energy
-            else:
-                logging.warning(
-                    "Non-positive energy audio feature to mix, will not scale it with snr."
-                )
         self.tracks.append(feats_to_add)
         self.gains.append(gain)

--- a/lhotse/features/mixer.py
+++ b/lhotse/features/mixer.py
@@ -120,7 +120,7 @@ class FeatureMixer:
         """
         if len(feats) == 0:
             return  # do nothing for empty arrays
-        
+
         if self.reference_energy <= 0.0:
             return
 
@@ -182,6 +182,8 @@ class FeatureMixer:
                 target_energy = self.reference_energy * (10.0 ** (-snr / 10))
                 gain = target_energy / added_feats_energy
             else :
-                logging.warning("Non-positive energy audio feature to mix, will not scale it with snr.")
+                logging.warning(
+                    "Non-positive energy audio feature to mix, will not scale it with snr."
+                )
         self.tracks.append(feats_to_add)
         self.gains.append(gain)

--- a/test/known_issues/test_mixing_zero_energy_cuts.py
+++ b/test/known_issues/test_mixing_zero_energy_cuts.py
@@ -1,5 +1,6 @@
 import pytest
 
+import numpy as np
 from lhotse import CutSet
 from lhotse.dataset.collation import collate_audio
 from lhotse.testing.fixtures import RandomCutTestCase
@@ -13,26 +14,11 @@ class TestMixZeroEnergyCuts(RandomCutTestCase):
         zero_cut = self.with_cut(
             sampling_rate=sr, num_samples=sr, features=False, use_zeroes=True
         )
-        rand_cut = self.with_cut(sampling_rate=sr, num_samples=sr, features=False)
+        rand_cut = self.with_cut(
+            sampling_rate=sr, num_samples=sr, features=False)
 
         mixed = zero_cut.mix(rand_cut, snr=snr)
 
         mix_cut_samples = mixed.load_audio()
         assert mix_cut_samples.shape[1] == sr
-
-    @pytest.mark.parametrize("snr", [None, 10])
-    def test_fault_tolerant_loading_skips_cut(self, snr):
-        sr = 16000
-        zero_cut = self.with_cut(
-            sampling_rate=sr, num_samples=sr, features=False, use_zeroes=True
-        )
-        rand_cut = self.with_cut(sampling_rate=sr, num_samples=sr, features=False)
-
-        zero_mixed = zero_cut.mix(rand_cut, snr=snr)
-        rand_mixed = rand_cut.mix(rand_cut, snr=snr)
-
-        cuts_all = CutSet.from_cuts([zero_mixed, rand_mixed])
-
-        audio, audio_lens, cuts_ok = collate_audio(cuts_all, fault_tolerant=True)
-        assert cuts_ok[0] == zero_mixed
-        assert cuts_ok[1] == rand_mixed
+        assert np.testing.assert_equal(rand_cut.load_audio(), mix_cut_samples)

--- a/test/known_issues/test_mixing_zero_energy_cuts.py
+++ b/test/known_issues/test_mixing_zero_energy_cuts.py
@@ -20,5 +20,4 @@ class TestMixZeroEnergyCuts(RandomCutTestCase):
         mixed = zero_cut.mix(rand_cut, snr=snr)
 
         mix_cut_samples = mixed.load_audio()
-        assert mix_cut_samples.shape[1] == sr
-        assert np.testing.assert_equal(rand_cut.load_audio(), mix_cut_samples)
+        np.testing.assert_equal(rand_cut.load_audio(), mix_cut_samples)

--- a/test/known_issues/test_mixing_zero_energy_cuts.py
+++ b/test/known_issues/test_mixing_zero_energy_cuts.py
@@ -1,6 +1,6 @@
+import numpy as np
 import pytest
 
-import numpy as np
 from lhotse import CutSet
 from lhotse.dataset.collation import collate_audio
 from lhotse.testing.fixtures import RandomCutTestCase
@@ -14,8 +14,7 @@ class TestMixZeroEnergyCuts(RandomCutTestCase):
         zero_cut = self.with_cut(
             sampling_rate=sr, num_samples=sr, features=False, use_zeroes=True
         )
-        rand_cut = self.with_cut(
-            sampling_rate=sr, num_samples=sr, features=False)
+        rand_cut = self.with_cut(sampling_rate=sr, num_samples=sr, features=False)
 
         mixed = zero_cut.mix(rand_cut, snr=snr)
 

--- a/test/known_issues/test_mixing_zero_energy_cuts.py
+++ b/test/known_issues/test_mixing_zero_energy_cuts.py
@@ -17,8 +17,8 @@ class TestMixZeroEnergyCuts(RandomCutTestCase):
 
         mixed = zero_cut.mix(rand_cut, snr=snr)
 
-        with pytest.raises(NonPositiveEnergyError):
-            mixed.load_audio()
+        mix_cut_samples = mixed.load_audio()
+        assert mix_cut_samples.shape[1] == sr
 
     @pytest.mark.parametrize("snr", [None, 10])
     def test_fault_tolerant_loading_skips_cut(self, snr):
@@ -34,5 +34,5 @@ class TestMixZeroEnergyCuts(RandomCutTestCase):
         cuts_all = CutSet.from_cuts([zero_mixed, rand_mixed])
 
         audio, audio_lens, cuts_ok = collate_audio(cuts_all, fault_tolerant=True)
-        assert len(cuts_ok) == 1
-        assert cuts_ok[0] == rand_mixed
+        assert cuts_ok[0] == zero_mixed
+        assert cuts_ok[1] == rand_mixed


### PR DESCRIPTION
Remove 'NonPositiveEnergyError' exception when mix audio, still check if energy<=0.0 but just print warning.
For more detail reason, please see this [issue](https://github.com/lhotse-speech/lhotse/issues/917).