### PR TITLE
Optional quadratic duration correction for dynamic bucketing sampler

### DIFF
--- a/lhotse/dataset/sampling/bucketing.py
+++ b/lhotse/dataset/sampling/bucketing.py
@@ -54,9 +54,6 @@ class BucketingSampler(CutSampler):
         num_buckets: int = 10,
         drop_last: bool = False,
         seed: int = 0,
-        strict=None,
-        bucket_method=None,
-        proportional_sampling=None,
         **kwargs: Any,
     ) -> None:
         """
@@ -90,25 +87,6 @@ class BucketingSampler(CutSampler):
                 "those opened with 'load_manifest_lazy', 'CutSet.from_jsonl_lazy', or "
                 "'CutSet.from_webdataset'). "
                 "Please use lhotse.dataset.DynamicBucketingSampler instead."
-            )
-
-        if strict is not None:
-            warnings.warn(
-                "In Lhotse v1.4 all samplers act as if 'strict=True'. "
-                "Sampler's argument 'strict' will be removed in a future Lhotse release.",
-                category=DeprecationWarning,
-            )
-        if proportional_sampling is not None:
-            warnings.warn(
-                "In Lhotse v1.4 BucketingSampler always performs proportional sampling."
-                "Argument 'proportional_sampling' will be removed in a future Lhotse release.",
-                category=DeprecationWarning,
-            )
-        if bucket_method is not None:
-            warnings.warn(
-                "In Lhotse v1.4 BucketingSampler always uses 'equal_duration' bucketing method."
-                "Argument 'bucket_method' will be removed in a future Lhotse release.",
-                category=DeprecationWarning,
             )
 
         # Split data into buckets.

--- a/lhotse/dataset/sampling/cut_pairs.py
+++ b/lhotse/dataset/sampling/cut_pairs.py
@@ -22,12 +22,8 @@ class CutPairsSampler(CutSampler):
         self,
         source_cuts: CutSet,
         target_cuts: CutSet,
-        max_source_frames: int = None,
-        max_source_samples: int = None,
         max_source_duration: Seconds = None,
-        max_target_frames: int = None,
-        max_target_samples: int = None,
-        max_target_duration: int = None,
+        max_target_duration: Seconds = None,
         max_cuts: Optional[int] = None,
         shuffle: bool = False,
         drop_last: bool = False,
@@ -41,11 +37,7 @@ class CutPairsSampler(CutSampler):
 
         :param source_cuts: the first ``CutSet`` to sample data from.
         :param target_cuts: the second ``CutSet`` to sample data from.
-        :param max_source_frames: The maximum total number of feature frames from ``source_cuts``.
-        :param max_source_samples: The maximum total number of audio samples from ``source_cuts``.
         :param max_source_duration: The maximum total recording duration from ``source_cuts``.
-        :param max_target_frames: The maximum total number of feature frames from ``target_cuts``.
-        :param max_target_samples: The maximum total number of audio samples from ``target_cuts``.
         :param max_target_duration: The maximum total recording duration from ``target_cuts``.
         :param max_cuts: The maximum number of cuts sampled to form a mini-batch.
             By default, this constraint is off.
@@ -70,22 +62,12 @@ class CutPairsSampler(CutSampler):
         # Constraints
         self.source_constraints = TimeConstraint(
             max_duration=max_source_duration,
-            max_samples=max_source_samples,
-            max_frames=max_source_frames,
             max_cuts=max_cuts,
         )
         self.target_constraints = TimeConstraint(
             max_duration=max_target_duration,
-            max_samples=max_target_samples,
-            max_frames=max_target_frames,
             max_cuts=max_cuts,
         )
-        if strict is not None:
-            warnings.warn(
-                "In Lhotse v1.4 all samplers act as if 'strict=True'. "
-                "Sampler's argument 'strict' will be removed in a future Lhotse release.",
-                category=DeprecationWarning,
-            )
 
     @property
     def remaining_duration(self) -> Optional[float]:

--- a/lhotse/dataset/sampling/dynamic.py
+++ b/lhotse/dataset/sampling/dynamic.py
@@ -235,11 +235,10 @@ class DurationBatcher:
     def __init__(
         self,
         datapipe: Iterable[Union[Cut, Tuple[Cut]]],
-        max_frames: int = None,
-        max_samples: int = None,
         max_duration: Seconds = None,
         max_cuts: Optional[int] = None,
         drop_last: bool = False,
+        quadratic_duration: Optional[Seconds] = None,
         diagnostics: Optional[SamplingDiagnostics] = None,
     ) -> None:
         self.datapipe = datapipe
@@ -248,9 +247,8 @@ class DurationBatcher:
         self.diagnostics = ifnone(diagnostics, SamplingDiagnostics())
         self.time_constraint = TimeConstraint(
             max_duration=max_duration,
-            max_frames=max_frames,
-            max_samples=max_samples,
             max_cuts=max_cuts,
+            quadratic_duration=quadratic_duration,
         )
 
     def __iter__(self) -> Generator[Union[CutSet, Tuple[CutSet]], None, None]:

--- a/lhotse/dataset/sampling/simple.py
+++ b/lhotse/dataset/sampling/simple.py
@@ -30,8 +30,6 @@ class SimpleCutSampler(CutSampler):
     def __init__(
         self,
         cuts: CutSet,
-        max_frames: int = None,
-        max_samples: int = None,
         max_duration: Seconds = None,
         max_cuts: Optional[int] = None,
         shuffle: bool = False,
@@ -39,14 +37,11 @@ class SimpleCutSampler(CutSampler):
         world_size: Optional[int] = None,
         rank: Optional[int] = None,
         seed: int = 0,
-        strict=None,
     ):
         """
         SimpleCutSampler's constructor.
 
         :param cuts: the ``CutSet`` to sample data from.
-        :param max_frames: The maximum total number of feature frames from ``cuts``.
-        :param max_samples: The maximum total number of audio samples from ``cuts``.
         :param max_duration: The maximum total recording duration from ``cuts``.
         :param max_cuts: The maximum number of cuts sampled to form a mini-batch.
             By default, this constraint is off.
@@ -69,16 +64,8 @@ class SimpleCutSampler(CutSampler):
         self.data_source = DataSource(cuts)
         self.time_constraint = TimeConstraint(
             max_duration=max_duration,
-            max_frames=max_frames,
-            max_samples=max_samples,
             max_cuts=max_cuts,
         )
-        if strict is not None:
-            warnings.warn(
-                "In Lhotse v1.4 all samplers act as if 'strict=True'. "
-                "Sampler's argument 'strict' will be removed in a future Lhotse release.",
-                category=DeprecationWarning,
-            )
 
     @property
     def remaining_duration(self) -> Optional[float]:

--- a/test/dataset/sampling/test_dynamic_bucketing.py
+++ b/test/dataset/sampling/test_dynamic_bucketing.py
@@ -474,3 +474,47 @@ def test_dynamic_bucketing_sampler_cut_triplets():
     assert sum(c.duration for c in c1) == 2
     assert sum(c.duration for c in c2) == 2
     assert sum(c.duration for c in c3) == 2
+
+
+def test_dynamic_bucketing_quadratic_duration():
+    cuts = DummyManifest(CutSet, begin_id=0, end_id=10)
+    for i, c in enumerate(cuts):
+        if i < 5:
+            c.duration = 5
+        else:
+            c.duration = 30
+
+    # Set max_duration to 61 so that with quadratic_duration disabled,
+    # we would have gotten 2 per batch, but otherwise we only get 1.
+
+    # quadratic_duration=30
+    sampler = DynamicBucketingSampler(
+        cuts, max_duration=61, num_buckets=2, seed=0, quadratic_duration=30
+    )
+    batches = [b for b in sampler]
+    assert len(batches) == 6
+    for b in batches[:5]:
+        assert len(b) == 1  # single cut
+        assert b[0].duration == 30  # 30s long
+
+    b = batches[5]
+    assert len(b) == 5  # 5 cuts
+    assert sum(c.duration for c in b) == 25  # each 5s long
+
+    # quadratic_duration=None (disabled)
+    sampler = DynamicBucketingSampler(
+        cuts, max_duration=61, num_buckets=2, seed=0, quadratic_duration=None
+    )
+    batches = [b for b in sampler]
+    assert len(batches) == 4
+    for b in batches[:2]:
+        assert len(b) == 2  # two cuts
+        assert sum(c.duration for c in b) == 60  # each 30s long
+
+    b = batches[2]
+    assert len(b) == 5  # 5 cuts
+    assert sum(c.duration for c in b) == 25  # each 5s long
+
+    b = batches[3]
+    assert len(b) == 1  # single cut
+    assert sum(c.duration for c in b) == 30  # 30s long

--- a/test/dataset/sampling/test_sampling.py
+++ b/test/dataset/sampling/test_sampling.py
@@ -80,51 +80,29 @@ def test_single_cut_sampler_shuffling(sampler_cls):
     assert [c.id for c in sampled_cuts] != [c.id for c in cut_set]
 
 
-@pytest.mark.parametrize(
-    ["max_duration", "max_frames", "max_samples", "exception_expectation"],
-    [
-        (
-            None,
-            None,
-            None,
-            does_not_raise(),
-        ),  # represents no criterion (unlimited batch size)
-        (10.0, None, None, does_not_raise()),
-        (None, 1000, None, does_not_raise()),
-        (None, None, 160000, does_not_raise()),
-        (None, 1000, 160000, pytest.raises(AssertionError)),
-        (5.0, 1000, 160000, pytest.raises(AssertionError)),
-    ],
-)
-def test_single_cut_sampler_time_constraints(
-    max_duration, max_frames, max_samples, exception_expectation
-):
+@pytest.mark.parametrize("max_duration", [None, 10.0])
+def test_single_cut_sampler_time_constraints(max_duration):
     # The dummy cuts have a duration of 1 second each
     cut_set = DummyManifest(CutSet, begin_id=0, end_id=100)
-    if max_frames is None:
-        cut_set = cut_set.drop_features()
 
-    with exception_expectation:
-        sampler = SimpleCutSampler(
-            cut_set,
-            shuffle=True,
-            # Set an effective batch size of 10 cuts, as all have 1s duration == 100 frames
-            # This way we're testing that it works okay when returning multiple batches in
-            # a full epoch.
-            max_frames=max_frames,
-            max_samples=max_samples,
-            max_duration=max_duration,
-        )
-        sampler_cut_ids = []
-        for batch in sampler:
-            sampler_cut_ids.extend(batch)
+    sampler = SimpleCutSampler(
+        cut_set,
+        shuffle=True,
+        # Set an effective batch size of 10 cuts, as all have 1s duration == 100 frames
+        # This way we're testing that it works okay when returning multiple batches in
+        # a full epoch.
+        max_duration=max_duration,
+    )
+    sampler_cut_ids = []
+    for batch in sampler:
+        sampler_cut_ids.extend(batch)
 
-        # Invariant 1: we receive the same amount of items in a dataloader epoch as there we in the CutSet
-        assert len(sampler_cut_ids) == len(cut_set)
-        # Invariant 2: the items are not duplicated
-        assert len(set(c.id for c in sampler_cut_ids)) == len(sampler_cut_ids)
-        # Invariant 3: the items are shuffled, i.e. the order is different than that in the CutSet
-        assert [c.id for c in sampler_cut_ids] != [c.id for c in cut_set]
+    # Invariant 1: we receive the same amount of items in a dataloader epoch as there we in the CutSet
+    assert len(sampler_cut_ids) == len(cut_set)
+    # Invariant 2: the items are not duplicated
+    assert len(set(c.id for c in sampler_cut_ids)) == len(sampler_cut_ids)
+    # Invariant 3: the items are shuffled, i.e. the order is different than that in the CutSet
+    assert [c.id for c in sampler_cut_ids] != [c.id for c in cut_set]
 
 
 @pytest.mark.parametrize("sampler_cls", [SimpleCutSampler, DynamicCutSampler])
@@ -164,24 +142,6 @@ def test_single_cut_sampler_order_differs_between_epochs(sampler_cls):
         last_order = new_order
 
 
-@pytest.mark.xfail(
-    reason="len(sampler) is incorrect as it caches the num_buckets value "
-    "for a particular cut ordering -- if the cuts are re-shuffled, "
-    "the actual len might differ."
-)
-def test_single_cut_sampler_len():
-    # total duration is 55 seconds
-    # each second has 100 frames
-    cuts = CutSet.from_cuts(dummy_cut(idx, duration=float(idx)) for idx in range(1, 11))
-    sampler = SimpleCutSampler(cuts, shuffle=True, max_frames=10 * 100, max_cuts=6)
-
-    for epoch in range(5):
-        sampler.set_epoch(epoch)
-        sampler_len = len(sampler)
-        num_batches = len([batch for batch in sampler])
-        assert sampler_len == num_batches
-
-
 @pytest.mark.parametrize("sampler_cls", [SimpleCutSampler, DynamicCutSampler])
 def test_single_cut_sampler_low_max_frames(libri_cut_set, sampler_cls):
     sampler = sampler_cls(libri_cut_set, shuffle=False, max_duration=0.02)
@@ -202,8 +162,8 @@ def test_cut_pairs_sampler():
         # Set an effective batch size of 10 cuts, as all have 1s duration == 100 frames
         # This way we're testing that it works okay when returning multiple batches in
         # a full epoch.
-        max_source_frames=1000,
-        max_target_frames=500,
+        max_source_duration=100.0,
+        max_target_duration=50.0,
     )
     source_cuts, target_cuts = [], []
     for src_batch, tgt_batch in sampler:
@@ -266,62 +226,6 @@ def test_cut_pairs_sampler_2():
     assert len(batch) == 2
 
 
-@pytest.mark.parametrize(
-    ["max_duration", "max_frames", "max_samples", "exception_expectation"],
-    [
-        (
-            None,
-            None,
-            None,
-            does_not_raise(),
-        ),  # represents no criterion (unlimited batch size)
-        (10.0, None, None, does_not_raise()),
-        (None, 1000, None, does_not_raise()),
-        (None, None, 160000, does_not_raise()),
-        (None, 1000, 160000, pytest.raises(AssertionError)),
-        (5.0, 1000, 160000, pytest.raises(AssertionError)),
-    ],
-)
-def test_cut_pairs_sampler_time_constraints(
-    max_duration, max_frames, max_samples, exception_expectation
-):
-    # The dummy cuts have a duration of 1 second each
-    cut_set = DummyManifest(CutSet, begin_id=0, end_id=100)
-    if max_frames is None:
-        cut_set = cut_set.drop_features()
-
-    with exception_expectation:
-        sampler = CutPairsSampler(
-            source_cuts=cut_set,
-            target_cuts=cut_set,
-            shuffle=True,
-            # Set an effective batch size of 10 cuts, as all have 1s duration == 100 frames
-            # This way we're testing that it works okay when returning multiple batches in
-            # a full epoch.
-            max_source_frames=max_frames,
-            max_target_frames=max_frames / 2 if max_frames is not None else None,
-            max_source_samples=max_samples,
-            max_target_samples=max_samples / 2 if max_samples is not None else None,
-            max_source_duration=max_duration,
-            max_target_duration=max_duration / 2 if max_duration is not None else None,
-        )
-        source_cuts, target_cuts = [], []
-        for src_batch, tgt_batch in sampler:
-            source_cuts.extend(src_batch)
-            target_cuts.extend(tgt_batch)
-
-        # Invariant 1: we receive the same amount of items in a dataloader epoch as there we in the CutSet
-        assert len(source_cuts) == len(cut_set)
-        assert len(target_cuts) == len(cut_set)
-        # Invariant 2: the items are not duplicated
-        assert len(set(c.id for c in source_cuts)) == len(source_cuts)
-        assert len(set(c.id for c in target_cuts)) == len(target_cuts)
-        # Invariant 3: the items are shuffled, i.e. the order is different than that in the CutSet
-        assert [c.id for c in source_cuts] != [c.id for c in cut_set]
-        # Invariant 4: the source and target cuts are in the same order
-        assert [c.id for c in source_cuts] == [c.id for c in target_cuts]
-
-
 def test_cut_pairs_sampler_order_is_deterministic_given_epoch():
     # The dummy cuts have a duration of 1 second each
     cut_set = DummyManifest(CutSet, begin_id=0, end_id=100)
@@ -333,8 +237,8 @@ def test_cut_pairs_sampler_order_is_deterministic_given_epoch():
         # Set an effective batch size of 10 cuts, as all have 1s duration == 100 frames
         # This way we're testing that it works okay when returning multiple batches in
         # a full epoch.
-        max_source_frames=1000,
-        max_target_frames=500,
+        max_source_duration=100,
+        max_target_duration=50,
     )
     sampler.set_epoch(42)
     # calling the sampler twice without epoch update gives identical ordering
@@ -352,8 +256,8 @@ def test_cut_pairs_sampler_order_differs_between_epochs():
         # Set an effective batch size of 10 cuts, as all have 1s duration == 100 frames
         # This way we're testing that it works okay when returning multiple batches in
         # a full epoch.
-        max_source_frames=1000,
-        max_target_frames=500,
+        max_source_duration=100,
+        max_target_duration=50,
     )
 
     last_order = [item for item in sampler]
@@ -362,28 +266,6 @@ def test_cut_pairs_sampler_order_differs_between_epochs():
         new_order = [item for item in sampler]
         assert new_order != last_order
         last_order = new_order
-
-
-@pytest.mark.xfail(
-    reason="len(sampler) is incorrect as it caches the num_buckets value "
-    "for a particular cut ordering -- if the cuts are re-shuffled, "
-    "the actual len might differ."
-)
-def test_cut_pairs_sampler_len():
-    # total duration is 55 seconds
-    # each second has 100 frames
-    cuts = CutSet.from_cuts(dummy_cut(idx, duration=float(idx)) for idx in range(1, 11))
-    sampler = CutPairsSampler(
-        source_cuts=cuts,
-        target_cuts=cuts,
-        shuffle=True,
-        max_source_frames=10 * 100,
-        max_target_frames=10 * 100,
-    )
-
-    for epoch in range(5):
-        assert len(sampler) == len([batch for batch in sampler])
-        sampler.set_epoch(epoch)
 
 
 def test_concat_cuts():
@@ -450,7 +332,6 @@ def test_bucketing_sampler_single_cuts_equal_duration():
     sampler = BucketingSampler(
         cut_set,
         sampler_type=SimpleCutSampler,
-        bucket_method="equal_duration",
         num_buckets=10,
     )
 
@@ -486,7 +367,7 @@ def test_bucketing_sampler_shuffle():
         sampler_type=SimpleCutSampler,
         shuffle=True,
         num_buckets=2,
-        max_frames=200,
+        max_duration=20.0,
     )
 
     sampler.set_epoch(0)
@@ -535,7 +416,6 @@ def test_bucketing_sampler_cut_pairs_equal_duration(shuffle):
         cut_set,
         cut_set_tgt,
         sampler_type=CutPairsSampler,
-        bucket_method="equal_duration",
         num_buckets=10,
         shuffle=shuffle,
     )
@@ -575,42 +455,6 @@ def test_bucketing_sampler_order_differs_between_epochs():
         new_order = [item for item in sampler]
         assert new_order != last_order
         last_order = new_order
-
-
-def test_bucketing_sampler_buckets_have_different_durations():
-    cut_set_1s = DummyManifest(CutSet, begin_id=0, end_id=10)
-    cut_set_2s = DummyManifest(CutSet, begin_id=10, end_id=20)
-    for c in cut_set_2s:
-        c.duration = 2.0
-    cut_set = (cut_set_1s + cut_set_2s).to_eager()
-
-    # The bucketing sampler should return 5 batches with two 1s cuts, and 10 batches with one 2s cut.
-    sampler = BucketingSampler(
-        cut_set, sampler_type=SimpleCutSampler, max_frames=200, num_buckets=2
-    )
-    batches = [item for item in sampler]
-    assert len(batches) == 15
-
-    # All cuts have the same durations (i.e. are from the same bucket in this case)
-    for batch in batches:
-        batch_durs = [cut_set[c.id].duration for c in batch]
-        assert all(d == batch_durs[0] for d in batch_durs)
-
-    batches = sorted(batches, key=len)
-    assert all(len(b) == 1 for b in batches[:10])
-    assert all(len(b) == 2 for b in batches[10:])
-
-
-@pytest.mark.parametrize(
-    "constraint", [{"max_frames": 1000}, {"max_samples": 16000}, {"max_duration": 10.0}]
-)
-def test_bucketing_sampler_time_constraints(constraint):
-    cut_set = DummyManifest(CutSet, begin_id=0, end_id=1000)
-    sampler = BucketingSampler(cut_set, sampler_type=SimpleCutSampler, **constraint)
-    sampled_cuts = []
-    for batch in sampler:
-        sampled_cuts.extend(batch)
-    assert set(cut_set.ids) == set(c.id for c in sampled_cuts)
 
 
 @pytest.mark.parametrize("world_size", [2, 3, 4])
@@ -790,7 +634,7 @@ def test_cut_pairs_sampler_filter():
         # Set an effective batch size of 10 cuts, as all have 1s duration == 100 frames
         # This way we're testing that it works okay when returning multiple batches in
         # a full epoch.
-        max_source_frames=1000,
+        max_source_duration=100.0,
     )
     removed_cut_id = "dummy-mono-cut-0010"
     sampler.filter(lambda cut: cut.id != removed_cut_id)
@@ -1039,7 +883,7 @@ def test_single_cut_sampler_lazy_shuffle(sampler_cls):
         pytest.param(
             BucketingSampler,
             marks=pytest.mark.xfail(
-                reason="BucketingSampler does not support lazy cuts pairs yet."
+                reason="BucketingSampler does not support lazy cuts pairs."
             ),
         ),
     ],
@@ -1058,7 +902,7 @@ def test_cut_pairs_sampler_lazy_shuffle(sampler_cls):
             # Set an effective batch size of 10 cuts, as all have 1s duration == 100 frames
             # This way we're testing that it works okay when returning multiple batches in
             # a full epoch.
-            max_source_frames=1000,
+            max_source_duration=100.0,
         )
         sampled_src_cuts = []
         sampled_tgt_cuts = []

--- a/test/dataset/test_speech_recognition_dataset.py
+++ b/test/dataset/test_speech_recognition_dataset.py
@@ -100,7 +100,7 @@ def test_k2_speech_recognition_iterable_dataset_shuffling():
         # Set an effective batch size of 10 cuts, as all have 1s duration == 100 frames
         # This way we're testing that it works okay when returning multiple batches in
         # a full epoch.
-        max_frames=1000,
+        max_duration=10.0,
     )
     dloader = DataLoader(dataset, batch_size=None, sampler=sampler, num_workers=2)
     dloader_cut_ids = []
@@ -117,9 +117,9 @@ def test_k2_speech_recognition_iterable_dataset_shuffling():
     assert dloader_cut_ids != [c.id for c in cut_set]
 
 
-def test_k2_speech_recognition_iterable_dataset_low_max_frames(k2_cut_set):
+def test_k2_speech_recognition_iterable_dataset_low_max_duration(k2_cut_set):
     dataset = K2SpeechRecognitionDataset()
-    sampler = SimpleCutSampler(k2_cut_set, shuffle=False, max_frames=2)
+    sampler = SimpleCutSampler(k2_cut_set, shuffle=False, max_duration=0.02)
     dloader = DataLoader(dataset, sampler=sampler, batch_size=None)
     # Check that it does not crash
     for batch in dloader:
@@ -225,7 +225,7 @@ def test_k2_speech_recognition_audio_inputs(k2_cut_set):
         input_strategy=AudioSamples(),
     )
     # all cuts in one batch
-    sampler = SimpleCutSampler(k2_cut_set, shuffle=False, max_frames=10000000)
+    sampler = SimpleCutSampler(k2_cut_set, shuffle=False)
     cut_ids = next(iter(sampler))
     batch = on_the_fly_dataset[cut_ids]
     assert batch["inputs"].shape == (4, 320000)


### PR DESCRIPTION
I've also removed some deprecated options like specifying max frames/samples and related tests.