### PR TITLE
AudioCache: caching for "command" type of audio files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ examples/tmp
 # IDEs / editors
 .idea/
 .vscode/
+*.sw?
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/lhotse/audio.py
+++ b/lhotse/audio.py
@@ -211,7 +211,7 @@ class AudioSource:
                     "You requested a subset of a recording that is read from URL. "
                     "Expect large I/O overhead if you are going to read many chunks like these, "
                     "since every time we will download the whole file rather than its subset."
-                    "You can use `caching.set_caching_enabled(True)` to mitigate the overhead."
+                    "You can use `lhotse.set_caching_enabled(True)` to mitigate the overhead."
                 )
 
             # Let's assume 'self.source' is url to unchangeable file,

--- a/lhotse/audio.py
+++ b/lhotse/audio.py
@@ -191,7 +191,7 @@ class AudioSource:
                     "You requested a subset of a recording that is read from disk via a bash command. "
                     "Expect large I/O overhead if you are going to read many chunks like these, "
                     "since every time we will read the whole file rather than its subset."
-                    "You can use `caching.set_caching_enabled(True)` to mitigate the overhead."
+                    "You can use `lhotse.set_caching_enabled(True)` to mitigate the overhead."
                 )
 
             # Let's assume 'self.source' is a pipe-command with unchangeable file,

--- a/lhotse/audio.py
+++ b/lhotse/audio.py
@@ -16,7 +16,6 @@ from itertools import islice
 from math import ceil, sqrt
 from pathlib import Path
 from subprocess import PIPE, CalledProcessError, run
-from threading import Lock
 from typing import (
     Any,
     Callable,
@@ -44,7 +43,7 @@ from lhotse.augmentation import (
     Tempo,
     Volume,
 )
-from lhotse.caching import dynamic_lru_cache
+from lhotse.caching import AudioCache
 from lhotse.lazy import AlgorithmMixin
 from lhotse.serialization import Serializable
 from lhotse.utils import (
@@ -144,92 +143,6 @@ def set_ffmpeg_torchaudio_info_enabled(enabled: bool) -> None:
     FFMPEG_TORCHAUDIO_INFO_ENABLED = enabled
 
 
-class AudioCache:
-    """
-    Cache of 'bytes' objects with audio data.
-    It is used to cache the "command" type audio inputs.
-
-    By default it is enabled, to disable call `AudioCache.disable()`.
-    The cache size is limited to max 100 elements and 500MB of audio.
-
-    A global dict `__cache_dict` (static member variable of class AudioCache)
-    is holding the wavs as 'bytes' arrays.
-    The key is the 'source' identifier (i.e. the command for loading the data).
-
-    Thread-safety is ensured by a threading.Lock guard.
-    """
-
-    __enabled: bool = True
-
-    max_cache_memory: int = 500 * 1e6
-    max_cache_elements: int = 100
-
-    __cache_dict: Dict[str, bytes] = {}
-    __lock: Lock = Lock()
-
-    @classmethod
-    def disable(cls, value=False):
-        cls.__enabled = value
-
-    @classmethod
-    def enabled(cls) -> bool:
-        return cls.__enabled
-
-    @classmethod
-    def try_cache(cls, key: str) -> Union[bytes, None]:
-        """
-        Test if 'key' is in the chache. If yes return the bytes array,
-        otherwise return None.
-        """
-
-        if not cls.__enabled:
-            return None
-
-        with cls.__lock:
-            if key in cls.__cache_dict:
-                return cls.__cache_dict[key]
-            else:
-                return None
-
-    @classmethod
-    def add_to_cache(cls, key: str, value: bytes):
-        """
-        Add the new (key,value) pair to cache.
-        Possibly free some elements before adding the new pair.
-        """
-
-        if not cls.__enabled:
-            return None
-
-        if len(value) > cls.max_cache_memory:
-            return
-
-        with cls.__lock:
-            # limit cache elements
-            while len(cls.__cache_dict) > cls.max_cache_elements:
-                # remove oldest elements from cache
-                cls.__cache_dict.pop(next(iter(cls.__cache_dict)))
-
-            # limit cache memory
-            while len(value) + AudioCache.__cache_memory() > cls.max_cache_memory:
-                # remove oldest elements from cache
-                cls.__cache_dict.pop(next(iter(cls.__cache_dict)))
-
-            # store the new (key,value) pair
-            cls.__cache_dict[key] = value
-
-    @classmethod
-    def __cache_memory(cls) -> int:
-        """
-        Return size of AudioCache values in bytes.
-        (internal, not to be called from outside)
-        """
-        ans = 0
-        for key, value in cls.__cache_dict.items():
-            ans += len(value)
-        return ans
-
-
 # TODO: document the dataclasses like this:
 # https://stackoverflow.com/a/3051356/5285891
 
@@ -274,17 +187,15 @@ class AudioSource:
 
         if self.type == "command":
             if (offset != 0.0 or duration is not None) and not AudioCache.enabled():
-                # TODO(pzelasko): How should we support chunking for commands?
-                #                 We risk being very inefficient when reading many chunks from the same file
-                #                 without some caching scheme, because we'll be re-running commands.
                 warnings.warn(
                     "You requested a subset of a recording that is read from disk via a bash command. "
                     "Expect large I/O overhead if you are going to read many chunks like these, "
                     "since every time we will read the whole file rather than its subset."
-                    "You can enable caching by `AudioCache.enable()`."
+                    "You can enable caching by `AudioCache.enable()`, "
+                    "or by setting env variable `LHOTSE_AUDIO_CACHE_ENABLED=1`."
                 )
 
-            # Let's assume 'self.source' is command with a file,
+            # Let's assume 'self.source' is a pipe-command with unchangeable file,
             # never a microphone-stream or a live-stream.
             audio_bytes = AudioCache.try_cache(self.source)
             if not audio_bytes:
@@ -1528,7 +1439,6 @@ def audio_energy(audio: np.ndarray) -> float:
 FileObject = Any  # Alias for file-like objects
 
 
-@dynamic_lru_cache
 def read_audio(
     path_or_fd: Union[Pathlike, FileObject],
     offset: Seconds = 0.0,

--- a/test/test_audio_reads.py
+++ b/test/test_audio_reads.py
@@ -121,36 +121,6 @@ def test_opus_torchaudio_vs_ffmpeg_with_resampling(path, force_opus_sampling_rat
     np.testing.assert_almost_equal(audio_ta, audio_ff, decimal=1)
 
 
-@pytest.mark.skip(reason="The audio caching by @lru_cache_optional was removed.")
-def test_audio_caching_enabled_works():
-    lhotse.set_caching_enabled(True)  # Enable caching.
-
-    np.random.seed(89)  # Reproducibility.
-
-    # Prepare two different waveforms.
-    noise1 = np.random.rand(1, 32000).astype(np.float32)
-    noise2 = np.random.rand(1, 32000).astype(np.float32)
-    # Sanity check -- the noises are different
-    assert np.abs(noise1 - noise2).sum() != 0
-
-    # Save the first waveform in a file.
-    with NamedTemporaryFile(suffix=".wav") as f:
-        torchaudio.save(f.name, torch.from_numpy(noise1), sample_rate=16000)
-        recording = Recording.from_file(f.name)
-
-        # Read the audio -- should be equal to noise1.
-        audio = recording.load_audio()
-        np.testing.assert_allclose(audio, noise1, atol=3e-5)
-
-        # Save noise2 to the same location.
-        torchaudio.save(f.name, torch.from_numpy(noise2), sample_rate=16000)
-
-        # Read the audio -- should *still* be equal to noise1,
-        # because reading from this path was cached before.
-        audio = recording.load_audio()
-        np.testing.assert_allclose(audio, noise1, atol=3e-5)
-
-
 def test_audio_caching_disabled_works():
     lhotse.set_caching_enabled(False)  # Disable caching.
 

--- a/test/test_audio_reads.py
+++ b/test/test_audio_reads.py
@@ -6,7 +6,7 @@ import torch
 import torchaudio
 
 import lhotse
-from lhotse import Recording
+from lhotse import AudioSource, Recording
 from lhotse.audio import read_opus_ffmpeg, read_opus_torchaudio, torchaudio_load
 
 
@@ -121,6 +121,7 @@ def test_opus_torchaudio_vs_ffmpeg_with_resampling(path, force_opus_sampling_rat
     np.testing.assert_almost_equal(audio_ta, audio_ff, decimal=1)
 
 
+@pytest.mark.skip(reason="The audio caching by @lru_cache_optional was removed.")
 def test_audio_caching_enabled_works():
     lhotse.set_caching_enabled(True)  # Enable caching.
 
@@ -176,4 +177,68 @@ def test_audio_caching_disabled_works():
         # Read the audio -- should be equal to noise2,
         # and the caching is ignored (doesn't happen).
         audio = recording.load_audio()
+        np.testing.assert_allclose(audio, noise2, atol=3e-5)
+
+
+def test_command_audio_caching_enabled_works():
+    lhotse.set_caching_enabled(True)  # Enable caching.
+
+    np.random.seed(89)  # Reproducibility.
+
+    # Prepare two different waveforms.
+    noise1 = np.random.rand(1, 32000).astype(np.float32)
+    noise2 = np.random.rand(1, 32000).astype(np.float32)
+    # Sanity check -- the noises are different
+    assert np.abs(noise1 - noise2).sum() != 0
+
+    # Save the first waveform in a file.
+    with NamedTemporaryFile(suffix=".wav") as f:
+        torchaudio.save(f.name, torch.from_numpy(noise1), sample_rate=16000)
+
+        audio_source = AudioSource("command", list([1]), f"cat {f.name}")
+
+        # Read the audio -- should be equal to noise1.
+        audio = audio_source.load_audio()
+        audio = np.expand_dims(audio, axis=0)
+        np.testing.assert_allclose(audio, noise1, atol=3e-5)
+
+        # Save noise2 to the same location.
+        torchaudio.save(f.name, torch.from_numpy(noise2), sample_rate=16000)
+
+        # Read the audio -- should *still* be equal to noise1,
+        # because reading from this path was cached before.
+        audio = audio_source.load_audio()
+        audio = np.expand_dims(audio, axis=0)
+        np.testing.assert_allclose(audio, noise1, atol=3e-5)
+
+
+def test_command_audio_caching_disabled_works():
+    lhotse.set_caching_enabled(False)  # Disable caching.
+
+    np.random.seed(89)  # Reproducibility.
+
+    # Prepare two different waveforms.
+    noise1 = np.random.rand(1, 32000).astype(np.float32)
+    noise2 = np.random.rand(1, 32000).astype(np.float32)
+    # Sanity check -- the noises are different
+    assert np.abs(noise1 - noise2).sum() != 0
+
+    # Save the first waveform in a file.
+    with NamedTemporaryFile(suffix=".wav") as f:
+        torchaudio.save(f.name, torch.from_numpy(noise1), sample_rate=16000)
+
+        audio_source = AudioSource("command", list([1]), f"cat {f.name}")
+
+        # Read the audio -- should be equal to noise1.
+        audio = audio_source.load_audio()
+        audio = np.expand_dims(audio, axis=0)
+        np.testing.assert_allclose(audio, noise1, atol=3e-5)
+
+        # Save noise2 to the same location.
+        torchaudio.save(f.name, torch.from_numpy(noise2), sample_rate=16000)
+
+        # Read the audio -- should be equal to noise2,
+        # and the caching is ignored (doesn't happen).
+        audio = audio_source.load_audio()
+        audio = np.expand_dims(audio, axis=0)
         np.testing.assert_allclose(audio, noise2, atol=3e-5)


### PR DESCRIPTION
- reduces overhead when reading lots of segments from 1 audio file
- cache-size is limited to 500MB or no more than 100 files
- by default it is enabled
- thread-safety is secured by threading.Lock

Tested by running `./pruned_transducer_stateless7_streaming/streaming_decode.py` with dataset imported from kaldi format (locally).

Question to @pzelasko : should the cache be used also for 'url' type of audio files ?
(locally I see 3x XFAIL on `pytest test/test_audio_reads.py -v`, but happens also for current `master` branch)