### PR TITLE
CutSet.mix: add random_mix_offset option

### DIFF
--- a/lhotse/dataset/cut_transforms/mix.py
+++ b/lhotse/dataset/cut_transforms/mix.py
@@ -20,6 +20,7 @@ class CutMix:
         pad_to_longest: bool = True,
         preserve_id: bool = False,
         seed: int = 42,
+        random_mix_offset: bool = False,
     ) -> None:
         """
         CutMix's constructor.
@@ -36,6 +37,9 @@ class CutMix:
             to match the duration of the longest Cut in a batch.
         :param preserve_id: When ``True``, preserves the IDs the cuts had before augmentation.
             Otherwise, new random IDs are generated for the augmented cuts (default).
+        :param random_mix_offset: an optional bool.
+            When ``True`` and the duration of the to be mixed in cut in longer than the original cut,
+             select a random sub-region from the to be mixed in cut.
         """
         self.cuts = cuts
         if len(self.cuts) == 0:
@@ -53,6 +57,7 @@ class CutMix:
         self.pad_to_longest = pad_to_longest
         self.preserve_id = preserve_id
         self.seed = seed
+        self.random_mix_offset = random_mix_offset
 
     def __call__(self, cuts: CutSet) -> CutSet:
 
@@ -70,4 +75,5 @@ class CutMix:
             mix_prob=self.p,
             preserve_id="left" if self.preserve_id else None,
             seed=self.seed,
+            random_mix_offset=self.random_mix_offset,
         )

--- a/test/cut/test_cut_set_mix.py
+++ b/test/cut/test_cut_set_mix.py
@@ -1,6 +1,7 @@
+import numpy as np
 import pytest
 
-from lhotse.cut import MixedCut
+from lhotse.cut import CutSet, MixedCut
 from lhotse.testing.fixtures import random_cut_set
 
 
@@ -49,3 +50,12 @@ def test_cut_set_mixing_with_prob(speech_cuts, noise_cuts):
     mixed_cuts = speech_cuts.mix(noise_cuts, mix_prob=0.5, duration=1000)
     was_mixed = [c.duration == 1000 for c in mixed_cuts]
     assert any(was_mixed) and not all(was_mixed)
+
+
+def test_cut_set_mixing_with_random_mix_offset():
+    speech_cuts = CutSet.from_json("test/fixtures/ljspeech/cuts.json").resample(16000)
+    noise_cuts = CutSet.from_json("test/fixtures/libri/cuts.json")
+    normal_mix = speech_cuts.mix(noise_cuts)
+    offset_mix = speech_cuts.mix(noise_cuts, random_mix_offset=True)
+    for a, b in zip(normal_mix, offset_mix):
+        assert not np.array_equal(a.load_audio(), b.load_audio())

--- a/test/dataset/test_cut_transforms.py
+++ b/test/dataset/test_cut_transforms.py
@@ -1,6 +1,7 @@
 import random
 from math import isclose
 
+import numpy as np
 import pytest
 
 from lhotse import CutSet
@@ -115,6 +116,15 @@ def test_cutmix(preserve_id: bool):
         assert all(
             cut.id != cut_noisy.id for cut, cut_noisy in zip(speech_cuts, tfnm_cuts)
         )
+
+
+def test_cutmix_random_mix_offset():
+    speech_cuts = CutSet.from_json("test/fixtures/ljspeech/cuts.json").resample(16000)
+    noise_cuts = CutSet.from_json("test/fixtures/libri/cuts.json")
+    normal_tfnm = CutMix(noise_cuts, p=1.0)
+    random_tfnm = CutMix(noise_cuts, p=1.0, random_mix_offset=True)
+    for a, b in zip(normal_tfnm(speech_cuts), random_tfnm(speech_cuts)):
+        assert not np.array_equal(a.load_audio(), b.load_audio())
 
 
 @pytest.mark.parametrize("randomized", [False, True])


### PR DESCRIPTION
Patch attempts to address this situation: given a recording of continuous background noise spanning an hour (e.g. https://doi.org/10.5281/zenodo.2660112), and a training cutset of short clean utterances, create an augmented dataset.

Run-time performance is about the same as this:

```
noise = noise.cut_into_windows(duration=20).to_eager()
cuts = cuts.mix(noise)
```
