### PR TITLE
Add multithread to peoples_speech

### DIFF
--- a/lhotse/bin/modes/recipes/peoples_speech.py
+++ b/lhotse/bin/modes/recipes/peoples_speech.py
@@ -8,12 +8,21 @@ from lhotse.utils import Pathlike
 @prepare.command(context_settings=dict(show_default=True))
 @click.argument("corpus_dir", type=click.Path(exists=True, dir_okay=True))
 @click.argument("output_dir", type=click.Path())
+@click.option(
+    "-j",
+    "--num-jobs",
+    type=int,
+    default=1,
+    help="How many threads to use (can give good speed-ups with slow disks).",
+)
 def peoples_speech(
     corpus_dir: Pathlike,
     output_dir: Pathlike,
+    num_jobs: int = 1,
 ):
     """Prepare The People's Speech corpus manifests."""
     prepare_peoples_speech(
-        corpus_dir,
+        corpus_dir=corpus_dir,
         output_dir=output_dir,
+        num_jobs=num_jobs,
     )

--- a/lhotse/recipes/gigast.py
+++ b/lhotse/recipes/gigast.py
@@ -106,7 +106,6 @@ def prepare_gigast(
     """
     corpus_dir = Path(corpus_dir)
     manifests_dir = Path(manifests_dir)
-    output_dir = Path(output_dir) if output_dir is not None else None
 
     assert corpus_dir.is_dir(), f"No such directory: {corpus_dir}"
 

--- a/lhotse/recipes/librilight.py
+++ b/lhotse/recipes/librilight.py
@@ -113,7 +113,6 @@ def prepare_librilight(
     :return: a Dict whose key is the dataset part, and the value is Dicts with the keys 'recordings' and 'supervisions'.
     """
     corpus_dir = Path(corpus_dir)
-    output_dir = Path(output_dir) if output_dir is not None else None
 
     assert corpus_dir.is_dir(), f"No such directory: {corpus_dir}"
 

--- a/lhotse/recipes/peoples_speech.py
+++ b/lhotse/recipes/peoples_speech.py
@@ -179,3 +179,7 @@ def prepare_peoples_speech(
         manifests[part] = {"recordings": recording_set, "supervisions": supervision_set}
 
     return manifests
+
+
+if __name__ == "__main__":
+    prepare_peoples_speech("/star-data/yifan/peoples_speech", ".", num_jobs=32)

--- a/lhotse/recipes/peoples_speech.py
+++ b/lhotse/recipes/peoples_speech.py
@@ -87,7 +87,7 @@ def _prepare_subset(
             load_jsonl(part_dir / f"{part_name}.json"),
             desc="Distributing tasks",
         ):
-            for _ , text, audio_path in zip(*item["training_data"].values()):
+            for _, text, audio_path in zip(*item["training_data"].values()):
                 futures.append(
                     ex.submit(
                         _parse_utterance,

--- a/lhotse/recipes/peoples_speech.py
+++ b/lhotse/recipes/peoples_speech.py
@@ -45,25 +45,14 @@ def _parse_utterance(
 ) -> Optional[Tuple[Recording, SupervisionSegment]]:
     full_path = audio_dir / audio_path
 
-    audio_info = info(full_path)
-    duration = duration_ms / 1000
-    recording = Recording(
-        id=full_path.stem,
-        sampling_rate=audio_info.samplerate,
-        num_samples=compute_num_samples(duration, audio_info.samplerate),
-        duration=duration,
-        sources=[
-            AudioSource(
-                type="file",
-                channels=[0],
-                source=str(full_path),
-            )
-        ],
+    recording = Recording.from_file(
+        path=full_path,
+        recording_id=full_path.stem,
     )
     segment = SupervisionSegment(
         id=recording.id,
         recording_id=recording.id,
-        start=0,
+        start=0.0,
         duration=recording.duration,
         channel=0,
         text=text,

--- a/lhotse/recipes/peoples_speech.py
+++ b/lhotse/recipes/peoples_speech.py
@@ -71,8 +71,6 @@ def _parse_utterance(
         custom={"session_id": identifier},
     )
 
-    validate_recordings_and_supervisions(recordings=recording, supervisions=segment)
-
     return recording, segment
 
 
@@ -97,10 +95,10 @@ def _prepare_subset(
         recordings = []
         supervisions = []
         for item in tqdm(
+            # Note: People's Speech manifest.json is really a JSONL.
             load_jsonl(part_dir / f"{part_name}.json"),
             desc="Distributing tasks",
         ):
-            # Note: People's Speech manifest.json is really a JSONL.
             for duration_ms, text, audio_path in zip(*item["training_data"].values()):
                 futures.append(
                     ex.submit(
@@ -121,6 +119,10 @@ def _prepare_subset(
 
         recording_set = RecordingSet.from_recordings(recordings)
         supervision_set = SupervisionSet.from_segments(supervisions)
+
+        validate_recordings_and_supervisions(
+            recordings=recording_set, supervisions=supervision_set
+        )
 
     return recording_set, supervision_set
 

--- a/lhotse/recipes/peoples_speech.py
+++ b/lhotse/recipes/peoples_speech.py
@@ -38,7 +38,6 @@ PEOPLES_SPEECH = (
 
 def _parse_utterance(
     audio_dir: Pathlike,
-    duration_ms: int,
     text: str,
     audio_path: str,
     identifier: str,
@@ -88,12 +87,11 @@ def _prepare_subset(
             load_jsonl(part_dir / f"{part_name}.json"),
             desc="Distributing tasks",
         ):
-            for duration_ms, text, audio_path in zip(*item["training_data"].values()):
+            for _ , text, audio_path in zip(*item["training_data"].values()):
                 futures.append(
                     ex.submit(
                         _parse_utterance,
                         audio_dir,
-                        duration_ms,
                         text,
                         audio_path,
                         item["identifier"],

--- a/lhotse/recipes/peoples_speech.py
+++ b/lhotse/recipes/peoples_speech.py
@@ -179,7 +179,3 @@ def prepare_peoples_speech(
         manifests[part] = {"recordings": recording_set, "supervisions": supervision_set}
 
     return manifests
-
-
-if __name__ == "__main__":
-    prepare_peoples_speech("/star-data/yifan/peoples_speech", ".", num_jobs=32)

--- a/lhotse/recipes/peoples_speech.py
+++ b/lhotse/recipes/peoples_speech.py
@@ -11,129 +11,166 @@ Source: https://mlcommons.org/en/peoples-speech/
 Full paper: https://openreview.net/pdf?id=R8CwidgJ0yT
 """
 
-import warnings
+import logging
+from collections import defaultdict
+from concurrent.futures.thread import ThreadPoolExecutor
 from pathlib import Path
-from typing import Dict, Union
+from typing import Dict, List, Optional, Sequence, Tuple, Union
 
 from tqdm.auto import tqdm
 
 from lhotse.audio import AudioSource, Recording, RecordingSet, info
+from lhotse.recipes.utils import manifests_exist
 from lhotse.qa import validate_recordings_and_supervisions
 from lhotse.serialization import load_jsonl
 from lhotse.supervision import SupervisionSegment, SupervisionSet
 from lhotse.utils import Pathlike, compute_num_samples
 
+PEOPLES_SPEECH = (
+    "train/dirty_sa",
+    "train/dirty",
+    "train/clean_sa",
+    "train/clean",
+    "validation/validation",
+    "test/test",
+)
+
+
+def _parse_utterance(
+    audio_dir: Pathlike,
+    duration_ms: int,
+    text: str,
+    audio_path: str,
+    identifier: str,
+) -> Optional[Tuple[Recording, SupervisionSegment]]:
+    full_path = audio_dir / audio_path
+
+    audio_info = info(full_path)
+    duration = duration_ms / 1000
+    recording = Recording(
+        id=full_path.stem,
+        sampling_rate=audio_info.samplerate,
+        num_samples=compute_num_samples(
+            duration, audio_info.samplerate
+        ),
+        duration=duration,
+        sources=[
+            AudioSource(
+                type="file",
+                channels=[0],
+                source=str(full_path),
+            )
+        ],
+    )
+    segment = SupervisionSegment(
+        id=recording.id,
+        recording_id=recording.id,
+        start=0,
+        duration=recording.duration,
+        channel=0,
+        text=text,
+        language="English",
+        custom={"session_id": identifier},
+    )
+
+    validate_recordings_and_supervisions(recordings=recording, supervisions=segment)
+
+    return recording, segment
+
+
+def _prepare_subset(
+    subset: str,
+    corpus_dir: Pathlike,
+    num_jobs: int = 1,
+) -> Tuple[RecordingSet, SupervisionSet]:
+    """
+    Returns the RecodingSet and SupervisionSet given a dataset part.
+    :param subset: str, the name of the subset.
+    :param corpus_dir: Pathlike, the path of the data dir.
+    :return: the RecodingSet and SupervisionSet for train and valid.
+    """
+    corpus_dir = Path(corpus_dir)
+    part_dir = corpus_dir / subset.split("/")[0]
+    part_name = subset.split("/")[1]
+    audio_dir = corpus_dir / subset
+
+    with ThreadPoolExecutor(num_jobs) as ex:
+        futures = []
+        recordings = []
+        supervisions = []
+        for item in tqdm(
+            load_jsonl(part_dir / f"{part_name}.json"), 
+            desc="Distributing tasks",
+        ):
+            # Note: People's Speech manifest.json is really a JSONL.
+            for duration_ms, text, audio_path in zip(*item["training_data"].values()):
+                futures.append(ex.submit(
+                    _parse_utterance,
+                    audio_dir,
+                    duration_ms,
+                    text,
+                    audio_path,
+                    item["identifier"],
+                ))
+
+        for future in tqdm(futures, desc="Processing"):
+            result = future.result()
+            recording, segment = result
+            recordings.append(recording)
+            supervisions.append(segment)
+
+        recording_set = RecordingSet.from_recordings(recordings)
+        supervision_set = SupervisionSet.from_segments(supervisions)
+
+    return recording_set, supervision_set
+
 
 def prepare_peoples_speech(
     corpus_dir: Pathlike,
-    output_dir: Pathlike,
+    output_dir: Optional[Pathlike] = None,
+    num_jobs: int = 1,
 ) -> Dict[str, Union[RecordingSet, SupervisionSet]]:
     """
     Prepare :class:`~lhotse.RecordingSet` and :class:`~lhotse.SupervisionSet` manifests
     for The People's Speech.
-
-    The metadata is read lazily and written to manifests in a stream to minimize
-    the CPU RAM usage. If you want to convert this data to a :class:`~lhotse.CutSet`
-    without using excessive memory, we suggest to call it like::
-
-        >>> peoples_speech = prepare_peoples_speech(corpus_dir=..., output_dir=...)
-        >>> cuts = CutSet.from_manifests(
-        ...     recordings=peoples_speech["recordings"],
-        ...     supervisions=peoples_speech["supervisions"],
-        ...     output_path=...,
-        ...     lazy=True,
-        ... )
 
     :param corpus_dir: Pathlike, the path of the main data dir.
     :param output_dir: Pathlike, the path where to write the manifests.
     :return: a dict with keys "recordings" and "supervisions" with lazily opened manifests.
     """
     corpus_dir = Path(corpus_dir)
-    output_dir = Path(output_dir)
-    output_dir.mkdir(parents=True, exist_ok=True)
 
-    recs_path = output_dir / "peoples-speech_recordings_all.jsonl.gz"
-    sups_path = output_dir / "peoples-speech_supervisions_all.jsonl.gz"
+    assert corpus_dir.is_dir(), f"No such directory: {corpus_dir}"
 
-    if recs_path.is_file() and sups_path.is_file():
-        # Nothing to do: just open the manifests in lazy mode.
-        return {
-            "recordings": RecordingSet.from_jsonl_lazy(recs_path),
-            "supervisions": SupervisionSet.from_jsonl_lazy(sups_path),
-        }
+    logging.info("Preparing People's Speech...")
 
-    exist = 0
-    tot = 0
-    err = 0
-    with RecordingSet.open_writer(recs_path,) as rec_writer, SupervisionSet.open_writer(
-        sups_path,
-    ) as sup_writer:
-        for item in tqdm(
-            # Note: People's Speech manifest.json is really a JSONL.
-            load_jsonl(corpus_dir / "manifest.json"),
-            desc="Converting People's Speech manifest.json to Lhotse manifests",
+    subsets = PEOPLES_SPEECH
+
+    if output_dir is not None:
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+    manifests = defaultdict(dict)
+
+    for part in tqdm(subsets, desc="Dataset parts"):
+        logging.info(f"Processing People's Speech subset: {part.split('/')[1]}")
+        if manifests_exist(
+            part=part.split("/")[1],
+            output_dir=output_dir,
+            prefix="peoples_speech",
+            suffix="jsonl.gz",
         ):
-            for duration_ms, text, audio_path in zip(*item["training_data"].values()):
-                full_path = corpus_dir / audio_path
+            logging.info(f"People's Speech subset: {part.split('/')[1]} already prepared - skipping.")
+            continue
 
-                tot += 1
-                if not full_path.exists():
-                    # If we can't find some data, we'll just continue and some items
-                    # were missing later.
-                    continue
-                exist += 1
+        recording_set, supervision_set = _prepare_subset(part, corpus_dir, num_jobs)
 
-                try:
-                    audio_info = info(full_path)
-                    duration = duration_ms / 1000
-                    r = Recording(
-                        id=full_path.stem,
-                        sampling_rate=audio_info.samplerate,
-                        num_samples=compute_num_samples(
-                            duration, audio_info.samplerate
-                        ),
-                        duration=duration,
-                        sources=[
-                            AudioSource(
-                                type="file",
-                                channels=[0],
-                                source=str(full_path),
-                            )
-                        ],
-                    )
-                    s = SupervisionSegment(
-                        id=r.id,
-                        recording_id=r.id,
-                        start=0,
-                        duration=r.duration,
-                        channel=0,
-                        text=text,
-                        language="English",
-                        custom={"session_id": item["identifier"]},
-                    )
+        if output_dir is not None:
+            supervision_set.to_file(
+                output_dir / f"peoples_speech_supervisions_{part.split('/')[1]}.jsonl.gz"
+            )
+            recording_set.to_file(output_dir / f"peoples_speech_recordings_{part.split('/')[1]}.jsonl.gz")
 
-                    validate_recordings_and_supervisions(recordings=r, supervisions=s)
+        manifests[part] = {"recordings": recording_set, "supervisions": supervision_set}
 
-                    rec_writer.write(r)
-                    sup_writer.write(s)
-
-                except Exception as e:
-                    # If some files are missing (e.g. somebody is working on a subset
-                    # of 30.000 hours), we won't interrupt processing; we will only
-                    # do so for violated assertions.
-                    if isinstance(e, AssertionError):
-                        raise
-                    err += 1
-                    continue
-
-    if exist < tot or err > 0:
-        warnings.warn(
-            f"We finished preparing The People's Speech Lhotse manifests. "
-            f"Out of {tot} entries in the original manifest, we found {exist} "
-            f"audio files existed, out of which {err} had errors during processing."
-        )
-
-    return {
-        "recordings": rec_writer.open_manifest(),
-        "supervisions": sup_writer.open_manifest(),
-    }
+    return manifests

--- a/lhotse/recipes/speechcommands.py
+++ b/lhotse/recipes/speechcommands.py
@@ -323,7 +323,6 @@ def prepare_speechcommands(
     :return: a Dict whose key is the dataset part, and the value is Dicts with the keys 'recordings' and 'supervisions'.
     """
     corpus_dir = Path(corpus_dir)
-    output_dir = Path(output_dir) if output_dir is not None else None
 
     assert corpus_dir.is_dir(), f"No such directory: {corpus_dir}"
 


### PR DESCRIPTION
- [x] Add multithread mechanism to peoples_speech recipe.
- [x] Support data splits (dirty, clean, dirty_sa, clean_sa, validation, test).
- [x] Fix duration mismatch, which results in errors when computing Fbank. 
- [x] Remove useless lines for 3 recipes (Submitted by myself)