### PR TITLE
Batch extraction for kaldi features

### DIFF
--- a/lhotse/cut/set.py
+++ b/lhotse/cut/set.py
@@ -2161,6 +2161,10 @@ class CutSet(Serializable, AlgorithmMixin):
                 futures.append(executor.submit(_save_worker, cuts, features))
                 progress.update(len(cuts))
 
+        # Wait for all background workers to finish.
+        for future in futures:
+            future.result()
+
         # If ``manifest_path`` was provided, this is a lazy manifest;
         # otherwise everything is in memory.
         return cuts_writer.open_manifest()

--- a/lhotse/cut/set.py
+++ b/lhotse/cut/set.py
@@ -2161,10 +2161,6 @@ class CutSet(Serializable, AlgorithmMixin):
                 futures.append(executor.submit(_save_worker, cuts, features))
                 progress.update(len(cuts))
 
-        # Wait for all background workers to finish.
-        for future in futures:
-            future.result()
-
         # If ``manifest_path`` was provided, this is a lazy manifest;
         # otherwise everything is in memory.
         return cuts_writer.open_manifest()

--- a/lhotse/cut/set.py
+++ b/lhotse/cut/set.py
@@ -2069,6 +2069,7 @@ class CutSet(Serializable, AlgorithmMixin):
             SimpleCutSampler(self, max_duration=batch_duration)
             if not collate
             else BucketingSampler(
+                self,
                 sampler_type=SimpleCutSampler,
                 num_buckets=num_buckets,
                 max_duration=batch_duration,

--- a/lhotse/cut/set.py
+++ b/lhotse/cut/set.py
@@ -2049,7 +2049,7 @@ class CutSet(Serializable, AlgorithmMixin):
         from torch.utils.data import DataLoader
 
         from lhotse.dataset import (
-            BucketingSampler,
+            DynamicBucketingSampler,
             SimpleCutSampler,
             UnsupervisedWaveformDataset,
         )
@@ -2068,9 +2068,8 @@ class CutSet(Serializable, AlgorithmMixin):
         sampler = (
             SimpleCutSampler(self, max_duration=batch_duration)
             if not collate
-            else BucketingSampler(
+            else DynamicBucketingSampler(
                 self,
-                sampler_type=SimpleCutSampler,
                 num_buckets=num_buckets,
                 max_duration=batch_duration,
             )

--- a/lhotse/cut/set.py
+++ b/lhotse/cut/set.py
@@ -1985,6 +1985,7 @@ class CutSet(Serializable, AlgorithmMixin):
         num_workers: int = 4,
         collate: bool = False,
         num_buckets: int = 20,
+        buffer_size: int = 10000,
         augment_fn: Optional[AugmentFn] = None,
         storage_type: Type[FW] = LilcomChunkyWriter,
         overwrite: bool = False,
@@ -2033,6 +2034,10 @@ class CutSet(Serializable, AlgorithmMixin):
         :param num_buckets: If ``collate`` is ``True``, we will use a bucketing sampler
             to group similar-length waveforms into batches. This parameter controls
             the number of buckets.
+        :param buffer_size: If ``collate`` is ``True``, we will use a bucketing sampler
+            to group similar-length waveforms into batches. This parameter controls
+            the buffer size, i.e., how many cuts are kept in the buffer across all buckets
+            at any given time.
         :param augment_fn: an optional callable used for audio augmentation.
             Be careful with the types of augmentations used: if they modify
             the start/end/duration times of the cut and its supervisions,
@@ -2071,6 +2076,7 @@ class CutSet(Serializable, AlgorithmMixin):
             else DynamicBucketingSampler(
                 self,
                 num_buckets=num_buckets,
+                buffer_size=buffer_size,
                 max_duration=batch_duration,
             )
         )

--- a/lhotse/features/__init__.py
+++ b/lhotse/features/__init__.py
@@ -27,7 +27,14 @@ from .io import (
     available_storage_backends,
     close_cached_file_handles,
 )
-from .kaldi.extractors import Fbank, FbankConfig, Mfcc, MfccConfig
+from .kaldi.extractors import (
+    Fbank,
+    FbankConfig,
+    Mfcc,
+    MfccConfig,
+    Spectrogram,
+    SpectrogramConfig,
+)
 from .kaldifeat import (
     KaldifeatFbank,
     KaldifeatFbankConfig,
@@ -38,5 +45,5 @@ from .librosa_fbank import LibrosaFbank, LibrosaFbankConfig
 from .mfcc import TorchaudioMfcc, TorchaudioMfccConfig
 from .mixer import FeatureMixer
 from .opensmile import OpenSmileConfig, OpenSmileExtractor
-from .spectrogram import Spectrogram, SpectrogramConfig
+from .spectrogram import TorchaudioSpectrogram, TorchaudioSpectrogramConfig
 from .ssl import S3PRLSSL, S3PRLSSLConfig

--- a/lhotse/features/base.py
+++ b/lhotse/features/base.py
@@ -24,6 +24,7 @@ from lhotse.utils import (
     Seconds,
     asdict_nonull,
     compute_num_frames,
+    compute_num_frames_from_samples,
     exactly_one_not_null,
     fastcopy,
     ifnone,
@@ -139,12 +140,15 @@ class FeatureExtractor(metaclass=ABCMeta):
             np.ndarray, torch.Tensor, Sequence[np.ndarray], Sequence[torch.Tensor]
         ],
         sampling_rate: int,
+        lengths: Optional[Union[np.ndarray, torch.Tensor]] = None,
     ) -> Union[np.ndarray, torch.Tensor, List[np.ndarray], List[torch.Tensor]]:
         """
         Performs batch extraction. It is not guaranteed to be faster
         than :meth:`FeatureExtractor.extract` -- it depends on whether
         the implementation of a particular feature extractor supports
-        accelerated batch computation.
+        accelerated batch computation. If `lengths` is provided, it is
+        assumed that the input is a batch of padded sequences, so we will
+        not perform any further collation.
 
         .. note::
             Unless overridden by child classes, it defaults to sequentially
@@ -156,22 +160,34 @@ class FeatureExtractor(metaclass=ABCMeta):
         input_is_list = False
         input_is_torch = False
 
-        if isinstance(samples, list):
-            input_is_list = True
-            pass  # nothing to do with `samples`
-        elif samples.ndim > 1:
-            samples = list(samples)
+        if lengths is not None:
+            feat_lens = [
+                compute_num_frames_from_samples(l, self.frame_shift, sampling_rate)
+                for l in lengths
+            ]
+            assert isinstance(
+                samples, torch.Tensor
+            ), "If `lengths` is provided, `samples` must be a batched and padded torch.Tensor."
         else:
-            # The user passed an array/tensor of shape (num_samples,)
-            samples = [samples.reshape(1, -1)]
+            if isinstance(samples, list):
+                input_is_list = True
+                pass  # nothing to do with `samples`
+            elif samples.ndim > 1:
+                samples = list(samples)
+            else:
+                # The user passed an array/tensor of shape (num_samples,)
+                samples = [samples.reshape(1, -1)]
 
-        if any(isinstance(x, torch.Tensor) for x in samples):
-            samples = [x.numpy() for x in samples]
-            input_is_torch = True
+            if any(isinstance(x, torch.Tensor) for x in samples):
+                samples = [x.numpy() for x in samples]
+                input_is_torch = True
 
         result = []
         for item in samples:
-            result.append(self.extract(item, sampling_rate=sampling_rate))
+            res = self.extract(item, sampling_rate=sampling_rate)
+            if lengths is not None:
+                res = res[: feat_lens[len(result)]]
+            result.append(res)
 
         if input_is_torch:
             result = [torch.from_numpy(x) for x in result]

--- a/lhotse/features/kaldi/extractors.py
+++ b/lhotse/features/kaldi/extractors.py
@@ -346,7 +346,7 @@ class Spectrogram(FeatureExtractor):
     def mix(
         features_a: np.ndarray, features_b: np.ndarray, energy_scaling_factor_b: float
     ) -> np.ndarray:
-        return np.exp(features_a) + energy_scaling_factor_b * np.exp(features_b)
+        return features_a + energy_scaling_factor_b * features_b
 
     @staticmethod
     def compute_energy(features: np.ndarray) -> float:

--- a/lhotse/features/kaldi/extractors.py
+++ b/lhotse/features/kaldi/extractors.py
@@ -348,6 +348,10 @@ class Spectrogram(FeatureExtractor):
     ) -> np.ndarray:
         return np.exp(features_a) + energy_scaling_factor_b * np.exp(features_b)
 
+    @staticmethod
+    def compute_energy(features: np.ndarray) -> float:
+        return float(np.sum(features))
+
 
 def _extract_batch(
     extractor: FeatureExtractor,

--- a/lhotse/features/kaldi/extractors.py
+++ b/lhotse/features/kaldi/extractors.py
@@ -110,9 +110,15 @@ class Fbank(FeatureExtractor):
             np.ndarray, torch.Tensor, Sequence[np.ndarray], Sequence[torch.Tensor]
         ],
         sampling_rate: int,
+        lengths: Optional[Union[np.ndarray, torch.Tensor]] = None,
     ) -> Union[np.ndarray, torch.Tensor, List[np.ndarray], List[torch.Tensor]]:
         return _extract_batch(
-            self.extractor, samples, sampling_rate, device=self.device
+            self.extractor,
+            samples,
+            sampling_rate,
+            frame_shift=self.frame_shift,
+            lengths=lengths,
+            device=self.device,
         )
 
     @staticmethod
@@ -229,9 +235,15 @@ class Mfcc(FeatureExtractor):
             np.ndarray, torch.Tensor, Sequence[np.ndarray], Sequence[torch.Tensor]
         ],
         sampling_rate: int,
+        lengths: Optional[Union[np.ndarray, torch.Tensor]] = None,
     ) -> Union[np.ndarray, torch.Tensor, List[np.ndarray], List[torch.Tensor]]:
         return _extract_batch(
-            self.extractor, samples, sampling_rate, device=self.device
+            self.extractor,
+            samples,
+            sampling_rate,
+            frame_shift=self.frame_shift,
+            lengths=lengths,
+            device=self.device,
         )
 
 
@@ -319,9 +331,15 @@ class Spectrogram(FeatureExtractor):
             np.ndarray, torch.Tensor, Sequence[np.ndarray], Sequence[torch.Tensor]
         ],
         sampling_rate: int,
+        lengths: Optional[Union[np.ndarray, torch.Tensor]] = None,
     ) -> Union[np.ndarray, torch.Tensor, List[np.ndarray], List[torch.Tensor]]:
         return _extract_batch(
-            self.extractor, samples, sampling_rate, device=self.device
+            self.extractor,
+            samples,
+            sampling_rate,
+            frame_shift=self.frame_shift,
+            lengths=lengths,
+            device=self.device,
         )
 
     @staticmethod
@@ -337,37 +355,50 @@ def _extract_batch(
         np.ndarray, torch.Tensor, Sequence[np.ndarray], Sequence[torch.Tensor]
     ],
     sampling_rate: int,
+    frame_shift: Seconds = 0.01,
+    lengths: Optional[Union[np.ndarray, torch.Tensor]] = None,
     device: Union[str, torch.device] = "cpu",
 ) -> Union[np.ndarray, torch.Tensor, List[np.ndarray], List[torch.Tensor]]:
     input_is_list = False
     input_is_torch = False
 
-    if isinstance(samples, list):
-        input_is_list = True
-        pass  # nothing to do with `samples`
-    elif samples.ndim > 1:
-        samples = list(samples)
+    if lengths is not None:
+        feat_lens = [
+            compute_num_frames_from_samples(l, frame_shift, sampling_rate)
+            for l in lengths
+        ]
+        assert isinstance(
+            samples, torch.Tensor
+        ), "If `lengths` is provided, `samples` must be a batched and padded torch.Tensor."
     else:
-        # The user passed an array/tensor of shape (num_samples,)
-        samples = [samples.reshape(1, -1)]
+        if isinstance(samples, list):
+            input_is_list = True
+            pass  # nothing to do with `samples`
+        elif samples.ndim > 1:
+            samples = list(samples)
+        else:
+            # The user passed an array/tensor of shape (num_samples,)
+            samples = [samples.reshape(1, -1)]
 
-    if any(isinstance(x, torch.Tensor) for x in samples):
-        samples = [x.numpy() for x in samples]
-        input_is_torch = True
+        if any(isinstance(x, torch.Tensor) for x in samples):
+            samples = [x.numpy() for x in samples]
+            input_is_torch = True
 
-    samples = [
-        torch.from_numpy(x).squeeze() if isinstance(x, np.ndarray) else x.squeeze()
-        for x in samples
-    ]
-    feat_lens = [
-        compute_num_frames_from_samples(
-            num_samples=len(x),
-            frame_shift=extractor.frame_shift,
-            sampling_rate=sampling_rate,
-        )
-        for x in samples
-    ]
-    samples = torch.nn.utils.rnn.pad_sequence(samples, batch_first=True)
+        samples = [
+            torch.from_numpy(x).squeeze() if isinstance(x, np.ndarray) else x.squeeze()
+            for x in samples
+        ]
+        feat_lens = [
+            compute_num_frames_from_samples(
+                num_samples=len(x),
+                frame_shift=extractor.frame_shift,
+                sampling_rate=sampling_rate,
+            )
+            for x in samples
+        ]
+        samples = torch.nn.utils.rnn.pad_sequence(samples, batch_first=True)
+
+    # Perform feature extraction
     feats = extractor(samples.to(device)).cpu()
     result = [feats[i, : feat_lens[i]] for i in range(len(samples))]
 

--- a/lhotse/features/kaldi/extractors.py
+++ b/lhotse/features/kaldi/extractors.py
@@ -1,3 +1,4 @@
+import warnings
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Sequence, Union
 
@@ -41,6 +42,11 @@ class FbankConfig:
         if self.num_mel_bins is not None:
             self.num_filters = self.num_mel_bins
             self.num_mel_bins = None
+
+        if self.snip_edges:
+            warnings.warn(
+                "`snip_edges` is set to True, which may cause issues in duration to num-frames conversion in Lhotse."
+            )
 
     def to_dict(self) -> Dict[str, Any]:
         return asdict_nonull(self)
@@ -147,6 +153,11 @@ class MfccConfig:
             self.num_filters = self.num_mel_bins
             self.num_mel_bins = None
 
+        if self.snip_edges:
+            warnings.warn(
+                "`snip_edges` is set to True, which may cause issues in duration to num-frames conversion in Lhotse."
+            )
+
     def to_dict(self) -> Dict[str, Any]:
         return asdict_nonull(self)
 
@@ -221,6 +232,12 @@ class SpectrogramConfig:
     raw_energy: bool = True
     use_energy: bool = False
     use_fft_mag: bool = False
+
+    def __post_init__(self):
+        if self.snip_edges:
+            warnings.warn(
+                "`snip_edges` is set to True, which may cause issues in duration to num-frames conversion in Lhotse."
+            )
 
     def to_dict(self) -> Dict[str, Any]:
         return asdict_nonull(self)

--- a/lhotse/features/kaldi/extractors.py
+++ b/lhotse/features/kaldi/extractors.py
@@ -1,12 +1,17 @@
 from dataclasses import dataclass
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, List, Optional, Sequence, Union
 
 import numpy as np
 import torch
 
 from lhotse.features.base import FeatureExtractor, register_extractor
-from lhotse.features.kaldi.layers import Wav2LogFilterBank, Wav2MFCC
-from lhotse.utils import EPSILON, Seconds, asdict_nonull
+from lhotse.features.kaldi.layers import Wav2LogFilterBank, Wav2MFCC, Wav2Spec
+from lhotse.utils import (
+    EPSILON,
+    Seconds,
+    asdict_nonull,
+    compute_num_frames_from_samples,
+)
 
 
 @dataclass
@@ -85,6 +90,15 @@ class Fbank(FeatureExtractor):
             return feats.cpu().numpy()
         else:
             return feats
+
+    def extract_batch(
+        self,
+        samples: Union[
+            np.ndarray, torch.Tensor, Sequence[np.ndarray], Sequence[torch.Tensor]
+        ],
+        sampling_rate: int,
+    ) -> Union[np.ndarray, torch.Tensor, List[np.ndarray], List[torch.Tensor]]:
+        return _extract_batch(self.extractor, samples, sampling_rate)
 
     @staticmethod
     def mix(
@@ -181,3 +195,150 @@ class Mfcc(FeatureExtractor):
             return feats.cpu().numpy()
         else:
             return feats
+
+    def extract_batch(
+        self,
+        samples: Union[
+            np.ndarray, torch.Tensor, Sequence[np.ndarray], Sequence[torch.Tensor]
+        ],
+        sampling_rate: int,
+    ) -> Union[np.ndarray, torch.Tensor, List[np.ndarray], List[torch.Tensor]]:
+        return _extract_batch(self.extractor, samples, sampling_rate)
+
+
+@dataclass
+class SpectrogramConfig:
+    sampling_rate: int = 16000
+    frame_length: Seconds = 0.025
+    frame_shift: Seconds = 0.01
+    round_to_power_of_two: bool = True
+    remove_dc_offset: bool = True
+    preemph_coeff: float = 0.97
+    window_type: str = "povey"
+    dither: float = 0.0
+    snip_edges: bool = False
+    energy_floor: float = EPSILON
+    raw_energy: bool = True
+    use_energy: bool = False
+    use_fft_mag: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict_nonull(self)
+
+    @staticmethod
+    def from_dict(data: Dict[str, Any]) -> "SpectrogramConfig":
+        return SpectrogramConfig(**data)
+
+
+@register_extractor
+class Spectrogram(FeatureExtractor):
+    name = "kaldi-spectrogram"
+    config_type = SpectrogramConfig
+
+    def __init__(self, config: Optional[SpectrogramConfig] = None):
+        super().__init__(config=config)
+        self.extractor = Wav2Spec(**self.config.to_dict()).eval()
+
+    @property
+    def frame_shift(self) -> Seconds:
+        return self.config.frame_shift
+
+    def feature_dim(self, sampling_rate: int) -> int:
+        return self.config.num_ceps
+
+    def extract(
+        self, samples: Union[np.ndarray, torch.Tensor], sampling_rate: int
+    ) -> Union[np.ndarray, torch.Tensor]:
+        assert sampling_rate == self.config.sampling_rate, (
+            f"Spectrogram was instantiated for sampling_rate "
+            f"{self.config.sampling_rate}, but "
+            f"sampling_rate={sampling_rate} was passed to extract(). "
+            "Note you can use CutSet/RecordingSet.resample() to change the audio sampling rate."
+        )
+
+        is_numpy = False
+        if not isinstance(samples, torch.Tensor):
+            samples = torch.from_numpy(samples)
+            is_numpy = True
+
+        if samples.ndim == 1:
+            samples = samples.unsqueeze(0)
+
+        feats = self.extractor(samples)[0]
+
+        if is_numpy:
+            return feats.cpu().numpy()
+        else:
+            return feats
+
+    def extract_batch(
+        self,
+        samples: Union[
+            np.ndarray, torch.Tensor, Sequence[np.ndarray], Sequence[torch.Tensor]
+        ],
+        sampling_rate: int,
+    ) -> Union[np.ndarray, torch.Tensor, List[np.ndarray], List[torch.Tensor]]:
+        return _extract_batch(self.extractor, samples, sampling_rate)
+
+    @staticmethod
+    def mix(
+        features_a: np.ndarray, features_b: np.ndarray, energy_scaling_factor_b: float
+    ) -> np.ndarray:
+        return np.exp(features_a) + energy_scaling_factor_b * np.exp(features_b)
+
+
+def _extract_batch(
+    extractor: FeatureExtractor,
+    samples: Union[
+        np.ndarray, torch.Tensor, Sequence[np.ndarray], Sequence[torch.Tensor]
+    ],
+    sampling_rate: int,
+) -> Union[np.ndarray, torch.Tensor, List[np.ndarray], List[torch.Tensor]]:
+    input_is_list = False
+    input_is_torch = False
+
+    if isinstance(samples, list):
+        input_is_list = True
+        pass  # nothing to do with `samples`
+    elif samples.ndim > 1:
+        samples = list(samples)
+    else:
+        # The user passed an array/tensor of shape (num_samples,)
+        samples = [samples.reshape(1, -1)]
+
+    if any(isinstance(x, torch.Tensor) for x in samples):
+        samples = [x.numpy() for x in samples]
+        input_is_torch = True
+
+    samples = [
+        torch.from_numpy(x).squeeze() if isinstance(x, np.ndarray) else x.squeeze()
+        for x in samples
+    ]
+    feat_lens = [
+        compute_num_frames_from_samples(
+            num_samples=len(x),
+            frame_shift=extractor.frame_shift,
+            sampling_rate=sampling_rate,
+        )
+        for x in samples
+    ]
+    samples = torch.nn.utils.rnn.pad_sequence(samples, batch_first=True)
+    feats = extractor(samples)
+    result = [feats[i, : feat_lens[i]] for i in range(len(samples))]
+
+    if not input_is_torch:
+        result = [x.numpy() for x in result]
+
+    # If all items are of the same shape, concatenate
+    if len(result) == 1:
+        if input_is_list:
+            return result
+        else:
+            return result[0]
+    elif all(item.shape == result[0].shape for item in result[1:]):
+        if input_is_torch:
+            return torch.stack(result, dim=0)
+        else:
+            return np.stack(result, axis=0)
+    else:
+        return result

--- a/lhotse/features/kaldifeat.py
+++ b/lhotse/features/kaldifeat.py
@@ -80,7 +80,11 @@ class KaldifeatExtractor(FeatureExtractor, ABC):
             np.ndarray, torch.Tensor, Sequence[np.ndarray], Sequence[torch.Tensor]
         ],
         sampling_rate: int,
+        lengths: Optional[Union[np.ndarray, torch.Tensor]] = None,
     ) -> Union[np.ndarray, torch.Tensor, List[np.ndarray], List[torch.Tensor]]:
+        # kaldifeat expects a list of 1D torch tensors.
+        if lengths is not None:
+            samples = [x[:l] for x, l in zip(samples, lengths)]
         return self.extract(samples=samples, sampling_rate=sampling_rate)
 
     def extract(

--- a/lhotse/features/spectrogram.py
+++ b/lhotse/features/spectrogram.py
@@ -8,7 +8,7 @@ from lhotse.utils import EPSILON, Seconds
 
 
 @dataclass
-class SpectrogramConfig:
+class TorchaudioSpectrogramConfig:
     # Note that `snip_edges` parameter is missing from config: in order to simplify the relationship between
     #  the duration and the number of frames, we are always setting `snip_edges` to False.
     dither: float = 0.0
@@ -27,16 +27,16 @@ class SpectrogramConfig:
         return asdict(self)
 
     @staticmethod
-    def from_dict(data: Dict[str, Any]) -> "SpectrogramConfig":
-        return SpectrogramConfig(**data)
+    def from_dict(data: Dict[str, Any]) -> "TorchaudioSpectrogramConfig":
+        return TorchaudioSpectrogramConfig(**data)
 
 
 @register_extractor
-class Spectrogram(TorchaudioFeatureExtractor):
+class TorchaudioSpectrogram(TorchaudioFeatureExtractor):
     """Log spectrogram feature extractor based on ``torchaudio.compliance.kaldi.spectrogram`` function."""
 
     name = "spectrogram"
-    config_type = SpectrogramConfig
+    config_type = TorchaudioSpectrogramConfig
 
     def _feature_fn(self, *args, **kwargs):
         from torchaudio.compliance.kaldi import spectrogram

--- a/lhotse/features/ssl.py
+++ b/lhotse/features/ssl.py
@@ -100,7 +100,11 @@ class S3PRLSSL(FeatureExtractor):
             np.ndarray, torch.Tensor, Sequence[np.ndarray], Sequence[torch.Tensor]
         ],
         sampling_rate: int,
+        lengths: Optional[Union[np.ndarray, torch.Tensor]] = None,
     ) -> Union[np.ndarray, torch.Tensor, List[np.ndarray], List[torch.Tensor]]:
+        # S3PRL expects a list of 1D torch tensors.
+        if lengths is not None:
+            samples = [x[:l] for x, l in zip(samples, lengths)]
         return self.extract(samples=samples, sampling_rate=sampling_rate)
 
     def extract(

--- a/test/cut/test_feature_extraction.py
+++ b/test/cut/test_feature_extraction.py
@@ -238,6 +238,33 @@ def test_cut_set_batch_feature_extraction(cut_set, extractor_type):
 
 
 @pytest.mark.parametrize(
+    "extractor_type",
+    [
+        Fbank,
+        TorchaudioFbank,
+        pytest.param(
+            KaldifeatFbank,
+            marks=pytest.mark.skipif(
+                not is_module_available("kaldifeat"),
+                reason="Requires kaldifeat to run.",
+            ),
+        ),
+    ],
+)
+def test_cut_set_batch_feature_extraction_with_collation(cut_set, extractor_type):
+    extractor = extractor_type()
+    cut_set = cut_set.resample(16000)
+    with NamedTemporaryFile() as tmpf:
+        cut_set_with_feats = cut_set.compute_and_store_features_batch(
+            extractor=extractor,
+            storage_path=tmpf.name,
+            num_workers=0,
+            collate=True,
+        )
+        validate(cut_set_with_feats, read_data=True)
+
+
+@pytest.mark.parametrize(
     ["suffix", "exception_expectation"],
     [
         (".jsonl", does_not_raise()),

--- a/test/cut/test_feature_extraction.py
+++ b/test/cut/test_feature_extraction.py
@@ -249,6 +249,15 @@ def test_cut_set_batch_feature_extraction(cut_set, extractor_type):
                 reason="Requires kaldifeat to run.",
             ),
         ),
+        pytest.param(
+            S3PRLSSL,
+            marks=[
+                pytest.mark.skipif(
+                    not is_module_available("s3prl"),
+                    reason="Requires s3prl to run.",
+                ),
+            ],
+        ),
     ],
 )
 def test_cut_set_batch_feature_extraction_with_collation(cut_set, extractor_type):

--- a/test/cut/test_feature_extraction.py
+++ b/test/cut/test_feature_extraction.py
@@ -21,6 +21,7 @@ from lhotse import (
     Mfcc,
     MonoCut,
     Recording,
+    Spectrogram,
     SupervisionSegment,
     TorchaudioFbank,
     TorchaudioMfcc,
@@ -189,6 +190,7 @@ def test_extract_and_store_features_from_cut_set(
     [
         Fbank,
         Mfcc,
+        Spectrogram,
         TorchaudioFbank,
         TorchaudioMfcc,
         pytest.param(

--- a/test/features/test_kaldi_features.py
+++ b/test/features/test_kaldi_features.py
@@ -4,7 +4,14 @@ import torch
 
 from lhotse import TorchaudioFbank, TorchaudioMfcc, TorchaudioSpectrogram
 from lhotse.audio import Recording
-from lhotse.features.kaldi.extractors import Fbank, Mfcc, Spectrogram, SpectrogramConfig
+from lhotse.features.kaldi.extractors import (
+    Fbank,
+    FbankConfig,
+    Mfcc,
+    MfccConfig,
+    Spectrogram,
+    SpectrogramConfig,
+)
 from lhotse.features.kaldi.layers import Wav2LogFilterBank, Wav2MFCC, Wav2Spec
 
 
@@ -123,3 +130,16 @@ def test_kaldi_spectrogram_extractor_vs_torchaudio(recording):
     # coefficient is the log energy, so we need to compare it separately.
     torch.testing.assert_allclose(feats[:, 0], feats_ta[:, 0])
     torch.testing.assert_allclose(feats[:, 1:], np.exp(feats_ta[:, 1:]))
+
+
+@pytest.mark.parametrize(
+    "extractor_type",
+    [
+        lambda: Fbank(FbankConfig(snip_edges=True)),
+        lambda: Mfcc(MfccConfig(snip_edges=True)),
+        lambda: Spectrogram(SpectrogramConfig(snip_edges=True)),
+    ],
+)
+def test_kaldi_extractors_snip_edges_warning(extractor_type):
+    with pytest.warns(UserWarning):
+        extractor = extractor_type()

--- a/test/features/test_kaldi_features.py
+++ b/test/features/test_kaldi_features.py
@@ -1,10 +1,11 @@
+import numpy as np
 import pytest
 import torch
 
-from lhotse import TorchaudioFbank, TorchaudioMfcc
+from lhotse import TorchaudioFbank, TorchaudioMfcc, TorchaudioSpectrogram
 from lhotse.audio import Recording
-from lhotse.features.kaldi.extractors import Fbank, Mfcc
-from lhotse.features.kaldi.layers import Wav2LogFilterBank, Wav2MFCC
+from lhotse.features.kaldi.extractors import Fbank, Mfcc, Spectrogram, SpectrogramConfig
+from lhotse.features.kaldi.layers import Wav2LogFilterBank, Wav2MFCC, Wav2Spec
 
 
 @pytest.fixture()
@@ -44,11 +45,32 @@ def test_kaldi_mfcc_layer(recording):
     audio.requires_grad = True
     assert audio.requires_grad
     # Test batch processing
-    fbank = Wav2MFCC(
+    mfcc = Wav2MFCC(
         sampling_rate=recording.sampling_rate,
     )
-    feats = fbank(audio)
+    feats = mfcc(audio)
     assert feats.shape == (4, 1604, 13)
+    # Test backprop
+    feats.sum().backward()
+    assert audio.grad is not None
+
+
+def test_kaldi_spec_layer(recording):
+    # Prepare a batch of recordings
+    audio = torch.from_numpy(recording.load_audio())
+    audio = torch.cat([audio] * 4, dim=0)
+    assert audio.shape == (4, recording.num_samples)
+    # We'll test the Kaldi feature extraction layers
+    # by checking if they can process batched audio and
+    # backprop gradients.
+    audio.requires_grad = True
+    assert audio.requires_grad
+    # Test batch processing
+    spec = Wav2Spec(
+        sampling_rate=recording.sampling_rate,
+    )
+    feats = spec(audio)
+    assert feats.shape == (4, 1604, 257)
     # Test backprop
     feats.sum().backward()
     assert audio.grad is not None
@@ -77,8 +99,25 @@ def test_kaldi_mfcc_extractor(recording):
 
 def test_kaldi_mfcc_extractor_vs_torchaudio(recording):
     audio = recording.load_audio()
-    fbank = Mfcc()
-    fbank_ta = TorchaudioMfcc()
-    feats = fbank.extract(audio, recording.sampling_rate)
-    feats_ta = fbank_ta.extract(audio, recording.sampling_rate)
+    mfcc = Mfcc()
+    mfcc_ta = TorchaudioMfcc()
+    feats = mfcc.extract(audio, recording.sampling_rate)
+    feats_ta = mfcc_ta.extract(audio, recording.sampling_rate)
     torch.testing.assert_allclose(feats, feats_ta)
+
+
+def test_kaldi_spectrogram_extractor(recording):
+    spec = Spectrogram()
+    feats = spec.extract(recording.load_audio(), recording.sampling_rate)
+    assert feats.shape == (1604, 257)
+
+
+def test_kaldi_spectrogram_extractor_vs_torchaudio(recording):
+    audio = recording.load_audio()
+    spec = Spectrogram()
+    spec_ta = TorchaudioSpectrogram()
+    feats = spec.extract(audio, recording.sampling_rate)
+    feats_ta = spec_ta.extract(audio, recording.sampling_rate)
+    # Torchaudio returns log power spectrum, while kaldi-spectrogram returns power
+    # spectrum, so we need to take log
+    torch.testing.assert_allclose(np.log(feats), feats_ta)

--- a/test/test_feature_set.py
+++ b/test/test_feature_set.py
@@ -15,7 +15,8 @@ from lhotse.features import (
     FeatureSet,
     FeatureSetBuilder,
     Mfcc,
-    Spectrogram,
+    TorchaudioSpectrogram,
+    TorchaudioSpectrogramConfig,
 )
 from lhotse.features.io import (
     ChunkedLilcomHdf5Writer,
@@ -243,7 +244,6 @@ def test_add_feature_sets():
     ["feature_extractor", "decimal", "exception_expectation"],
     [
         (Fbank(FbankConfig(num_filters=40, sampling_rate=8000)), 0, does_not_raise()),
-        (Spectrogram(), -1, does_not_raise()),
         (Mfcc(MfccConfig(sampling_rate=8000)), None, raises(ValueError)),
     ],
 )


### PR DESCRIPTION
This PR adds `extract_batch()` method for the kaldi compatible features implemented in Lhotse.

NOTE: We rename Torchaudio's `Spectrogram` feature to `TorchaudioSpectrogram` to be consistent with `TorchaudioMfcc` and `TorchaudioFbank`.