### PR TITLE
`CutSet.from_files` constructor for random order multi-file cutsets

### DIFF
--- a/lhotse/cut/set.py
+++ b/lhotse/cut/set.py
@@ -271,6 +271,34 @@ class CutSet(Serializable, AlgorithmMixin):
         )
 
     @staticmethod
+    def from_files(
+        paths: List[Pathlike], shuffle_iters: bool = True, seed: int = 0
+    ) -> "CutSet":
+        """
+        Constructor that creates a single CutSet out of many manifest files.
+        We will iterate sequentially over each of the files, and by default we
+        will randomize the file order every time CutSet is iterated.
+
+        This is intended primarily for large datasets which are split into many small manifests,
+        to ensure that the order in which data is seen during training can be properly randomized.
+
+        :param paths: a list of paths to cut manifests.
+        :param shuffle_iters: bool, should we shuffle `paths` each time we iterate the returned
+            CutSet (enabled by default).
+        :param seed: int, random seed controlling the shuffling RNG.
+        :return: a lazy CutSet instance.
+        """
+        from lhotse.lazy import LazyIteratorChain, LazyManifestIterator
+
+        return CutSet(
+            LazyIteratorChain(
+                *(LazyManifestIterator(p) for p in paths),
+                shuffle_iters=shuffle_iters,
+                seed=seed,
+            )
+        )
+
+    @staticmethod
     def from_cuts(cuts: Iterable[Cut]) -> "CutSet":
         return CutSet(cuts=index_by_id_and_check(cuts))
 

--- a/lhotse/cut/set.py
+++ b/lhotse/cut/set.py
@@ -272,7 +272,7 @@ class CutSet(Serializable, AlgorithmMixin):
 
     @staticmethod
     def from_files(
-        paths: List[Pathlike], shuffle_iters: bool = True, seed: int = 0
+        paths: List[Pathlike], shuffle_iters: bool = True, seed: Optional[int] = None
     ) -> "CutSet":
         """
         Constructor that creates a single CutSet out of many manifest files.
@@ -286,6 +286,8 @@ class CutSet(Serializable, AlgorithmMixin):
         :param shuffle_iters: bool, should we shuffle `paths` each time we iterate the returned
             CutSet (enabled by default).
         :param seed: int, random seed controlling the shuffling RNG.
+            By default, we'll use Python's global RNG so the order
+            will be different on each script execution.
         :return: a lazy CutSet instance.
         """
         from lhotse.lazy import LazyIteratorChain, LazyManifestIterator

--- a/lhotse/lazy.py
+++ b/lhotse/lazy.py
@@ -237,7 +237,10 @@ class LazyIteratorChain(ImitatesDict):
     """
 
     def __init__(
-        self, *iterators: Iterable, shuffle_iters: bool = False, seed: int = 0
+        self,
+        *iterators: Iterable,
+        shuffle_iters: bool = False,
+        seed: Optional[int] = None,
     ) -> None:
         self.iterators = []
         self.shuffle_iters = shuffle_iters
@@ -254,7 +257,11 @@ class LazyIteratorChain(ImitatesDict):
     def __iter__(self):
         iterators = self.iterators
         if self.shuffle_iters:
-            random.Random(self.seed + self.num_iters).shuffle(iterators)
+            if self.seed is None:
+                rng = random  # global Python RNG
+            else:
+                rng = random.Random(self.seed + self.num_iters)
+            rng.shuffle(iterators)
             self.num_iters += 1
         for it in iterators:
             if isinstance(it, dict):

--- a/lhotse/lazy.py
+++ b/lhotse/lazy.py
@@ -227,11 +227,22 @@ class LazyIteratorChain(ImitatesDict):
     A thin wrapper over multiple iterators that enables to combine lazy manifests
     in Lhotse. It iterates all underlying iterables sequentially.
 
+    It also supports shuffling the sub-iterators when it's iterated over.
+    This can be used to implement sharding (where each iterator is a shard)
+    with randomized shard order. Every iteration of this object will increment
+    an internal counter so that the next time it's iterated, the order of shards
+    is again randomized.
+
     .. note:: if any of the input iterables is a dict, we'll iterate only its values.
     """
 
-    def __init__(self, *iterators: Iterable) -> None:
+    def __init__(
+        self, *iterators: Iterable, shuffle_iters: bool = False, seed: int = 0
+    ) -> None:
         self.iterators = []
+        self.shuffle_iters = shuffle_iters
+        self.seed = seed
+        self.num_iters = 0
         for it in iterators:
             # Auto-flatten LazyIteratorChain instances if any are passed
             if isinstance(it, LazyIteratorChain):
@@ -241,7 +252,11 @@ class LazyIteratorChain(ImitatesDict):
                 self.iterators.append(it)
 
     def __iter__(self):
-        for it in self.iterators:
+        iterators = self.iterators
+        if self.shuffle_iters:
+            random.Random(self.seed + self.num_iters).shuffle(iterators)
+            self.num_iters += 1
+        for it in iterators:
             if isinstance(it, dict):
                 it = it.values()
             yield from it

--- a/test/cut/test_cut_set.py
+++ b/test/cut/test_cut_set.py
@@ -667,3 +667,21 @@ def test_cut_set_decompose_output_dir_doesnt_duplicate_recording():
         # deduplicated recording
         assert len(recs) == 1
         assert recs[0].id == "dummy-recording-0000"
+
+
+def test_cut_set_from_files():
+    cs1 = DummyManifest(CutSet, begin_id=0, end_id=10)
+    cs2 = DummyManifest(CutSet, begin_id=10, end_id=20)
+    with NamedTemporaryFile(suffix=".jsonl.gz") as f1, NamedTemporaryFile(
+        suffix=".jsonl.gz"
+    ) as f2:
+        cs1.to_file(f1.name)
+        f1.flush()
+        cs2.to_file(f2.name)
+        f2.flush()
+
+        cs = CutSet.from_files([f1.name, f2.name], shuffle_iters=True, seed=0)
+        # __getitem__ with int index iterates lazy manifets
+        assert cs[0].id == "dummy-mono-cut-0000"
+        # On second iteration, we see a different order
+        assert cs[0].id == "dummy-mono-cut-0010"


### PR DESCRIPTION
An example of typical usage is:

```python
# We start with a big cut set that refers to all of the data.
big_cutset = CutSet.from_file("100k_hour_cuts.jsonl.gz")

# It's being split into smaller parts below.
big_cutset.split_lazy("shards", chunk_size=1000)

# Now we can iterate over the shards, randomizing their order on each iteration.
# Randomization is enabled by default.
sharded_cutset = CutSet.from_files(Path("shards").glob("*.jsonl.gz"))

# Order of shards will be randomized
for cut in sharded_cutset:
    pass

# This time the order will be different
for cut in sharded_cutset:
   pass

# We can randomize the cuts across the shards as well in a streaming fashion
# (note: this happens automatically in samplers when shuffle=True)
cuts = sharded_cutset.shuffle(buffer_size=50000)

# Works as usual with samplers
sampler = DynamicBucketingSampler(sharded_cutset, ...)
```