### PR TITLE
Add `trim_to_supervision_groups` method

### DIFF
--- a/lhotse/bin/modes/cut.py
+++ b/lhotse/bin/modes/cut.py
@@ -227,6 +227,34 @@ def trim_to_alignments(
 
 
 @cut.command()
+@click.argument("cuts", type=click.Path(exists=True, dir_okay=False, allow_dash=True))
+@click.argument("output_cuts", type=click.Path(allow_dash=True))
+@click.option(
+    "--max-pause",
+    type=float,
+    default=0.0,
+    help="Merge supervision groups separated by a pause shorter than this value",
+)
+def trim_to_supervision_groups(
+    cuts: Pathlike,
+    output_cuts: Pathlike,
+    max_pause: float,
+):
+    """
+    Return a new CutSet with Cuts that have identical spans as the supervision groups.
+    An additional `max_pause` is allowed to merge contiguous supervision groups.
+
+    A supervision group is defined as a set of supervisions that are overlapping or
+    separated by a pause shorter than `max_pause`.
+    """
+    cuts = CutSet.from_file(cuts)
+
+    with CutSet.open_writer(output_cuts) as writer:
+        for cut in cuts.trim_to_supervision_groups(max_pause=max_pause):
+            writer.write(cut)
+
+
+@cut.command()
 @click.argument("cut_manifests", nargs=-1, type=click.Path(exists=True, dir_okay=False))
 @click.argument("output_cut_manifest", type=click.Path())
 def mix_sequential(cut_manifests: List[Pathlike], output_cut_manifest: Pathlike):

--- a/test/cut/test_cut_trim_to_supervisions.py
+++ b/test/cut/test_cut_trim_to_supervisions.py
@@ -447,3 +447,16 @@ def test_cut_set_trim_to_alignments(mono_cut, num_jobs):
     cuts = mono_cut.trim_to_supervisions(keep_overlapping=False)
     cuts = cuts.trim_to_alignments("word", max_pause=0.2, num_jobs=num_jobs).to_eager()
     assert len(cuts) == 4
+
+
+@pytest.mark.parametrize(["max_pause", "expected"], [(0.1, 2), (1.5, 1)])
+def test_cut_trim_to_supervision_groups(mono_cut, max_pause, expected):
+    cuts = mono_cut.trim_to_supervision_groups(max_pause=max_pause).to_eager()
+    assert len(cuts) == expected
+
+
+@pytest.mark.parametrize("num_jobs", [1, 2])
+def test_cut_set_trim_to_supervision_groups(mono_cut, num_jobs):
+    cuts = mono_cut.trim_to_supervisions(keep_overlapping=False)
+    cuts = cuts.trim_to_supervision_groups(max_pause=0.1, num_jobs=num_jobs).to_eager()
+    assert len(cuts) == 3


### PR DESCRIPTION
This PR adds another way of trimming a cut set --- by trimming to "supervision groups". A supervision group (or an utterance group, see [Fig. 2 in this paper](https://arxiv.org/abs/2211.00482)) is defined as a group of contiguous supervisions that are either overlapping or separated by a small pause (shorter than some `max_pause` threshold. Such a way of trimming is useful for evaluating multi-talker ASR.

```
For example, the following cut::

                                        Cut
╔═════════════════════════════════════════════════════════════════════════════════╗
║┌──────────────────────┐                              ┌────────┐                 ║
║│ Hello this is John.  │                              │   Hi   │                 ║
║└──────────────────────┘                              └────────┘                 ║
║            ┌──────────────────────────────────┐            ┌───────────────────┐║
║            │     Hey, John. How are you?      │            │  What do you do?  │║
║            └──────────────────────────────────┘            └───────────────────┘║
╚═════════════════════════════════════════════════════════════════════════════════╝

is transformed into two cuts::

                    Cut 1                                       Cut 2
╔════════════════════════════════════════════════╗    ╔═══════════════════════════╗
║┌──────────────────────┐                        ║    ║┌────────┐                 ║
║│ Hello this is John.  │                        ║    ║│   Hi   │                 ║
║└──────────────────────┘                        ║    ║└────────┘                 ║
║            ┌──────────────────────────────────┐║    ║      ┌───────────────────┐║
║            │     Hey, John. How are you?      │║    ║      │  What do you do?  │║
║            └──────────────────────────────────┘║    ║      └───────────────────┘║
╚════════════════════════════════════════════════╝    ╚═══════════════════════════╝
```