### PR TITLE
Small changes in some cut methods

### DIFF
--- a/lhotse/cut/base.py
+++ b/lhotse/cut/base.py
@@ -490,7 +490,7 @@ class Cut:
                     len(set(to_hashable(s.channel) for s in trimmed.supervisions)) == 1
                 ), (
                     "Trimmed cut has supervisions with different channels. Either set "
-                    "`ignore_channel=True` to keep original channels or `keep_overlapping=False` "
+                    "`keep_all_channels=True` to keep original channels or `keep_overlapping=False` "
                     "to retain only 1 supervision per trimmed cut."
                 )
                 trimmed.channel = trimmed.supervisions[0].channel

--- a/lhotse/cut/base.py
+++ b/lhotse/cut/base.py
@@ -652,6 +652,7 @@ class Cut:
         supervision_group = [supervisions[0]]
         cur_end = supervisions[0].end
         new_cuts = []
+        group_idx = 0
         for sup in supervisions[1:]:
             if sup.start - cur_end <= max_pause:
                 supervision_group.append(sup)
@@ -666,8 +667,9 @@ class Cut:
                         offset=offset,
                         duration=duration,
                         keep_excessive_supervisions=False,
-                    )
+                    ).with_id(f"{self.id}-{max_pause}-{group_idx}")
                 )
+                group_idx += 1
                 supervision_group = [sup]
                 cur_end = sup.end
 
@@ -680,7 +682,7 @@ class Cut:
                     offset=offset,
                     duration=duration,
                     keep_excessive_supervisions=False,
-                )
+                ).with_id(f"{self.id}-{max_pause}-{group_idx}")
             )
         # The total number of supervisions should be the same.
         assert sum(len(c.supervisions) for c in new_cuts) == len(self.supervisions), (
@@ -724,7 +726,7 @@ class Cut:
                     offset=hop * i,
                     duration=duration,
                     keep_excessive_supervisions=keep_excessive_supervisions,
-                )
+                ).with_id(f"{self.id}-{i}")
             )
         return CutSet.from_cuts(new_cuts)
 

--- a/lhotse/cut/set.py
+++ b/lhotse/cut/set.py
@@ -2610,7 +2610,7 @@ def mix(
         )
         snr = None
 
-    if reference_cut.num_features is not None:
+    if reference_cut.num_features is not None and mixed_in_cut.num_features is not None:
         assert (
             reference_cut.num_features == mixed_in_cut.num_features
         ), "Cannot mix cuts with different feature dimensions."

--- a/lhotse/cut/set.py
+++ b/lhotse/cut/set.py
@@ -590,6 +590,7 @@ class CutSet(Serializable, AlgorithmMixin):
                 warn_unused_fields=warn_unused_fields,
                 include_cuts=include_cuts,
                 shard_suffix=None,
+                verbose=verbose,
             )
 
         progbar = partial(tqdm, desc="Shard progress") if verbose else lambda x: x
@@ -610,6 +611,7 @@ class CutSet(Serializable, AlgorithmMixin):
                         warn_unused_fields=warn_unused_fields,
                         include_cuts=True,
                         shard_suffix=f".{idx:06d}",
+                        verbose=False,
                     )
                 )
             for f in progbar(as_completed(futures)):
@@ -2706,7 +2708,7 @@ def mix(
     elif isinstance(mixed_in_cut, (DataCut, PaddingCut)):
         new_tracks = [MixTrack(cut=mixed_in_cut, offset=offset, snr=snr)]
     else:
-        raise ValueError(f"Unsupported type of cut in mix(): {type(reference_cut)}")
+        raise ValueError(f"Unsupported type of cut in mix(): {type(mixed_in_cut)}")
 
     return MixedCut(id=mixed_cut_id, tracks=old_tracks + new_tracks)
 
@@ -3386,8 +3388,11 @@ def _export_to_shar_single(
     warn_unused_fields: bool,
     include_cuts: bool,
     shard_suffix: Optional[str],
+    verbose: bool,
 ) -> Dict[str, List[str]]:
     from lhotse.shar import SharWriter
+
+    pbar = tqdm(desc="Exporting to SHAR", disable=not verbose)
 
     with SharWriter(
         output_dir=output_dir,
@@ -3399,5 +3404,7 @@ def _export_to_shar_single(
     ) as writer:
         for cut in cuts:
             writer.write(cut)
+            pbar.update()
 
+    # Finally, return the list of output files.
     return writer.output_paths

--- a/test/cut/test_cut_mixing.py
+++ b/test/cut/test_cut_mixing.py
@@ -324,6 +324,12 @@ def test_mix_cut_snr(libri_cut):
     assert E(feats) > E(feats_snr)
 
 
+def test_mix_cut_with_other_raises_error(libri_cut):
+    libri_cut = libri_cut.drop_features()
+    with pytest.raises(ValueError):
+        _ = libri_cut.mix(libri_cut.recording)
+
+
 def test_mix_cut_snr_truncate_snr_reference(libri_cut):
     mixed = libri_cut.pad(duration=20).mix(libri_cut, offset_other_by=10)
     mixed_snr = libri_cut.pad(duration=20).mix(libri_cut, offset_other_by=10, snr=10)


### PR DESCRIPTION
* When trimming to supervision groups, give sensible ids instead of completely randomized.
* Progress bar for exporting to Shar.
* Minor fix in error message.
* Fix for https://github.com/lhotse-speech/lhotse/issues/1034.