### PR TITLE
Fix broken `save_audio`

### DIFF
--- a/lhotse/cut/base.py
+++ b/lhotse/cut/base.py
@@ -850,7 +850,11 @@ class Cut:
                 )
             ],
         )
-        return fastcopy(self, recording=recording)
+        return fastcopy(
+            recording.to_cut(),
+            supervisions=self.supervisions,
+            custom=self.custom if hasattr(self, "custom") else None,
+        )
 
     def speakers_feature_mask(
         self,


### PR DESCRIPTION
Commit https://github.com/lhotse-speech/lhotse/commit/2046b55d9b91577271ec29ba312c3296234a0d492046b55d9b91577271ec29ba312c3296234a0d49 introduced a silly yet horrible regression, completely breaking down `save_audio` method:

- It stopped working in the first place for `MixedCut`s, since they do not have `recording` field, so `fastcopy` fails there;
- It stopped really working for `DataCut`s as well, since `fastcopy` preserved the original start times of the cut, while the underlying recording had changed, and so every such cut became invalid after `save_audio` (except maybe for the one starting from the very beginning of the original recording.

I do not have time today to add regression test for this, maybe tomorrow. This amounted to my almost entire working day being completely puzzled about why my data preparation pipeline got completely broken after I just changed the underlying data.... been blaming the data itself initially, not the `master` update.