### PR TITLE
Allow dash in SequentialJsonlWriter

### DIFF
--- a/lhotse/serialization.py
+++ b/lhotse/serialization.py
@@ -173,7 +173,7 @@ class SequentialJsonlWriter:
     def __init__(self, path: Pathlike, overwrite: bool = True) -> None:
         self.path = path
         self.file = None
-        if not extension_contains(".jsonl", self.path):
+        if not (extension_contains(".jsonl", self.path) or (self.path == "-")):
             raise InvalidPathExtension(
                 f"SequentialJsonlWriter supports only JSONL format (one JSON item per line), "
                 f"but path='{path}'."


### PR DESCRIPTION
This makes piping possible for several CLI binaries such as `trim-to-supervisions` etc. An example piped workflow for combining LibriSpeech train set, cutting into shorter segments, and shuffling:

```
lhotse combine data/manifests/librispeech_cuts_train* - |\
  lhotse cut trim-to-alignments --type word --max-pause 0.2 - - |\
  shuf | gzip -c > data/manifests/librispeech_cuts_train_trimmed.jsonl.gz
 ```