### PR TITLE
Fix `resumable_download` for fully downloaded files

### DIFF
--- a/lhotse/utils.py
+++ b/lhotse/utils.py
@@ -470,23 +470,32 @@ def resumable_download(
     with open(filename, "ab") as f:
         f.seek(file_size)
 
-        # Open the URL and read the contents in chunks
-        with urllib.request.urlopen(req) as response:
-            chunk_size = 1024
-            total_size = int(response.headers.get("content-length", 0)) + file_size
-            with tqdm(
-                total=total_size,
-                initial=file_size,
-                unit="B",
-                unit_scale=True,
-                desc=str(filename),
-            ) as pbar:
-                while True:
-                    chunk = response.read(chunk_size)
-                    if not chunk:
-                        break
-                    f.write(chunk)
-                    pbar.update(len(chunk))
+        try:
+            # Open the URL and read the contents in chunks
+            with urllib.request.urlopen(req) as response:
+                chunk_size = 1024
+                total_size = int(response.headers.get("content-length", 0)) + file_size
+                with tqdm(
+                    total=total_size,
+                    initial=file_size,
+                    unit="B",
+                    unit_scale=True,
+                    desc=str(filename),
+                ) as pbar:
+                    while True:
+                        chunk = response.read(chunk_size)
+                        if not chunk:
+                            break
+                        f.write(chunk)
+                        pbar.update(len(chunk))
+
+        except urllib.error.HTTPError as e:
+            # "Request Range Not Satisfiable" means the requested range
+            # starts after the file ends, hence the file is already downloaded.
+            if e.code == 416:
+                logging.info(f"File already downloaded: {filename}")
+            else:
+                raise e
 
 
 def _is_within_directory(directory: Path, target: Path):

--- a/lhotse/utils.py
+++ b/lhotse/utils.py
@@ -501,7 +501,9 @@ def resumable_download(
                     # then the file is already downloaded
                     logging.info(f"File already downloaded: {filename}")
                 else:
-                    logging.info("Server does not support range requests - attempting downloading from scratch")
+                    logging.info(
+                        "Server does not support range requests - attempting downloading from scratch"
+                    )
                     _download(urllib.request.Request(url), 0)
             else:
                 raise e


### PR DESCRIPTION
When `resumable_download` is called and the file is fully downloaded, the requested range starts after the file ends, which yields HTTP error 416. It seems logical that in this case the exception should not be raised, but rather Lhotse should report that the file is already downloaded.