### PR TITLE
Fix serialization for reverb

### DIFF
--- a/lhotse/augmentation/torchaudio.py
+++ b/lhotse/augmentation/torchaudio.py
@@ -337,7 +337,7 @@ class ReverbWithImpulseResponse(AudioTransform):
     normalize_output: bool = True
     early_only: bool = False
     rir_channels: List[int] = field(default_factory=lambda: [0])
-    rir_generator: Optional[Callable] = None
+    rir_generator: Optional[Union[dict, Callable]] = None
 
     RIR_SCALING_FACTOR: float = 0.5**15
 
@@ -356,6 +356,9 @@ class ReverbWithImpulseResponse(AudioTransform):
             assert all(
                 c < self.rir.num_channels for c in self.rir_channels
             ), "Invalid channel index in `rir_channels`"
+
+        if self.rir_generator is not None and isinstance(self.rir_generator, dict):
+            self.rir_generator = FastRandomRIRGenerator(**self.rir_generator)
 
     def __call__(
         self,

--- a/lhotse/augmentation/utils.py
+++ b/lhotse/augmentation/utils.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass, field
 from typing import List, Optional
 
 import numpy as np
@@ -75,45 +76,27 @@ def convolve1d(signal: torch.Tensor, kernel: torch.Tensor) -> torch.Tensor:
 
 
 # The following is based on: https://github.com/yluo42/FRA-RIR/blob/main/FRA-RIR.py
+@dataclass
 class FastRandomRIRGenerator:
-    def __init__(
-        self,
-        sr: int = 16000,
-        direct_range: List = [-6, 50],
-        max_T60: float = 0.8,
-        alpha: float = 0.25,
-        a: float = -2.0,
-        b: float = 2.0,
-        tau: float = 0.2,
-        room_seed: Optional[int] = None,
-        source_seed: Optional[int] = None,
-    ):
-        """
-        The fast random approximation of room impulse response (FRA-RIR) method.
-        :param sr: target sample rate. Default: 16000.
-        :param direct_range: the context range (at milliseconds) at the first peak of the RIR filter to define the direct-path RIR. Default: [-6, 50] ms.
-        :param max_T60: the maximum range of T60 to sample from. Default: 0.8.
-        :param alpha: controlling the probability distribution to sample the distance of the virtual sound sources from. Default: 0.25.
-        :param a, b: controlling the random pertubation added to each virtual sound source. Default: -2, 2.
-        :param tau: controlling the relationship between the distance and the number of reflections of each virtual sound source. Default: 0.25.
-        :param room_seed: random seed for room configuration.
-        :param source_seed: random seed for virtual sound sources.
-        """
-        self.sr = sr
-        self.direct_range = direct_range
-        self.max_T60 = max_T60
-        self.alpha = alpha
-        self.a = a
-        self.b = b
-        self.tau = tau
+    sr: int = 16000
+    direct_range: List = field(default_factory=lambda: [-6, 50])
+    max_T60: float = 0.8
+    alpha: float = 0.25
+    a: float = -2.0
+    b: float = 2.0
+    tau: float = 0.2
+    room_seed: Optional[int] = None
+    source_seed: Optional[int] = None
+
+    def __post_init__(self):
         self.room_rng = (
-            np.random.default_rng(room_seed)
-            if source_seed is not None
+            np.random.default_rng(self.room_seed)
+            if self.room_seed is not None
             else np.random.default_rng()
         )
         self.source_rng = (
-            np.random.default_rng(source_seed)
-            if source_seed is not None
+            np.random.default_rng(self.source_seed)
+            if self.source_seed is not None
             else np.random.default_rng()
         )
 

--- a/lhotse/cut/padding.py
+++ b/lhotse/cut/padding.py
@@ -339,6 +339,8 @@ class PaddingCut(Cut):
         early_only: bool = False,
         affix_id: bool = True,
         rir_channels: List[int] = [0],
+        room_rng_seed: Optional[int] = None,
+        source_rng_seed: Optional[int] = None,
     ) -> "PaddingCut":
         """
         Return a new ``PaddingCut`` that will "mimic" the effect of reverberation with impulse response

--- a/test/augmentation/test_torchaudio.py
+++ b/test/augmentation/test_torchaudio.py
@@ -23,6 +23,7 @@ from lhotse.augmentation import (
     speed,
     volume,
 )
+from lhotse.augmentation.utils import FastRandomRIRGenerator
 
 SAMPLING_RATE = 16000
 
@@ -227,11 +228,17 @@ def test_serialize_deserialize_transform_volume(mono_audio):
 
 
 @pytest.mark.parametrize("recording_to_dict", [True, False])
-def test_serialize_deserialize_transform_reverb(
-    mono_audio, mono_rir, recording_to_dict
-):
+def test_serialize_deserialize_transform_reverb(mono_rir, recording_to_dict):
     mono_rir = mono_rir.to_dict() if recording_to_dict else mono_rir
     reverb_orig = ReverbWithImpulseResponse(rir=mono_rir)
+    data_reverb = reverb_orig.to_dict()
+    reverb = ReverbWithImpulseResponse.from_dict(data_reverb)
+    assert reverb_orig == reverb
+
+
+def test_serialize_deserialize_transform_reverb_without_rir():
+    rir_generator = FastRandomRIRGenerator()
+    reverb_orig = ReverbWithImpulseResponse(rir_generator=rir_generator)
     data_reverb = reverb_orig.to_dict()
     reverb = ReverbWithImpulseResponse.from_dict(data_reverb)
     assert reverb_orig == reverb


### PR DESCRIPTION
The changes in https://github.com/lhotse-speech/lhotse/pull/920 introduced a bug in serialization/deserialization of `ReverbWithImpulseResponse` transform when used with an RIR generator. This PR fixes that bug and adds a test case for it.