### PR TITLE
Remove negative duration segments from whisper

### DIFF
--- a/lhotse/bin/modes/workflows.py
+++ b/lhotse/bin/modes/workflows.py
@@ -57,6 +57,11 @@ def workflows():
     "-d", "--device", default="cpu", help="Device on which to run the inference."
 )
 @click.option("-j", "--jobs", default=1, help="Number of jobs for audio scanning.")
+@click.option(
+    "--force-nonoverlapping/--keep-overlapping",
+    default=False,
+    help="If True, the Whisper segment time-stamps will be processed to make sure they are non-overlapping.",
+)
 def annotate_with_whisper(
     out_cuts: str,
     recordings_manifest: Optional[str],
@@ -67,6 +72,7 @@ def annotate_with_whisper(
     language: Optional[str],
     device: str,
     jobs: int,
+    force_nonoverlapping: bool,
 ):
     """
     Use OpenAI Whisper model to annotate either RECORDINGS_MANIFEST, RECORDINGS_DIR, or CUTS_MANIFEST.
@@ -101,6 +107,7 @@ def annotate_with_whisper(
                 language=language,
                 model_name=model_name,
                 device=device,
+                force_nonoverlapping=force_nonoverlapping,
             ),
             total=len(manifest),
             desc="Annotating with Whisper",

--- a/lhotse/qa.py
+++ b/lhotse/qa.py
@@ -190,7 +190,7 @@ def trim_supervisions_to_recordings(
             continue
         if s.end > end:
             trimmed += 1
-            s = s.trim(recordings[s.recording_id].duration)
+            s = s.trim(end=end)
         sups.append(s)
     if verbose and removed:
         logging.warning(

--- a/lhotse/workflows/forced_alignment.py
+++ b/lhotse/workflows/forced_alignment.py
@@ -57,10 +57,6 @@ def align_with_torchaudio(
     discard_symbols = _make_discard_symbols_regex(labels)
 
     for cut in cuts:
-        assert not cut.has_overlapping_supervisions, (
-            f"We don't support forced alignment of cuts with overlapping supervisions "
-            f"(cut ID: '{cut.id}')"
-        )
 
         for idx, subcut in enumerate(cut.trim_to_supervisions(keep_overlapping=False)):
             sup = subcut.supervisions[0]


### PR DESCRIPTION
This PR addresses https://github.com/lhotse-speech/lhotse/issues/891.

* Remove segments with non-positive duration from the whisper output
* Segment post-processing to force non-overlapping is made optional (disabled by default)
* Allow overlapping segments in forced alignment workflow