### PR TITLE
Enhancements and bug fixes for AMI and ICSI

### DIFF
--- a/lhotse/bin/modes/recipes/ami.py
+++ b/lhotse/bin/modes/recipes/ami.py
@@ -53,6 +53,13 @@ __all__ = ["ami"]
         " segmentation). If None, no segmentation is performed."
     ),
 )
+@click.option(
+    "--merge-consecutive",
+    type=bool,
+    is_flag=True,
+    default=False,
+    help="Merge consecutive segments from the same speaker.",
+)
 def ami(
     corpus_dir: Pathlike,
     output_dir: Pathlike,
@@ -61,6 +68,7 @@ def ami(
     partition: str,
     normalize_text: bool,
     max_words_per_segment: int,
+    merge_consecutive: bool,
 ):
     """AMI data preparation."""
     prepare_ami(
@@ -71,6 +79,7 @@ def ami(
         partition=partition,
         normalize_text=normalize_text,
         max_words_per_segment=max_words_per_segment,
+        merge_consecutive=merge_consecutive,
     )
 
 

--- a/lhotse/bin/modes/recipes/icsi.py
+++ b/lhotse/bin/modes/recipes/icsi.py
@@ -64,12 +64,13 @@ def icsi(
 )
 @click.option(
     "--normalize-text",
-    is_flag=True,
-    help="If set, convert all text annotations to upper case (similar to Kaldi)",
+    type=click.Choice(["none", "upper", "kaldi"], case_sensitive=False),
+    default="kaldi",
+    help="Type of text normalization to apply (kaldi style, by default)",
 )
 def icsi(
     audio_dir: Pathlike,
-    transcript_dir: Pathlike,
+    transcripts_dir: Pathlike,
     output_dir: Pathlike,
     mic: str,
     normalize_text: bool,
@@ -77,7 +78,7 @@ def icsi(
     """AMI data preparation."""
     prepare_icsi(
         audio_dir,
-        transcript_dir,
+        transcripts_dir,
         output_dir=output_dir,
         mic=mic,
         normalize_text=normalize_text,

--- a/lhotse/bin/modes/recipes/icsi.py
+++ b/lhotse/bin/modes/recipes/icsi.py
@@ -68,18 +68,26 @@ def icsi(
     default="kaldi",
     help="Type of text normalization to apply (kaldi style, by default)",
 )
+@click.option(
+    "--save-to-wav",
+    is_flag=True,
+    default=False,
+    help="If True and `mic` is sdm/ihm/mdm, save the recordings as WAV for faster processing.",
+)
 def icsi(
     audio_dir: Pathlike,
     transcripts_dir: Pathlike,
     output_dir: Pathlike,
     mic: str,
     normalize_text: bool,
+    save_to_wav: bool,
 ):
-    """AMI data preparation."""
+    """ICSI data preparation."""
     prepare_icsi(
         audio_dir,
         transcripts_dir,
         output_dir=output_dir,
         mic=mic,
         normalize_text=normalize_text,
+        save_to_wav=save_to_wav,
     )

--- a/lhotse/recipes/ami.py
+++ b/lhotse/recipes/ami.py
@@ -370,8 +370,15 @@ def parse_ami_annotations(
                     )
                     for w in subseg
                 ]
-                # Filter out empty words
-                word_alignments = [w for w in word_alignments if w.symbol]
+                word_alignments = [w for w in word_alignments if len(w.symbol) > 0]
+                if any(w.duration <= 0 for w in word_alignments):
+                    logging.warning(
+                        f"Segment {key[0]}.{key[1]}.{key[2]} at time {start}-{end} "
+                        f"has a word with zero or negative duration."
+                    )
+                    word_alignments = [
+                        w for w in word_alignments if w.duration > 0
+                    ]  # type: ignore
                 text = " ".join(w.symbol for w in word_alignments)
                 annotations[key].append(
                     AmiSegmentAnnotation(

--- a/lhotse/recipes/icsi.py
+++ b/lhotse/recipes/icsi.py
@@ -347,24 +347,23 @@ def parse_icsi_annotations(
                 continue
             start = seg_words[0][0]
             end = seg_words[-1][1]
-            word_alignments = [
-                AlignmentItem(
-                    start=round(w[0], ndigits=4),
-                    duration=add_durations(w[1], -w[0], sampling_rate=16000),
-                    symbol=normalize_text_ami(w[2], normalize=normalize),
+            word_alignments = []
+            for w in seg_words:
+                w_start = max(start, round(w[0], ndigits=4))
+                w_end = min(end, round(w[1], ndigits=4))
+                w_dur = add_durations(w_end, -w_start, sampling_rate=16000)
+                w_symbol = normalize_text_ami(w[2], normalize=normalize)
+                if len(w_symbol) == 0:
+                    continue
+                if w_dur <= 0:
+                    logging.warning(
+                        f"Segment {key[0]}.{spk_id}.{channel} at time {start}-{end} "
+                        f"has a word with zero or negative duration. Skipping."
+                    )
+                    continue
+                word_alignments.append(
+                    AlignmentItem(start=w_start, duration=w_dur, symbol=w_symbol)
                 )
-                for w in seg_words
-            ]
-            # Filter out empty words
-            word_alignments = [w for w in word_alignments if len(w.symbol) > 0]
-            if any(w.duration <= 0 for w in word_alignments):
-                logging.warning(
-                    f"Segment {key[0]}.{spk_id}.{channel} at time {start}-{end} "
-                    f"has a word with zero or negative duration."
-                )
-                word_alignments = [
-                    w for w in word_alignments if w.duration > 0
-                ]  # type: ignore
             text = " ".join(w.symbol for w in word_alignments)
             annotations[new_key].append(
                 IcsiSegmentAnnotation(

--- a/lhotse/recipes/icsi.py
+++ b/lhotse/recipes/icsi.py
@@ -357,6 +357,14 @@ def parse_icsi_annotations(
             ]
             # Filter out empty words
             word_alignments = [w for w in word_alignments if len(w.symbol) > 0]
+            if any(w.duration <= 0 for w in word_alignments):
+                logging.warning(
+                    f"Segment {key[0]}.{spk_id}.{channel} at time {start}-{end} "
+                    f"has a word with zero or negative duration."
+                )
+                word_alignments = [
+                    w for w in word_alignments if w.duration > 0
+                ]  # type: ignore
             text = " ".join(w.symbol for w in word_alignments)
             annotations[new_key].append(
                 IcsiSegmentAnnotation(

--- a/lhotse/recipes/utils.py
+++ b/lhotse/recipes/utils.py
@@ -146,6 +146,7 @@ def normalize_text_ami(text: str, normalize: str = "upper") -> str:
         text = re.sub(r"MM HMM", "MM-HMM", text)
         text = re.sub(r"UH HUH", "UH-HUH", text)
         text = re.sub(r"(\b)O K(\b)", r"\g<1>OK\g<2>", text)
+        text = re.sub(r"(\b)O_K(\b)", r"\g<1>OK\g<2>", text)
         return text
 
 

--- a/lhotse/recipes/utils.py
+++ b/lhotse/recipes/utils.py
@@ -147,7 +147,7 @@ def normalize_text_ami(text: str, normalize: str = "upper") -> str:
         text = re.sub(r"UH HUH", "UH-HUH", text)
         text = re.sub(r"(\b)O K(\b)", r"\g<1>OK\g<2>", text)
         text = re.sub(r"(\b)O_K(\b)", r"\g<1>OK\g<2>", text)
-        return text
+        return text.strip()
 
 
 def normalize_text_chime6(text: str, normalize: str = "upper") -> str:


### PR DESCRIPTION
* Add a `merge_consecutive` option for AMI. This is to prevent over-segmentation which results in too many short segments like "Yeah", "Okay", etc.
* Return word alignments in AMI supervisions (these are provided in office AMI annotations).
* Fix some bugs in ICSI recipe (e.g. `fix_manifests()` should be done before saving to file).
* Return word alignments in ICSI supervisions (provided in annotations).
* Add option for saving ICSI sph files to wav, so that they are faster to process later.