### PR TITLE
Fix typo in https://github.com/lhotse-speech/lhotse/blob/master/lhotse/cut/mixed.py line 76 

### DIFF
--- a/lhotse/cut/mixed.py
+++ b/lhotse/cut/mixed.py
@@ -73,7 +73,7 @@ class MixedCut(Cut):
     Its primary purpose is to allow time-domain and feature-domain augmentation via mixing the training cuts
     with noise, music, and babble cuts. The actual mixing operations are performed on-the-fly.
 
-    Internally, :class:`~lhotse.cut.MixedCut` holds other cuts in multiple trakcs (:class:`~lhotse.cut.MixTrack`),
+    Internally, :class:`~lhotse.cut.MixedCut` holds other cuts in multiple tracks (:class:`~lhotse.cut.MixTrack`),
     each with its own offset and SNR that is relative to the first track.
 
     Please refer to the documentation of :class:`~lhotse.cut.Cut` to learn more about using cuts.


### PR DESCRIPTION
line 76: 
```
Internally, :class:`~lhotse.cut.MixedCut` holds other cuts in multiple trakcs (:class:`~lhotse.cut.MixTrack`),
```
`trakcs` -> `tracks`