### PR TITLE
add 'decode_options' to annotate_with_whisper

### DIFF
--- a/lhotse/workflows/whisper.py
+++ b/lhotse/workflows/whisper.py
@@ -39,6 +39,9 @@ def annotate_with_whisper(
     :param device: Where to run the inference (cpu, cuda, etc.).
     :param force_nonoverlapping: if True, the Whisper segment time-stamps will be processed to make
         sure they are non-overlapping.
+    :param download_root: if specified, the model will be downloaded to this directory. Otherwise,
+        it will be downloaded to the default location specfied by whisper.
+    :param decode_options: additional options to pass to the ``whisper.transcribe`` function.
     :return: a generator of cuts (use ``CutSet.open_writer()`` to write them).
     """
     assert is_module_available("whisper"), (

--- a/lhotse/workflows/whisper.py
+++ b/lhotse/workflows/whisper.py
@@ -20,6 +20,7 @@ def annotate_with_whisper(
     model_name: str = "base",
     device: str = "cpu",
     force_nonoverlapping: bool = False,
+    download_root: Optional[str] = None,
     **decode_options,
 ) -> Generator[MonoCut, None, None]:
     """
@@ -48,11 +49,11 @@ def annotate_with_whisper(
 
     if isinstance(manifest, RecordingSet):
         yield from _annotate_recordings(
-            manifest, model_name, device, force_nonoverlapping, **decode_options
+            manifest, model_name, device, force_nonoverlapping, download_root, **decode_options
         )
     elif isinstance(manifest, CutSet):
         yield from _annotate_cuts(
-            manifest, model_name, device, force_nonoverlapping, **decode_options
+            manifest, model_name, device, force_nonoverlapping, download_root, **decode_options
         )
     else:
         raise ValueError("The ``manifest`` must be either a RecordingSet or a CutSet.")
@@ -63,6 +64,7 @@ def _annotate_recordings(
     model_name: str,
     device: str,
     force_nonoverlapping: bool,
+    download_root: Optional[str] = None,
     **decode_options,
 ):
     """
@@ -70,7 +72,7 @@ def _annotate_recordings(
     """
     import whisper
 
-    model = whisper.load_model(model_name, device=device)
+    model = whisper.load_model(model_name, device=device, download_root=download_root)
 
     for recording in recordings:
         if recording.num_channels > 1:
@@ -116,6 +118,7 @@ def _annotate_cuts(
     model_name: str,
     device: str,
     force_nonoverlapping: bool,
+    download_root: Optional[str] = None,
     **decode_options,
 ):
     """
@@ -123,7 +126,7 @@ def _annotate_cuts(
     """
     import whisper
 
-    model = whisper.load_model(model_name, device=device)
+    model = whisper.load_model(model_name, device=device, download_root=download_root)
 
     for cut in cuts:
         if cut.num_channels > 1:


### PR DESCRIPTION
I added decode_options to better match the original whisper implementation and allowing more control over the generation process of the transcription. This should NOT be a breaking change.