### PR TITLE
Add multiprocessing to meeting simulation workflow

### DIFF
--- a/lhotse/bin/modes/workflows.py
+++ b/lhotse/bin/modes/workflows.py
@@ -313,6 +313,13 @@ def align_with_torchaudio(
     default=1234,
     help="Random seed for reproducibility.",
 )
+@click.option(
+    "--num-jobs",
+    "-j",
+    type=int,
+    default=1,
+    help="Number of parallel jobs to run.",
+)
 def simulate_meetings(
     in_cuts: str,
     out_cuts: str,

--- a/lhotse/parallel.py
+++ b/lhotse/parallel.py
@@ -68,7 +68,7 @@ class SubmitterThread(threading.Thread):
         self.use_threads = threads
 
     def run(self) -> None:
-        executor = ProcessPoolExecutor if self.use_threads else ThreadPoolExecutor
+        executor = ThreadPoolExecutor if self.use_threads else ProcessPoolExecutor
         with executor(self.num_jobs) as ex:
             for args in zip(*self.iterables):
                 future = ex.submit(self.fn, *args)

--- a/lhotse/workflows/meeting_simulation/base.py
+++ b/lhotse/workflows/meeting_simulation/base.py
@@ -145,12 +145,15 @@ class MeetingSampler:
         # sampling items from a set is O(n).
         self.samplers = {}
         for spk, spk_cuts in tqdm(
-            groupby(cuts, lambda cut: cut.supervisions[0].speaker),
+            groupby(
+                sorted(cuts, key=lambda cut: cut.supervisions[0].speaker),
+                lambda cut: cut.supervisions[0].speaker,
+            ),
             desc="Creating samplers for each speaker...",
         ):
             sampler = DynamicCutSampler(
                 CutSet.from_cuts(list(spk_cuts)).repeat(
-                    times=num_repeats, preserve_id=False
+                    times=num_repeats, preserve_id=True
                 ),
                 max_duration=max_duration_per_speaker,
                 max_cuts=max_utterances_per_speaker,
@@ -197,6 +200,9 @@ class MeetingSampler:
             except StopIteration:
                 del self.samplers[spk_id]
                 continue
+
+        # shuffle the utterances
+        utterances = utterances.shuffle()
 
         if self._remaining_meetings is not None:
             self._remaining_meetings -= 1

--- a/lhotse/workflows/meeting_simulation/base.py
+++ b/lhotse/workflows/meeting_simulation/base.py
@@ -3,13 +3,19 @@ This is an experimental workflow that can be used to simulate multi-speaker meet
 a CutSet containing MonoCut objects.
 """
 import abc
-from collections import defaultdict
-from typing import Optional
+import logging
+from itertools import groupby
+from typing import Dict, List, Optional, Union
+
+import numpy as np
+from tqdm import tqdm
 
 from lhotse import RecordingSet, SupervisionSet
 from lhotse.cut import CutSet
-from lhotse.dataset.sampling import DynamicCutSampler, RoundRobinSampler
+from lhotse.dataset.sampling import SimpleCutSampler
 from lhotse.utils import fastcopy, is_module_available
+
+MAX_TASKS_WAITING = 1000
 
 
 class BaseMeetingSimulator(abc.ABC):
@@ -83,6 +89,123 @@ class BaseMeetingSimulator(abc.ABC):
         ...
 
 
+class MeetingSampler:
+    """
+    Create a sampler that will be used to sample cuts from the input CutSet. The cuts
+    are partitioned into speaker-wise buckets, and a DynamicCutSampler is created for
+    each bucket. The samplers are then combined into a RoundRobinSampler, which will
+    sample cuts from each bucket in a round-robin fashion. When we iterate over the
+    sampler, we get batches of cuts from each bucket.
+
+    :param cuts: a CutSet containing MonoCut objects.
+    :param num_repeats: the number of times each cut will be repeated (by default, they
+        are repeated infinitely).
+    :param num_meetings: the number of meetings to simulate.
+    :param num_speakers_per_meeting: the number of speakers per meeting.
+    :param speaker_count_probs: the probabilities of the number of speakers per meeting.
+    :param max_duration_per_speaker: the maximum duration of a speaker in a meeting.
+    :param max_utterances_per_speaker: the maximum number of utterances of a speaker in a meeting.
+    :param seed: the random seed.
+    :return: a DynamicCutSampler object.
+    """
+
+    def __init__(
+        self,
+        cuts: CutSet,
+        num_repeats: Optional[int] = None,
+        num_meetings: Optional[int] = None,
+        num_speakers_per_meeting: Union[int, List[int]] = 2,
+        speaker_count_probs: Optional[List[float]] = None,
+        max_duration_per_speaker: Optional[float] = 20.0,
+        max_utterances_per_speaker: Optional[int] = 5,
+        seed: int = 0,
+    ):
+        # Some basic checks
+        assert all(n > 1 for n in num_speakers_per_meeting), (
+            "The number of speakers per meeting must be greater than 1. "
+            f"Got: {num_speakers_per_meeting}"
+        )
+        assert all(p > 0.0 for p in speaker_count_probs), (
+            "The probabilities of the number of speakers per meeting must be greater than 0. "
+            f"Got: {speaker_count_probs}"
+        )
+        assert sum(speaker_count_probs) == 1.0, (
+            "The probabilities of the number of speakers per meeting must sum to 1. "
+            f"Got: {speaker_count_probs}"
+        )
+        assert len(num_speakers_per_meeting) == len(
+            speaker_count_probs
+        ), "The number of speakers per meeting and the number of probabilities must be the same."
+
+        # Create samplers for each bucket.
+        self.samplers = []
+        for spk, spk_cuts in tqdm(
+            groupby(cuts, lambda cut: cut.supervisions[0].speaker),
+            desc="Creating samplers for each speaker...",
+        ):
+            sampler = SimpleCutSampler(
+                CutSet.from_cuts(list(spk_cuts)).repeat(
+                    times=num_repeats, preserve_id=True
+                ),
+                max_duration=max_duration_per_speaker,
+                max_cuts=max_utterances_per_speaker,
+                shuffle=True,
+                seed=seed,
+            )
+            self.samplers.append(sampler)
+
+        self.num_speakers_per_meeting = num_speakers_per_meeting
+        self.speaker_count_probs = speaker_count_probs
+
+        self.npr = np.random.RandomState(seed)
+        self._remaining_meetings = num_meetings
+        self._nondepleted_samplers_indices = list(range(len(self.samplers)))
+
+    def __iter__(self):
+        for sampler in self.samplers:
+            iter(sampler)
+        self._nondepleted_samplers_indices = list(range(len(self.samplers)))
+        return self
+
+    def __next__(self):
+        # If we have sampled enough meetings, stop.
+        if self._remaining_meetings is not None and self._remaining_meetings == 0:
+            raise StopIteration()
+
+        # If we don't have enough speakers, stop.
+        if len(self._nondepleted_samplers_indices) < min(self.num_speakers_per_meeting):
+            raise StopIteration()
+
+        # Sample the number of speakers for this meeting.
+        N = min(
+            self.npr.choice(self.num_speakers_per_meeting, p=self.speaker_count_probs),
+            len(self._nondepleted_samplers_indices),
+        )
+
+        this_batch_spk_ids = []
+        utterances = CutSet.from_cuts([])
+        while (
+            len(this_batch_spk_ids) < N and len(self._nondepleted_samplers_indices) > 0
+        ):
+            # Sample a speaker index.
+            idx = self.npr.choice(self._nondepleted_samplers_indices)
+            if idx in this_batch_spk_ids:
+                continue
+
+            sampler = self.samplers[idx]
+            try:
+                this_batch = next(sampler)
+                utterances += this_batch
+            except StopIteration:
+                self._nondepleted_samplers_indices.remove(idx)
+                continue
+            this_batch_spk_ids.append(idx)
+
+        if self._remaining_meetings is not None:
+            self._remaining_meetings -= 1
+        return utterances if len(utterances) > 0 else next(self)
+
+
 def reverberate_cuts(cuts: CutSet, *rirs: RecordingSet) -> CutSet:
     """
     Use provided RIRs to convolve each track of the input CutSet. The cuts here are
@@ -114,47 +237,3 @@ def reverberate_cuts(cuts: CutSet, *rirs: RecordingSet) -> CutSet:
             out_cuts.append(cut.reverb_rir())
 
     return CutSet.from_cuts(out_cuts)
-
-
-def create_sampler(
-    cuts: CutSet,
-    num_repeats: Optional[int] = None,
-    max_duration: float = None,
-    max_cuts: int = None,
-    seed: int = 0,
-) -> DynamicCutSampler:
-    """
-    Create a sampler that will be used to sample cuts from the input CutSet. The cuts
-    are partitioned into speaker-wise buckets, and a DynamicCutSampler is created for
-    each bucket. The samplers are then combined into a RoundRobinSampler, which will
-    sample cuts from each bucket in a round-robin fashion.
-
-    :param cuts: a CutSet containing MonoCut objects.
-    :param num_repeats: the number of times each cut will be repeated (by default, they
-        are repeated infinitely).
-    :param max_duration: the maximum duration of the cuts in each batch.
-    :param max_cuts: the maximum number of cuts in each batch.
-    :param seed: the random seed.
-    :return: a DynamicCutSampler object.
-    """
-    # Create buckets by speaker.
-    buckets = defaultdict(list)
-    for cut in cuts:
-        buckets[cut.supervisions[0].speaker].append(cut)
-
-    buckets = [CutSet.from_cuts(cuts) for cuts in buckets.values()]
-
-    # Create samplers for each bucket.
-    samplers = [
-        DynamicCutSampler(
-            cuts.repeat(times=num_repeats),
-            max_duration=max_duration,
-            max_cuts=max_cuts,
-            shuffle=True,
-            seed=seed,
-        )
-        for cuts in buckets
-    ]
-
-    # Combine samplers into a round-robin sampler.
-    return RoundRobinSampler(*samplers, randomize=True, seed=seed)

--- a/lhotse/workflows/meeting_simulation/base.py
+++ b/lhotse/workflows/meeting_simulation/base.py
@@ -153,7 +153,7 @@ class MeetingSampler:
         ):
             sampler = DynamicCutSampler(
                 CutSet.from_cuts(list(spk_cuts)).repeat(
-                    times=num_repeats, preserve_id=True
+                    times=num_repeats, preserve_id=False
                 ),
                 max_duration=max_duration_per_speaker,
                 max_cuts=max_utterances_per_speaker,

--- a/lhotse/workflows/meeting_simulation/base.py
+++ b/lhotse/workflows/meeting_simulation/base.py
@@ -91,11 +91,11 @@ class BaseMeetingSimulator(abc.ABC):
 
 class MeetingSampler:
     """
-    Create a sampler that will be used to sample cuts from the input CutSet. The cuts
-    are partitioned into speaker-wise buckets, and a DynamicCutSampler is created for
-    each bucket. The samplers are then combined into a RoundRobinSampler, which will
-    sample cuts from each bucket in a round-robin fashion. When we iterate over the
-    sampler, we get batches of cuts from each bucket.
+    Create a sampler that will be used to sample groups of utterances from the sources.
+    The cuts are partitioned into speaker-wise buckets, and a SimpleCutSampler is created
+    for each bucket. When we sample a group of utterances, we first sample the number of
+    speakers in the meeting, and then sample the utterances of each speaker. This is done
+    by sampling a batch from the corresponding SimpleCutSampler.
 
     :param cuts: a CutSet containing MonoCut objects.
     :param num_repeats: the number of times each cut will be repeated (by default, they

--- a/lhotse/workflows/meeting_simulation/conversational.py
+++ b/lhotse/workflows/meeting_simulation/conversational.py
@@ -1,17 +1,20 @@
 import logging
 from collections import defaultdict
+from multiprocessing import Pool
 from typing import Any, List, Optional, Union
 
 import numpy as np
 from tqdm import tqdm
 
 from lhotse import RecordingSet, SupervisionSet
-from lhotse.cut import CutSet, MixedCut, MixTrack, MonoCut
+from lhotse.cut import CutSet, MixedCut, MixTrack
 from lhotse.cut.set import mix
+from lhotse.parallel import parallel_map
 from lhotse.utils import uuid4
 from lhotse.workflows.meeting_simulation.base import (
+    MAX_TASKS_WAITING,
     BaseMeetingSimulator,
-    create_sampler,
+    MeetingSampler,
     reverberate_cuts,
 )
 
@@ -252,6 +255,7 @@ class ConversationalMeetingSimulator(BaseMeetingSimulator):
         max_utterances_per_speaker: Optional[int] = 5,
         allow_3fold_overlap: bool = False,
         seed: int = 0,
+        num_jobs: int = 1,
     ) -> CutSet:
         """
         Simulate the desired number of multi-speaker meetings.
@@ -271,6 +275,8 @@ class ConversationalMeetingSimulator(BaseMeetingSimulator):
         :param allow_3fold_overlap: if True, allow 3-fold overlaps between speakers.
             [Default: False]
         :param seed: the random seed to be used for simulation. [Default: 0]
+        :param num_jobs: the number of jobs to use for simulation. Use more jobs to speed up
+            simulation when you have large number of source utterances. [Default: 1]
         """
         from scipy.stats import bernoulli
 
@@ -288,85 +294,54 @@ class ConversationalMeetingSimulator(BaseMeetingSimulator):
                 num_speakers_per_meeting
             )
 
-        # Some basic checks
-        assert all(n > 1 for n in num_speakers_per_meeting), (
-            "The number of speakers per meeting must be greater than 1. "
-            f"Got: {num_speakers_per_meeting}"
-        )
-        assert all(p > 0.0 for p in speaker_count_probs), (
-            "The probabilities of the number of speakers per meeting must be greater than 0. "
-            f"Got: {speaker_count_probs}"
-        )
-        assert sum(speaker_count_probs) == 1.0, (
-            "The probabilities of the number of speakers per meeting must sum to 1. "
-            f"Got: {speaker_count_probs}"
-        )
-        assert len(num_speakers_per_meeting) == len(
-            speaker_count_probs
-        ), "The number of speakers per meeting and the number of probabilities must be the same."
-        assert all(
-            isinstance(cut, MonoCut) for cut in cuts
-        ), "Only MonoCuts are supported."
-
         # Initialize default distributions if not provided.
         if getattr(self, "same_spk_pause_dist", None) is None:
             self._init_defaults()
 
-        # Create cuts sampler
-        sampler = create_sampler(
-            cuts,
-            num_repeats=num_repeats,
-            max_duration=max_duration_per_speaker,
-            max_cuts=max_utterances_per_speaker,
-            seed=seed,
-        )
-        # Create an iterator from the sampler
-        sampler_iter = iter(sampler)
-
         # Create random number generators with the given seed.
-        npr = np.random.RandomState(seed)
-
         self.bernoulli = bernoulli
 
-        mixtures = []
-        N = len(cuts.speakers)
+        # Create cuts sampler
+        sampler = MeetingSampler(
+            cuts,
+            num_repeats=num_repeats,
+            num_meetings=num_meetings,
+            max_duration_per_speaker=max_duration_per_speaker,
+            max_utterances_per_speaker=max_utterances_per_speaker,
+            num_speakers_per_meeting=num_speakers_per_meeting,
+            speaker_count_probs=speaker_count_probs,
+            seed=seed,
+        )
+        sampler_iter = iter(sampler)
 
-        pbar = tqdm(total=num_meetings)
-        while True:
-            # If the number of meetings is provided, stop when we reach that number.
-            if num_meetings is not None and len(mixtures) >= num_meetings:
-                break
+        global _simulate_worker
 
-            # Sample the number of speakers for this meeting.
-            num_speakers = min(
-                npr.choice(num_speakers_per_meeting, p=speaker_count_probs), N
-            )
-
-            # Sample from the sampler to get 1 batch per desired number of speakers.
-            utterances = CutSet.from_cuts([])
-            finished = False
-            while len(utterances.speakers) < num_speakers:
-                try:
-                    this_batch = next(sampler_iter)
-                except StopIteration:
-                    # If we run out of data, finish simulation.
-                    finished = True
-                    break
-                utterances += this_batch
-
-            if finished:
-                break
-
-            # Randomly shuffle the utterances
-            utterances = utterances.shuffle()
-
-            # Create the meeting.
-            mixture = self._create_mixture(
+        def _simulate_worker(utterances):
+            return self._create_mixture(
                 utterances, allow_3fold_overlap=allow_3fold_overlap
             )
 
-            mixtures.append(mixture)
-            pbar.update(1)
+        mixtures = []
+        if num_jobs == 1:
+            # Don't use multiprocessing if num_jobs == 1.
+            for mixture in tqdm(
+                map(_simulate_worker, sampler_iter),
+                total=num_meetings,
+                desc="Simulating meetings",
+            ):
+                mixtures.append(mixture)
+        else:
+            for mixture in tqdm(
+                parallel_map(
+                    _simulate_worker,
+                    sampler_iter,
+                    num_jobs=num_jobs,
+                    queue_size=num_jobs * MAX_TASKS_WAITING,
+                ),
+                total=num_meetings,
+                desc="Simulating meetings",
+            ):
+                mixtures.append(mixture)
 
         return CutSet.from_cuts(mixtures)
 

--- a/lhotse/workflows/meeting_simulation/speaker_independent.py
+++ b/lhotse/workflows/meeting_simulation/speaker_independent.py
@@ -6,12 +6,14 @@ import numpy as np
 from tqdm import tqdm
 
 from lhotse import RecordingSet, SupervisionSet
-from lhotse.cut import CutSet, MixedCut, MixTrack, MonoCut
+from lhotse.cut import CutSet, MixedCut, MixTrack
 from lhotse.cut.set import mix
+from lhotse.parallel import parallel_map
 from lhotse.utils import uuid4
 from lhotse.workflows.meeting_simulation.base import (
+    MAX_TASKS_WAITING,
     BaseMeetingSimulator,
-    create_sampler,
+    MeetingSampler,
     reverberate_cuts,
 )
 
@@ -120,6 +122,7 @@ class SpeakerIndependentMeetingSimulator(BaseMeetingSimulator):
         max_duration_per_speaker: Optional[float] = 20.0,
         max_utterances_per_speaker: Optional[int] = 5,
         seed: int = 0,
+        num_jobs: int = 1,
     ) -> CutSet:
         """
         Simulate the desired number of multi-speaker meetings.
@@ -138,6 +141,8 @@ class SpeakerIndependentMeetingSimulator(BaseMeetingSimulator):
         :param max_utterances_per_speaker: the maximum number of utterances per speaker.
             [Default: 5]
         :param seed: the random seed to be used for simulation. [Default: 0]
+        :param num_jobs: the number of jobs to use for simulation. Use more jobs to speed up
+            simulation when you have large number of source utterances. [Default: 1]
         """
         if num_meetings is None and num_repeats is None:
             raise ValueError("Either num_meetings or num_repeats must be provided.")
@@ -153,69 +158,25 @@ class SpeakerIndependentMeetingSimulator(BaseMeetingSimulator):
                 num_speakers_per_meeting
             )
 
-        # Some basic checks
-        assert all(n > 1 for n in num_speakers_per_meeting), (
-            "The number of speakers per meeting must be greater than 1. "
-            f"Got: {num_speakers_per_meeting}"
-        )
-        assert all(p > 0.0 for p in speaker_count_probs), (
-            "The probabilities of the number of speakers per meeting must be greater than 0. "
-            f"Got: {speaker_count_probs}"
-        )
-        assert sum(speaker_count_probs) == 1.0, (
-            "The probabilities of the number of speakers per meeting must sum to 1. "
-            f"Got: {speaker_count_probs}"
-        )
-        assert len(num_speakers_per_meeting) == len(
-            speaker_count_probs
-        ), "The number of speakers per meeting and the number of probabilities must be the same."
-        assert all(
-            isinstance(cut, MonoCut) for cut in cuts
-        ), "Only MonoCuts are supported."
-
         # Create cuts sampler
-        sampler = create_sampler(
+        sampler = MeetingSampler(
             cuts,
             num_repeats=num_repeats,
-            max_duration=max_duration_per_speaker,
-            max_cuts=max_utterances_per_speaker,
+            num_meetings=num_meetings,
+            max_duration_per_speaker=max_duration_per_speaker,
+            max_utterances_per_speaker=max_utterances_per_speaker,
+            num_speakers_per_meeting=num_speakers_per_meeting,
+            speaker_count_probs=speaker_count_probs,
             seed=seed,
         )
-        # Create an iterator from the sampler
         sampler_iter = iter(sampler)
 
         # Create random number generators with the given seed.
         npr = np.random.RandomState(seed)
 
-        mixtures = []
-        N = len(cuts.speakers)
+        global _simulate_worker
 
-        pbar = tqdm(total=num_meetings)
-        while True:
-            # If the number of meetings is provided, stop when we reach that number.
-            if num_meetings is not None and len(mixtures) >= num_meetings:
-                break
-
-            # Sample the number of speakers for this meeting.
-            num_speakers = min(
-                npr.choice(num_speakers_per_meeting, p=speaker_count_probs), N
-            )
-
-            # Sample from the sampler to get 1 batch per desired number of speakers.
-            utterances = CutSet.from_cuts([])
-            finished = False
-            while len(utterances.speakers) < num_speakers:
-                try:
-                    this_batch = next(sampler_iter)
-                except StopIteration:
-                    # If we run out of data, finish simulation.
-                    finished = True
-                    break
-                utterances += this_batch
-
-            if finished:
-                break
-
+        def _simulate_worker(utterances: CutSet) -> MixedCut:
             # Group the cuts by speaker.
             utts_by_speaker = defaultdict(list)
             for utt in utterances:
@@ -231,9 +192,27 @@ class SpeakerIndependentMeetingSimulator(BaseMeetingSimulator):
 
             # Create the meeting.
             mixture = self._create_mixture(utterances, silence_durations)
+            return mixture
 
-            mixtures.append(mixture)
-            pbar.update(1)
+        mixtures = []
+        if num_jobs == 1:
+            # Don't use multiprocessing if num_jobs == 1.
+            for mixture in tqdm(
+                map(_simulate_worker, sampler_iter), total=num_meetings
+            ):
+                mixtures.append(mixture)
+        else:
+            for mixture in tqdm(
+                parallel_map(
+                    _simulate_worker,
+                    sampler_iter,
+                    num_jobs=num_jobs,
+                    queue_size=num_jobs * MAX_TASKS_WAITING,
+                ),
+                total=num_meetings,
+                desc="Simulating meetings",
+            ):
+                mixtures.append(mixture)
 
         return CutSet.from_cuts(mixtures)
 

--- a/test/fixtures/ami/cuts.json
+++ b/test/fixtures/ami/cuts.json
@@ -40,7 +40,7 @@
         "id": "ES2011a.Headset-0-40s-46s-0-3",
         "language": "English",
         "recording_id": "ES2011a.Headset-0-40s-46s.wav",
-        "speaker": "ES2011a.Headset",
+        "speaker": "ES2011a.Headset-1",
         "start": 1.46,
         "text": "I'M ABIGAIL CLAFLIN"
       },
@@ -50,7 +50,7 @@
         "id": "ES2011a.Headset-0-40s-46s-0-4",
         "language": "English",
         "recording_id": "ES2011a.Headset-0-40s-46s.wav",
-        "speaker": "ES2011a.Headset",
+        "speaker": "ES2011a.Headset-2",
         "start": 3.36,
         "text": "YOU CAN CALL ME ABBIE"
       }

--- a/test/fixtures/libri/cuts.json
+++ b/test/fixtures/libri/cuts.json
@@ -11,7 +11,8 @@
         "start": 0,
         "duration": 10.0,
         "channel": 0,
-        "text": "EXAMPLE OF TEXT"
+        "text": "EXAMPLE OF TEXT",
+        "speaker": "libri-spk1"
       }
     ],
     "features": {

--- a/test/test_workflows.py
+++ b/test/test_workflows.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 import pytest
-from hypothesis import given, reproduce_failure, settings
+from hypothesis import given, settings
 from hypothesis import strategies as st
 
 from lhotse import CutSet, SupervisionSet

--- a/test/test_workflows.py
+++ b/test/test_workflows.py
@@ -79,9 +79,12 @@ def test_simulate_meetings(
     if reverberate:
         mixed_cuts = simulator.reverberate(mixed_cuts)
 
-    assert len(mixed_cuts) > 0
-    mixed_cut = mixed_cuts[0]
-    assert mixed_cut.load_audio().shape[1] == mixed_cut.num_samples
+    if len(cuts.speakers) >= num_speakers_per_meeting:
+        assert len(mixed_cuts) > 0
+        mixed_cut = mixed_cuts[0]
+        assert mixed_cut.load_audio().shape[1] == mixed_cut.num_samples
+    else:
+        assert len(mixed_cuts) == 0
 
 
 def test_base_meeting_simulator_raises():

--- a/test/test_workflows.py
+++ b/test/test_workflows.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 import pytest
-from hypothesis import given, settings
+from hypothesis import given, reproduce_failure, settings
 from hypothesis import strategies as st
 
 from lhotse import CutSet, SupervisionSet
@@ -37,6 +37,7 @@ def sups():
     max_utterances_per_speaker=st.integers(min_value=0, max_value=5),
     reverberate=st.booleans(),
     seed=st.integers(min_value=0, max_value=2**16 - 1),
+    num_jobs=st.integers(min_value=1, max_value=4),
 )
 def test_simulate_meetings(
     cuts: CutSet,
@@ -50,6 +51,7 @@ def test_simulate_meetings(
     max_utterances_per_speaker: int,
     reverberate: bool,
     seed: int,
+    num_jobs: int,
 ):
     if method == "independent":
         simulator = SpeakerIndependentMeetingSimulator()
@@ -71,6 +73,7 @@ def test_simulate_meetings(
         if max_utterances_per_speaker > 0
         else None,
         seed=seed,
+        num_jobs=num_jobs,
     )
 
     if reverberate:


### PR DESCRIPTION
## Changes in this PR

* Refactor meeting simulation workflow to put utterance group creation as a common sampler.
* Add option for using multiple workers to mix the sampled utterance groups. Can potentially speed up ~2-3x.
* Fix `parallel_map` method.

## Recommendations for `num_jobs`

When using the `simulate()` method in the workflow. we recommend using 1 job when the number of source utterances is small (up to 50k, for example). For larger inputs, this number can be scaled up slowly, but not more than 4-8 jobs to avoid slow-down due to multiprocessing overhead.