### PR TITLE
Add padding direction when using transform ExtraPadding

### DIFF
--- a/lhotse/dataset/cut_transforms/extra_padding.py
+++ b/lhotse/dataset/cut_transforms/extra_padding.py
@@ -55,7 +55,9 @@ class ExtraPadding:
             extra_frames, extra_samples, extra_seconds
         ), "For ExtraPadding, you have to specify exactly one of: frames, samples, or duration."
         assert direction in [
-            "both", "left", "right"
+            "both",
+            "left",
+            "right",
         ], "Only three padding modes are supported"
         self.extra_frames = extra_frames
         self.extra_samples = extra_samples

--- a/lhotse/dataset/cut_transforms/extra_padding.py
+++ b/lhotse/dataset/cut_transforms/extra_padding.py
@@ -31,6 +31,7 @@ class ExtraPadding:
         pad_feat_value: float = LOG_EPSILON,
         randomized: bool = False,
         preserve_id: bool = False,
+        direction: str = "both",
     ) -> None:
         """
         ExtraPadding's constructor.
@@ -48,16 +49,21 @@ class ExtraPadding:
             for duration -- sample a float).
         :param preserve_id: When ``True``, preserves the IDs the cuts had before augmentation.
             Otherwise, new random IDs are generated for the augmented cuts (default).
+        :param direction: The padding direction.
         """
         assert exactly_one_not_null(
             extra_frames, extra_samples, extra_seconds
         ), "For ExtraPadding, you have to specify exactly one of: frames, samples, or duration."
+        assert direction in [
+            "both", "left", "right"
+        ], "Only three padding modes are supported"
         self.extra_frames = extra_frames
         self.extra_samples = extra_samples
         self.extra_seconds = extra_seconds
         self.pad_feat_value = pad_feat_value
         self.randomized = randomized
         self.preserve_id = preserve_id
+        self.direction = direction
 
     def __call__(self, cuts: CutSet) -> CutSet:
         if self.extra_frames is not None:
@@ -66,7 +72,7 @@ class ExtraPadding:
                     num_frames=c.num_frames
                     + maybe_sample_int(value=self.extra_frames, sample=self.randomized),
                     pad_feat_value=self.pad_feat_value,
-                    direction="both",
+                    direction=self.direction,
                     preserve_id=self.preserve_id,
                 )
                 for c in cuts
@@ -78,7 +84,7 @@ class ExtraPadding:
                     + maybe_sample_int(
                         value=self.extra_samples, sample=self.randomized
                     ),
-                    direction="both",
+                    direction=self.direction,
                     preserve_id=self.preserve_id,
                 )
                 for c in cuts
@@ -92,7 +98,7 @@ class ExtraPadding:
                         sample=self.randomized,
                     ),
                     pad_feat_value=self.pad_feat_value,
-                    direction="both",
+                    direction=self.direction,
                     preserve_id=self.preserve_id,
                 )
                 for c in cuts

--- a/lhotse/dataset/speech_recognition.py
+++ b/lhotse/dataset/speech_recognition.py
@@ -107,6 +107,9 @@ class K2SpeechRecognitionDataset(torch.utils.data.Dataset):
         # the supervision boundaries.
         for tnfm in self.cut_transforms:
             cuts = tnfm(cuts)
+        
+        # Sort the cuts again after transforms    
+        cuts = cuts.sort_by_duration(ascending=False)
 
         # Get a tensor with batched feature matrices, shape (B, T, F)
         # Collation performs auto-padding, if necessary.

--- a/lhotse/dataset/speech_recognition.py
+++ b/lhotse/dataset/speech_recognition.py
@@ -107,8 +107,8 @@ class K2SpeechRecognitionDataset(torch.utils.data.Dataset):
         # the supervision boundaries.
         for tnfm in self.cut_transforms:
             cuts = tnfm(cuts)
-        
-        # Sort the cuts again after transforms    
+
+        # Sort the cuts again after transforms
         cuts = cuts.sort_by_duration(ascending=False)
 
         # Get a tensor with batched feature matrices, shape (B, T, F)


### PR DESCRIPTION
This PR adds the padding direction as an option when using transform `ExtraPadding`.

The original implementation only supports padding on both sides. Now users can select from "left", "right" or "both".
