### PR TITLE
Fixing shar reader assert

### DIFF
--- a/lhotse/shar/readers/lazy.py
+++ b/lhotse/shar/readers/lazy.py
@@ -268,7 +268,7 @@ class LazySharIterator(ImitatesDict):
                     if maybe_manifest is None:
                         continue  # No value available for the current field for this cut.
                     assert (
-                        data_path.stem == cut.id
+                        str(data_path.parent / data_path.stem) == cut.id
                     ), f"Mismatched IDs: cut ID is '{cut.id}' but found data with name '{data_path}' fsor field {field}"
                     setattr(cut, field, maybe_manifest)
 


### PR DESCRIPTION
This PR fixes shar reader's assert that fails unexpectedly for cut IDs with slashes. For example, it fails if the cut ID is `small/5118/told_in_a_french_garden_1010_librivox_64kb_mp3/toldinafrenchgarden_05_aldrich_64kb` and the recording path is `small/5118/told_in_a_french_garden_1010_librivox_64kb_mp3/toldinafrenchgarden_05_aldrich_64kb.flac` (a realistic cut ID produced by this recipe https://github.com/lhotse-speech/lhotse/blob/master/lhotse/recipes/librilight.py)