### PR TITLE
Fix bugs in `MixedCut` logic

### DIFF
--- a/lhotse/audio.py
+++ b/lhotse/audio.py
@@ -1301,6 +1301,7 @@ class AudioMixer:
         base_audio: np.ndarray,
         sampling_rate: int,
         reference_energy: Optional[float] = None,
+        base_offset: Seconds = 0.0,
     ):
         """
         AudioMixer's constructor.
@@ -1310,9 +1311,10 @@ class AudioMixer:
         :param sampling_rate: Sampling rate of the audio.
         :param reference_energy: Optionally pass a reference energy value to compute SNRs against.
             This might be required when ``base_audio`` corresponds to zero-padding.
+        :param base_offset: Optionally pass a time offset for the base signal.
         """
         self.tracks = [base_audio]
-        self.offsets = [0]
+        self.offsets = [compute_num_samples(base_offset, sampling_rate)]
         self.sampling_rate = sampling_rate
         self.num_channels = base_audio.shape[0]
         self.dtype = self.tracks[0].dtype

--- a/lhotse/cut/mixed.py
+++ b/lhotse/cut/mixed.py
@@ -1058,6 +1058,7 @@ class MixedCut(Cut):
             self.tracks[0].cut.load_audio(),
             sampling_rate=self.tracks[0].cut.sampling_rate,
             reference_energy=reference_energy,
+            base_offset=self.tracks[0].offset,
         )
 
         for pos, track in enumerate(self.tracks[1:], start=1):

--- a/lhotse/cut/mixed.py
+++ b/lhotse/cut/mixed.py
@@ -490,6 +490,17 @@ class MixedCut(Cut):
                     snr=track.snr,
                 )
             )
+
+        # Edge case: no tracks left after truncation. This can happen if we truncated an offset region.
+        # In this case, return a PaddingCut of the requested duration
+        if len(new_tracks) == 0:
+            return PaddingCut(
+                id=self.id if preserve_id else str(uuid4()),
+                duration=duration,
+                sampling_rate=self.sampling_rate,
+                feat_value=0.0,
+            )
+
         if len(new_tracks) == 1:
             # The truncation resulted in just a single cut - simply return it.
             return new_tracks[0].cut

--- a/test/cut/test_cut_mixing.py
+++ b/test/cut/test_cut_mixing.py
@@ -180,6 +180,16 @@ def mixed_audio_cut() -> MixedCut:
     return mixed_cut
 
 
+@pytest.fixture
+def offseted_mixed_audio_cut() -> MixedCut:
+    cut_set = CutSet.from_json(
+        "test/fixtures/mix_cut_test/offseted_audio_cut_manifest.json"
+    )
+    mixed_cut = cut_set["mixed-cut-id"]
+    assert isclose(mixed_cut.duration, 16.66)
+    return mixed_cut
+
+
 def test_mixed_cut_load_audio_mixed(mixed_audio_cut):
     audio = mixed_audio_cut.load_audio()
     assert audio.shape == (1, 230400)
@@ -191,6 +201,11 @@ def test_mixed_cut_load_audio_unmixed(mixed_audio_cut):
     assert len(audio) == 2
     assert audio[0].shape == (1, 230400)
     assert audio[1].shape == (1, 230400)
+
+
+def test_mixed_cut_load_offseted_mixed(offseted_mixed_audio_cut):
+    audio = offseted_mixed_audio_cut.load_audio()
+    assert audio.shape == (1, 266560)
 
 
 @pytest.mark.parametrize(

--- a/test/fixtures/mix_cut_test/offseted_audio_cut_manifest.json
+++ b/test/fixtures/mix_cut_test/offseted_audio_cut_manifest.json
@@ -1,0 +1,83 @@
+[
+  {
+    "id": "mixed-cut-id",
+    "tracks": [
+      {
+        "cut": {
+          "channel": 0,
+          "id": "ab34ea6b-9d68-4113-8386-b4c585e596f5",
+          "duration": 11.66,
+          "recording": {
+            "duration": 11.66,
+            "id": "2412-153948-0000",
+            "num_samples": 186560,
+            "sampling_rate": 16000,
+            "sources": [
+              {
+                "channels": [
+                  0
+                ],
+                "source": "test/fixtures/mix_cut_test/audio/storage/2412-153948-0000.flac",
+                "type": "file"
+              }
+            ]
+          },
+          "start": 0,
+          "supervisions": [
+            {
+              "channel": 0,
+              "duration": 11.66,
+              "id": "2412-153948-0000",
+              "language": "English",
+              "recording_id": "2412-153948-0000",
+              "speaker": "2412",
+              "start": 0.0,
+              "text": "IF THE READER WILL EXCUSE ME I WILL SAY NOTHING OF MY ANTECEDENTS NOR OF THE CIRCUMSTANCES WHICH LED ME TO LEAVE MY NATIVE COUNTRY THE NARRATIVE WOULD BE TEDIOUS TO HIM AND PAINFUL TO MYSELF"
+            }
+          ]
+        },
+        "type": "MonoCut",
+        "offset": 5.0
+      },
+      {
+        "cut": {
+          "channel": 0,
+          "id": "07d009a9-e7a1-4611-aa21-32ff9b43dff0",
+          "duration": 10.51,
+          "recording": {
+            "duration": 10.51,
+            "id": "2412-153948-0001",
+            "num_samples": 168160,
+            "sampling_rate": 16000,
+            "sources": [
+              {
+                "channels": [
+                  0
+                ],
+                "source": "test/fixtures/mix_cut_test/audio/storage/2412-153948-0001.flac",
+                "type": "file"
+              }
+            ]
+          },
+          "start": 0,
+          "supervisions": [
+            {
+              "channel": 0,
+              "duration": 4.65,
+              "id": "174-168635-0001",
+              "language": "English",
+              "recording_id": "174-168635-0001",
+              "speaker": "174",
+              "start": 0.0,
+              "text": "THE HEART OF THAT EX CONVICT WAS FULL OF VIRGINITY"
+            }
+          ]
+        },
+        "type": "MonoCut",
+        "offset": 5.02,
+        "snr": 20.0
+      }
+    ],
+    "type": "MixedCut"
+  }
+]


### PR DESCRIPTION
I attempted to simulate some conversations, then cut them into windows and save the resulting cuts on the disk. I have encountered two bugs:

- `IndexError` in `MixedCut.truncate`: happened because the cut window happened to be in the region between `MixTrack`s, so no intersecting tracks were found and such case was not handled;
- `AssertionError` in `MixedCut.load_audio`: the resulting audio length were mismatched, because the offset of the first track in the cut was not accounted for during mixing, resulting in incorrect mix length.

This PR fixes those:
- returning `PaddingCut` in the first case;
- accounting for the base audio offset in the mixer, via providing an extra optional constructor parameter.