### PR TITLE
Add option to create segments for LibriCSS

### DIFF
--- a/lhotse/bin/modes/recipes/libricss.py
+++ b/lhotse/bin/modes/recipes/libricss.py
@@ -13,12 +13,19 @@ from lhotse.utils import Pathlike
     type=click.Choice(["ihm", "ihm-mix", "sdm", "mdm"]),
     default="mdm",
     help="Type of the corpus to prepare",
+    show_default=True,
 )
-def libricss(corpus_dir: Pathlike, output_dir: Pathlike, type: str):
+@click.option(
+    "--segmented/--no-segmented",
+    default=False,
+    help="If True, the manifest will contain Cuts corresponding to 1-minute segments.",
+    show_default=True,
+)
+def libricss(corpus_dir: Pathlike, output_dir: Pathlike, type: str, segmented: bool):
     """
     LibriCSS recording and supervision manifest preparation.
     """
-    prepare_libricss(corpus_dir, output_dir, type)
+    prepare_libricss(corpus_dir, output_dir, type=type, segmented_cuts=segmented)
 
 
 @download.command()


### PR DESCRIPTION
The LibriCSS dataset comes with official ~1-min segments obtained by splitting the 10-min recordings at long silences. We add this an option to prepare this segmented data in the recipe.

Possible use case: evaluation of multi-talker ASR (e.g. https://arxiv.org/abs/2109.08555).