### PR TITLE
Function to drop alignments from cut

### DIFF
--- a/lhotse/cut/data.py
+++ b/lhotse/cut/data.py
@@ -382,6 +382,12 @@ class DataCut(Cut, metaclass=ABCMeta):
         """Return a copy of the current :class:`.DataCut`, detached from ``supervisions``."""
         return fastcopy(self, supervisions=[])
 
+    def drop_alignments(self) -> "DataCut":
+        """Return a copy of the current :class:`.DataCut`, detached from ``alignments``."""
+        return fastcopy(
+            self, supervisions=[fastcopy(s, alignment={}) for s in self.supervisions]
+        )
+
     def fill_supervision(
         self, add_empty: bool = True, shrink_ok: bool = False
     ) -> "DataCut":

--- a/lhotse/cut/mixed.py
+++ b/lhotse/cut/mixed.py
@@ -1041,6 +1041,13 @@ class MixedCut(Cut):
             tracks=[fastcopy(t, cut=t.cut.drop_supervisions()) for t in self.tracks],
         )
 
+    def drop_alignments(self) -> "MixedCut":
+        """Return a copy of the current :class:`.MixedCut`, detached from ``supervisions``."""
+        return fastcopy(
+            self,
+            tracks=[fastcopy(t, cut=t.cut.drop_alignments()) for t in self.tracks],
+        )
+
     def compute_and_store_features(
         self,
         extractor: FeatureExtractor,

--- a/lhotse/cut/padding.py
+++ b/lhotse/cut/padding.py
@@ -375,6 +375,10 @@ class PaddingCut(Cut):
         """Return a copy of the current :class:`.PaddingCut`, detached from ``supervisions``."""
         return self
 
+    def drop_alignments(self) -> "PaddingCut":
+        """Return a copy of the current :class:`.PaddingCut`, detached from ``alignments``."""
+        return self
+
     def compute_and_store_features(
         self, extractor: FeatureExtractor, *args, **kwargs
     ) -> Cut:

--- a/lhotse/cut/set.py
+++ b/lhotse/cut/set.py
@@ -1821,6 +1821,12 @@ class CutSet(Serializable, AlgorithmMixin):
         """
         return self.map(lambda cut: cut.drop_supervisions())
 
+    def drop_alignments(self) -> "CutSet":
+        """
+        Return a new :class:`.CutSet`, where each :class:`.Cut` is copied and detached from the alignments present in its supervisions.
+        """
+        return self.map(lambda cut: cut.drop_alignments())
+
     def compute_and_store_features(
         self,
         extractor: FeatureExtractor,

--- a/test/cut/test_cut_drop_attributes.py
+++ b/test/cut/test_cut_drop_attributes.py
@@ -73,6 +73,17 @@ def test_drop_supervisions(cut):
     assert len(cut_drop.supervisions) == 0
 
 
+@parametrize_on_cut_types
+def test_drop_alignments(cut):
+    assert all(len(s.alignment) > 0 for s in cut.supervisions) or isinstance(
+        cut, PaddingCut
+    )
+    cut_drop = cut.drop_alignments()
+    assert all(
+        s.alignment is None or len(s.alignment) == 0 for s in cut_drop.supervisions
+    )
+
+
 @pytest.fixture()
 def cutset():
     return CutSet.from_cuts(
@@ -126,3 +137,13 @@ def test_drop_supervisions_cutset(cutset):
     cutset_drop = cutset.drop_supervisions()
     assert any(len(cut.supervisions) > 0 for cut in cutset)
     assert all(len(cut.supervisions) == 0 for cut in cutset_drop)
+
+
+def test_drop_alignments_cutset(cutset):
+    assert any(all(len(s.alignment) > 0 for s in cut.supervisions) for cut in cutset)
+    cutset_drop = cutset.drop_alignments()
+    assert any(all(len(s.alignment) > 0 for s in cut.supervisions) for cut in cutset)
+    assert all(
+        all(s.alignment is None or len(s.alignment) == 0 for s in cut.supervisions)
+        for cut in cutset_drop
+    )


### PR DESCRIPTION
This is just a helper function to drop alignments if they are not required. I have been using it in my multi-talker dataset class to reduce size of the returned batch. Might be useful until such time as we decide to store alignments in a separate archive, like features.