### PR TITLE
Small fix for speechcommands.py

### DIFF
--- a/lhotse/recipes/speechcommands.py
+++ b/lhotse/recipes/speechcommands.py
@@ -162,7 +162,7 @@ def _prepare_train(
 
         if train_path_splits[0] == BACKGROUND_NOISE:
             speaker = None
-            text = None
+            text = ""
         else:
             speaker = audio_file_name_splits[0]
             text = train_path_splits[0].strip()
@@ -217,7 +217,7 @@ def _prepare_valid(
 
         if valid_path_splits[0] == BACKGROUND_NOISE:
             speaker = None
-            text = None
+            text = ""
         else:
             speaker = audio_file_name_splits[0]
             text = valid_path_splits[0].strip()
@@ -285,7 +285,7 @@ def _prepare_test(
             text = test_path_splits[0].strip()
         elif test_path_splits[0] == SILENCE:
             speaker = None
-            text = None
+            text = ""
         elif test_path_splits[0] == UNKNOWN:
             speaker = audio_file_name_splits[1]
             text = audio_file_name_splits[0].strip()


### PR DESCRIPTION
In the initial version, I assigned the value `None` to the `text` parameter in SupervisionSegment for instances labeled BACKGROUND_NOISE or SILENCE, which could cause an error in https://github.com/lhotse-speech/lhotse/blob/master/lhotse/dataset/speech_recognition.py#L138.

The None type is not compatible with the default_collate(), so I replace the value `None` with "" in this PR. 