### PR TITLE
Fix bugs in `resumable_download`

### DIFF
--- a/lhotse/utils.py
+++ b/lhotse/utils.py
@@ -453,7 +453,8 @@ def resumable_download(
     completed_file_size: Optional[int] = None,
 ) -> None:
     # Check if the file exists and get its size
-    if os.path.exists(filename):
+    file_exists = os.path.exists(filename)
+    if file_exists:
         if force_download:
             logging.info(
                 f"Removing existing file and downloading from scratch because force_download=True: {filename}"
@@ -475,7 +476,8 @@ def resumable_download(
     # Open the file for writing in binary mode and seek to the end
     # r+b is needed in order to allow seeking at the beginning of a file
     # when downloading from scratch
-    with open(filename, "r+b") as f:
+    mode = "r+b" if file_exists else "wb"
+    with open(filename, mode) as f:
 
         def _download(rq, size):
             f.seek(size, 0)

--- a/lhotse/utils.py
+++ b/lhotse/utils.py
@@ -513,7 +513,7 @@ def resumable_download(
                     # sometimes, the server actually supports range requests
                     # but does not return the Content-Range header with 416 code
                     # This is out of spec, but let us check twice for pragmatic reasons.
-                    head_req = urllib.request.Request(url, method='HEAD')
+                    head_req = urllib.request.Request(url, method="HEAD")
                     head_res = urllib.request.urlopen(head_req)
                     if head_res.headers.get("Accept-Ranges", "none") != "none":
                         content_length = head_res.headers.get("Content-Length")


### PR DESCRIPTION
Bug #1: re-downloading from scratch worked incorrectly, since the file was opened in "ab" mode - hence, seeking to byte 0 had no effect, and the entire file was appended to the already downloaded part instead of rewriting it. Fixed this by opening the file in "r+b" mode (not "wb" to preserve the original contents).

Bug #2 (which is not really a bug but still): some servers serving some datasets behave incorrectly while returning 416 status code - they do not supply the "Content-Range" header with the response, even though they accept ranged downloads, as indicated by "Accept-Ranges" header in 200/206 responses. The example of that is [AMI dataset server](https://groups.inf.ed.ac.uk).

These bugs were encountered by me when trying to resume an interrupted download of AMI dataset, which resulted in a huge mess in the corpus folder. With those fixes, interrupting and resuming the download works without problems.