### PR TITLE
cut/mono: only optimize load_audio() when returned number of feature frames is identical

### DIFF
--- a/lhotse/cut/data.py
+++ b/lhotse/cut/data.py
@@ -457,7 +457,7 @@ class DataCut(Cut, metaclass=ABCMeta):
         :return: a new ``MonoCut`` instance with a ``Features`` manifest attached to it.
         """
         features_info = extractor.extract_from_samples_and_store(
-            samples=self.load_audio(),
+            samples=self.load_audio(frame_shift=extractor.frame_shift),
             storage=storage,
             sampling_rate=self.sampling_rate,
             offset=self.start,


### PR DESCRIPTION
Candidate fix for second problem reported in #1064

This adds an optional _frame_shift_ parameter to cut/mono:load_audio(). We compute the number of frames for the cut.duration and cut.recording.duration and only apply the optimization if the resulting number of feature frames are identical.

Idea(?): The duration math.isclose() test could be removed altogether.