### PR TITLE
Add `transforms` attribute for MixedCut

### DIFF
--- a/test/cut/test_cut_augmentation.py
+++ b/test/cut/test_cut_augmentation.py
@@ -471,17 +471,20 @@ def test_mixed_cut_start01_reverb_rir_multi_channel(
     not is_module_available("pyloudnorm"),
     reason="This test requires pyloudnorm to be installed.",
 )
-@pytest.mark.parametrize("target", [-15.0, -20.0, -25.0])
-def test_mixed_cut_normalize_loudness(cut_with_supervision_start01, target):
+@pytest.mark.parametrize(
+    "target, mix_first", [(-15.0, True), (-20.0, True), (-25.0, False)]
+)
+def test_mixed_cut_normalize_loudness(cut_with_supervision_start01, target, mix_first):
     mixed_cut = cut_with_supervision_start01.append(cut_with_supervision_start01)
-    mixed_cut_ln = mixed_cut.normalize_loudness(target)
+    mixed_cut_ln = mixed_cut.normalize_loudness(target, mix_first=mix_first)
 
     import pyloudnorm as pyln
 
     # check if loudness is correct
     meter = pyln.Meter(mixed_cut_ln.sampling_rate)  # create BS.1770 meter
     loudness = meter.integrated_loudness(mixed_cut_ln.load_audio().T)
-    assert loudness == pytest.approx(target, abs=0.5)
+    if mix_first:
+        assert loudness == pytest.approx(target, abs=0.5)
 
 
 @pytest.mark.skipif(

--- a/test/cut/test_cut_augmentation.py
+++ b/test/cut/test_cut_augmentation.py
@@ -349,7 +349,7 @@ def test_mixed_cut_start01_perturb_volume(cut_with_supervision_start01):
 def test_mixed_cut_start01_reverb_rir(cut_with_supervision_start01, rir):
     mixed_rvb = cut_with_supervision_start01.append(
         cut_with_supervision_start01
-    ).reverb_rir(rir_recording=rir)
+    ).reverb_rir(rir_recording=rir, mix_first=False)
     assert mixed_rvb.start == 0  # MixedCut always starts at 0
     assert mixed_rvb.duration == cut_with_supervision_start01.duration * 2
     assert mixed_rvb.end == cut_with_supervision_start01.duration * 2
@@ -393,6 +393,24 @@ def test_mixed_cut_start01_reverb_rir(cut_with_supervision_start01, rir):
         np.hstack(
             (cut_with_supervision_start01_samples, cut_with_supervision_start01_samples)
         ),
+    )
+
+
+def test_mixed_cut_start01_reverb_rir_mix_first(cut_with_supervision_start01, rir):
+    mixed_rvb = cut_with_supervision_start01.pad(duration=0.5).reverb_rir(
+        rir_recording=rir, mix_first=True
+    )
+    assert mixed_rvb.start == 0  # MixedCut always starts at 0
+    assert mixed_rvb.duration == 0.5
+    assert mixed_rvb.end == 0.5
+    assert mixed_rvb.num_samples == 4000
+
+    # Check that the padding part should not be all zeros afte
+    np.testing.assert_raises(
+        AssertionError,
+        np.testing.assert_array_almost_equal,
+        mixed_rvb.load_audio()[:, 3200:],
+        np.zeros((1, 800)),
     )
 
 
@@ -447,6 +465,23 @@ def test_mixed_cut_start01_reverb_rir_multi_channel(
     else:
         with pytest.raises(AssertionError):
             mixed_cut.reverb_rir(multi_channel_rir, rir_channels=rir_channels)
+
+
+@pytest.mark.skipif(
+    not is_module_available("pyloudnorm"),
+    reason="This test requires pyloudnorm to be installed.",
+)
+@pytest.mark.parametrize("target", [-15.0, -20.0, -25.0])
+def test_mixed_cut_normalize_loudness(cut_with_supervision_start01, target):
+    mixed_cut = cut_with_supervision_start01.append(cut_with_supervision_start01)
+    mixed_cut_ln = mixed_cut.normalize_loudness(target)
+
+    import pyloudnorm as pyln
+
+    # check if loudness is correct
+    meter = pyln.Meter(mixed_cut_ln.sampling_rate)  # create BS.1770 meter
+    loudness = meter.integrated_loudness(mixed_cut_ln.load_audio().T)
+    assert loudness == pytest.approx(target, abs=0.5)
 
 
 @pytest.mark.skipif(
@@ -587,6 +622,10 @@ def test_cut_perturb_volume(cut_set, cut_id, scale):
     )
 
 
+@pytest.mark.skipif(
+    not is_module_available("pyloudnorm"),
+    reason="This test requires pyloudnorm to be installed.",
+)
 @pytest.mark.parametrize("target", [-15.0, -20.0, -25.0])
 def test_cut_normalize_loudness(libri_cut_set, target):
     cut_set_ln = libri_cut_set.normalize_loudness(target)

--- a/test/cut/test_cut_mixing.py
+++ b/test/cut/test_cut_mixing.py
@@ -345,6 +345,28 @@ def test_mix_cut_snr_pad_both(libri_cut):
     assert E(feats_nosnr) > E(feats_snr)
 
 
+@pytest.mark.parametrize("mix_first", [True, False])
+def test_mix_cut_with_transform(libri_cut, mix_first):
+    # Create original mixed cut
+    padded = libri_cut.pad(duration=20, direction="right")
+    # Create transformed mixed cut
+    padded = padded.reverb_rir(mix_first=mix_first)
+    # Mix another cut
+    mixed1 = padded.mix(libri_cut)
+    mixed2 = libri_cut.mix(padded)
+
+    assert isinstance(padded, MixedCut)
+    assert len(padded.tracks) == 2
+    assert isinstance(mixed1, MixedCut)
+    assert isinstance(mixed2, MixedCut)
+    if mix_first:
+        assert len(mixed1.tracks) == 2
+        assert len(mixed2.tracks) == 2
+    else:
+        assert len(mixed1.tracks) == 3
+        assert len(mixed2.tracks) == 3
+
+
 def test_cut_set_mix_snr_is_deterministic():
     cuts = DummyManifest(CutSet, begin_id=0, end_id=2)
 


### PR DESCRIPTION
Currently, for `MixedCut`, any transforms are always lazily applied on the underlying tracks. This is fine for transforms such as speed perturbation, but may not be ideal for other kinds of transforms. Consider the following examples:

1. We have a `MixedCut` consisting of 3 tracks: 2 `MonoCut`s and a `PaddingCut`, i.e., it represents 2 utterances from a speaker with some silence in between. Suppose we want to convolve it with an RIR. In the current method, the tracks will be individually convolved, and the silence portion will not contain any residue from the previous `MonoCut`. Instead, we should first mix the 3 tracks and then apply the RIR on the resulting audio.

2. We have a `MixedCut` comprising 2 `MonoCut`s with some overlap, and we want to perform loudness normalization. Currently, the tracks will be normalized individually and then mixed, and the resulting mixture may not have the target loudness.

To solve these problems, we introduce a `transforms` attribute for `MixedCut`. It is analogous to the `transforms` attribute in `Recording`, and contains the transforms that should be lazily applied at the time of audio loading, but after the underlying tracks have been mixed. 