### PR TITLE
Add Bengali.AI Speech corpus for Kaggle Research Code Competition

### DIFF
--- a/docs/corpus.rst
+++ b/docs/corpus.rst
@@ -63,6 +63,8 @@ a CLI tool that create the manifests given a corpus directory.
     - :func:`lhotse.recipes.prepare_atcosim`
   * - BABEL
     - :func:`lhotse.recipes.prepare_single_babel_language`
+  * - Bengali.AI Speech
+    - :func:`lhotse.recipes.prepare_bengaliai_speech`
   * - BUT ReverbDB
     - :func:`lhotse.recipes.prepare_but_reverb_db`
   * - BVCC / VoiceMOS Challenge

--- a/lhotse/bin/modes/recipes/__init__.py
+++ b/lhotse/bin/modes/recipes/__init__.py
@@ -9,6 +9,7 @@ from .ami import *
 from .aspire import *
 from .atcosim import *
 from .babel import *
+from .bengaliai_speech import *
 from .broadcast_news import *
 from .but_reverb_db import *
 from .bvcc import *

--- a/lhotse/bin/modes/recipes/bengaliai_speech.py
+++ b/lhotse/bin/modes/recipes/bengaliai_speech.py
@@ -1,0 +1,30 @@
+from typing import Dict, List, Optional, Tuple, Union
+
+import click
+
+from lhotse.bin.modes import download, prepare
+from lhotse.recipes.bengaliai_speech import prepare_bengaliai_speech
+from lhotse.utils import Pathlike
+
+
+@prepare.command(context_settings=dict(show_default=True))
+@click.argument("corpus_dir", type=click.Path(exists=True, dir_okay=True))
+@click.argument("output_dir", type=click.Path())
+@click.option(
+    "-j",
+    "--num-jobs",
+    type=int,
+    default=1,
+    help="How many threads to use (can give good speed-ups with slow disks).",
+)
+def bengaliai_speech(
+    corpus_dir: Pathlike,
+    output_dir: Optional[Pathlike] = None,
+    num_jobs: int = 1,
+):
+    """Bengali.AI Speech data preparation."""
+    prepare_bengaliai_speech(
+        corpus_dir=corpus_dir,
+        output_dir=output_dir,
+        num_jobs=num_jobs,
+    )

--- a/lhotse/bin/modes/recipes/bengaliai_speech.py
+++ b/lhotse/bin/modes/recipes/bengaliai_speech.py
@@ -2,7 +2,7 @@ from typing import Dict, List, Optional, Tuple, Union
 
 import click
 
-from lhotse.bin.modes import download, prepare
+from lhotse.bin.modes import prepare
 from lhotse.recipes.bengaliai_speech import prepare_bengaliai_speech
 from lhotse.utils import Pathlike
 

--- a/lhotse/recipes/__init__.py
+++ b/lhotse/recipes/__init__.py
@@ -7,6 +7,7 @@ from .ami import download_ami, prepare_ami
 from .aspire import prepare_aspire
 from .atcosim import download_atcosim, prepare_atcosim
 from .babel import prepare_single_babel_language
+from .bengaliai_speech import prepare_bengaliai_speech
 from .broadcast_news import prepare_broadcast_news
 from .but_reverb_db import download_but_reverb_db, prepare_but_reverb_db
 from .bvcc import download_bvcc, prepare_bvcc

--- a/lhotse/recipes/bengaliai_speech.py
+++ b/lhotse/recipes/bengaliai_speech.py
@@ -1,0 +1,208 @@
+"""
+About the Bengali.AI Speech corpus
+
+The competition dataset comprises about 1200 hours of recordings of Bengali speech.
+Your goal is to transcribe recordings of speech that is out-of-distribution with respect to the training set.
+
+Note that this is a Code Competition, in which the actual test set is hidden.
+In this public version, we give some sample data in the correct format to help you author your solutions.
+The full test set contains about 20 hours of speech in almost 8000 MP3 audio files.
+All of the files in the test set are encoded at a sample rate of 32k, a bit rate of 48k, in one channel.
+
+It is covered in more detail at https://arxiv.org/abs/2305.09688
+
+Please download manually by
+kaggle competitions download -c bengaliai-speech
+"""
+
+import logging
+import os
+from collections import defaultdict
+from concurrent.futures.process import ProcessPoolExecutor
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple, Union
+
+from tqdm.auto import tqdm
+
+from lhotse import (
+    get_ffmpeg_torchaudio_info_enabled,
+    set_ffmpeg_torchaudio_info_enabled,
+)
+from lhotse.audio import Recording, RecordingSet
+from lhotse.recipes.utils import manifests_exist
+from lhotse.supervision import SupervisionSegment, SupervisionSet
+from lhotse.utils import Pathlike
+
+BENGALIAI_SPEECH = ("train", "valid", "test")
+
+
+@contextmanager
+def disable_ffmpeg_torchaudio_info() -> None:
+    enabled = get_ffmpeg_torchaudio_info_enabled()
+    set_ffmpeg_torchaudio_info_enabled(False)
+    try:
+        yield
+    finally:
+        set_ffmpeg_torchaudio_info_enabled(enabled)
+
+
+def _parse_utterance(
+    corpus_dir: Pathlike,
+    audio_path: Pathlike,
+    audio_id: str,
+    text: Optional[str] = "",
+) -> Optional[Tuple[Recording, SupervisionSegment]]:
+    audio_path = audio_path.resolve()
+
+    if not audio_path.is_file():
+        logging.warning(f"No such file: {audio_path}")
+        return None
+
+    recording = Recording.from_file(
+        path=audio_path,
+        recording_id=audio_id,
+    )
+    segment = SupervisionSegment(
+        id=audio_id,
+        recording_id=audio_id,
+        text=text,
+        start=0.0,
+        duration=recording.duration,
+        channel=0,
+        language="Bengali",
+    )
+
+    return recording, segment
+
+
+def _prepare_subset(
+    subset: str,
+    corpus_dir: Pathlike,
+    audio_info: Optional[dict] = None,
+    num_jobs: int = 1,
+) -> Tuple[RecordingSet, SupervisionSet]:
+    """
+    Returns the RecodingSet and SupervisionSet given a dataset part.
+    :param subset: str, the name of the subset.
+    :param corpus_dir: Pathlike, the path of the data dir.
+    :return: the RecodingSet and SupervisionSet for train and valid.
+    """
+    corpus_dir = Path(corpus_dir)
+    if subset == "test":
+        part_path = corpus_dir / "test_mp3s"
+    else:
+        part_path = corpus_dir / "train_mp3s"
+
+    audio_paths = list(part_path.rglob("*.mp3"))
+
+    with disable_ffmpeg_torchaudio_info():
+        with ProcessPoolExecutor(num_jobs) as ex:
+            futures = []
+            recordings = []
+            supervisions = []
+            for audio_path in tqdm(audio_paths, desc="Distributing tasks"):
+                audio_id = os.path.split(str(audio_path))[1].replace(".mp3", "")
+                if audio_info is not None:
+                    if audio_id not in audio_info.keys():
+                        continue
+                    text = audio_info[audio_id]
+                else:
+                    text = None
+                futures.append(
+                    ex.submit(_parse_utterance, corpus_dir, audio_path, audio_id, text)
+                )
+
+            for future in tqdm(futures, desc="Processing"):
+                result = future.result()
+                if result is None:
+                    continue
+                recording, segment = result
+                recordings.append(recording)
+                supervisions.append(segment)
+
+            recording_set = RecordingSet.from_recordings(recordings)
+            supervision_set = SupervisionSet.from_segments(supervisions)
+
+    return recording_set, supervision_set
+
+
+def prepare_bengaliai_speech(
+    corpus_dir: Pathlike,
+    output_dir: Optional[Pathlike] = None,
+    num_jobs: int = 1,
+) -> Dict[str, Dict[str, Union[RecordingSet, SupervisionSet]]]:
+    """
+    Returns the manifests which consist of the Recordings and Supervisions
+    :param corpus_dir: Path to the Bengali.AI Speech dataset.
+    :param output_dir: Pathlike, the path where to write the manifests.
+    :return: a Dict whose key is the dataset part, and the value is Dicts with the keys 'recordings' and 'supervisions'.
+    """
+    corpus_dir = Path(corpus_dir)
+
+    assert corpus_dir.is_dir(), f"No such directory: {corpus_dir}"
+
+    logging.info("Preparing Bengali.AI Speech...")
+
+    subsets = BENGALIAI_SPEECH
+
+    if output_dir is not None:
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+    manifests = defaultdict(dict)
+
+    with open(corpus_dir / "train.csv") as f:
+        audio_info = f.read().splitlines()
+
+    train_info = {}
+    valid_info = {}
+    for line in audio_info[1:]:
+        if ",train" in line:
+            line = line.replace(",train", "").split(",", 1)
+            train_info[line[0]] = line[1]
+        elif ",valid" in line:
+            line = line.replace(",valid", "").split(",", 1)
+            valid_info[line[0]] = line[1]
+
+    for part in tqdm(subsets, desc="Dataset parts"):
+        logging.info(f"Processing Bengali.AI Speech subset: {part}")
+        if manifests_exist(
+            part=part,
+            output_dir=output_dir,
+            prefix="bengaliai_speech",
+            suffix="jsonl.gz",
+        ):
+            logging.info(
+                f"Bengali.AI Speech subset: {part} already prepared - skipping."
+            )
+            continue
+
+        if part == "train":
+            recording_set, supervision_set = _prepare_subset(
+                part, corpus_dir, train_info, num_jobs
+            )
+        elif part == "valid":
+            recording_set, supervision_set = _prepare_subset(
+                part, corpus_dir, valid_info, num_jobs
+            )
+        else:
+            recording_set, supervision_set = _prepare_subset(
+                part, corpus_dir, None, num_jobs
+            )
+
+        if output_dir is not None:
+            supervision_set.to_file(
+                output_dir / f"bengaliai_speech_supervisions_{part}.jsonl.gz"
+            )
+            recording_set.to_file(
+                output_dir / f"bengaliai_speech_recordings_{part}.jsonl.gz"
+            )
+
+        manifests[part] = {"recordings": recording_set, "supervisions": supervision_set}
+
+    return manifests
+
+
+if __name__ == "__main__":
+    prepare_bengaliai_speech("/star-data/kangwei/data/bengaliai", ".", 8)

--- a/lhotse/recipes/bengaliai_speech.py
+++ b/lhotse/recipes/bengaliai_speech.py
@@ -178,18 +178,16 @@ def prepare_bengaliai_speech(
             )
             continue
 
-        if part == "train":
-            recording_set, supervision_set = _prepare_subset(
-                part, corpus_dir, train_info, num_jobs
-            )
-        elif part == "valid":
-            recording_set, supervision_set = _prepare_subset(
-                part, corpus_dir, valid_info, num_jobs
-            )
-        else:
-            recording_set, supervision_set = _prepare_subset(
-                part, corpus_dir, None, num_jobs
-            )
+        recording_set, supervision_set = _prepare_subset(
+            subset=part,
+            corpus_dir=corpus_dir,
+            audio_info=train_info
+            if part == "train"
+            else valid_info
+            if part == "valid"
+            else None,
+            num_jobs=num_jobs,
+        )
 
         if output_dir is not None:
             supervision_set.to_file(

--- a/lhotse/recipes/bengaliai_speech.py
+++ b/lhotse/recipes/bengaliai_speech.py
@@ -202,7 +202,3 @@ def prepare_bengaliai_speech(
         manifests[part] = {"recordings": recording_set, "supervisions": supervision_set}
 
     return manifests
-
-
-if __name__ == "__main__":
-    prepare_bengaliai_speech("/star-data/kangwei/data/bengaliai", ".", 8)


### PR DESCRIPTION
This recipe prepares manifests for the dataset of a [Kaggle Research Code Competition](https://www.kaggle.com/competitions/bengaliai-speech).

The competition dataset comprises about 1200 hours of recordings of Bengali speech. 
Note that this is a [Code Competition](https://www.kaggle.com/competitions/bengaliai-speech/overview/code-requirements), in which the actual test set is hidden. The full test set contains about 20 hours of speech in almost 8000 MP3 audio files. All of the files in the test set are encoded at a sample rate of 32k, a bit rate of 48k, in one channel.

Details on the dataset are available in the dataset paper: https://arxiv.org/abs/2305.09688