### PR TITLE
Optimize `cut_into_windows` for long cuts

### DIFF
--- a/lhotse/cut/base.py
+++ b/lhotse/cut/base.py
@@ -750,15 +750,8 @@ class Cut:
 
         # Operation without an Interval Tree is O(nm), where `n` is the number
         # of resulting windows, and `m` is the number of supervisions in the cut.
-        # With an Interval Tree, we can do it in O(nlog(m) + m), but we have to pay
-        # the overhead of creating an IntervalTree.
-        #
-        # We will use an IntervalTree only if there are more than 10 supervisions and n > 5.
-        # (need to check via benchmarks)
-        if len(self.supervisions) > 10 and n_windows > 5:
-            supervisions_index = self.index_supervisions(index_mixed_tracks=True)
-        else:
-            supervisions_index = None
+        # With an Interval Tree, we can do it in O(nlog(m) + m)
+        supervisions_index = self.index_supervisions(index_mixed_tracks=True)
 
         for i in range(n_windows):
             new_cuts.append(


### PR DESCRIPTION
Even though the ability to optimize `truncate` calls using `IntervalTree` index on supervisions has been present for quite a while, it hasn't been used in the `cut_into_windows` method... I don't know why.

I used this optimization when the numbers of windows and supervisions were not very small and achieved dramatic (~50x) improvements for cutting sets of very long recordings into windows:

```
In [0]:
cs.describe()

Out[0]:
Cut statistics:
╒═══════════════════════════╤══════════╕
│ Cuts count:               │ 36       │
├───────────────────────────┼──────────┤
│ Total duration (hh:mm:ss) │ 35:29:42 │
├───────────────────────────┼──────────┤
│ mean                      │ 3549.5   │
├───────────────────────────┼──────────┤
│ std                       │ 136.8    │
├───────────────────────────┼──────────┤
│ min                       │ 3355.4   │
├───────────────────────────┼──────────┤
│ 25%                       │ 3477.2   │
├───────────────────────────┼──────────┤
│ 50%                       │ 3539.7   │
├───────────────────────────┼──────────┤
│ 75%                       │ 3558.1   │
├───────────────────────────┼──────────┤
│ 99%                       │ 4023.6   │
├───────────────────────────┼──────────┤
│ 99.5%                     │ 4037.8   │
├───────────────────────────┼──────────┤
│ 99.9%                     │ 4049.1   │
├───────────────────────────┼──────────┤
│ max                       │ 4052.0   │
├───────────────────────────┼──────────┤
│ Recordings available:     │ 36       │
├───────────────────────────┼──────────┤
│ Features available:       │ 0        │
├───────────────────────────┼──────────┤
│ Supervisions available:   │ 9339     │
╘═══════════════════════════╧══════════╛
Speech duration statistics:
╒══════════════════════════════╤══════════╤═════════════════════╕
│ Total speech duration        │ 34:38:04 │ 97.58% of recording │
├──────────────────────────────┼──────────┼─────────────────────┤
│ Total speaking time duration │ 34:38:01 │ 97.57% of recording │
├──────────────────────────────┼──────────┼─────────────────────┤
│ Total silence duration       │ 00:51:38 │ 2.42% of recording  │
╘══════════════════════════════╧══════════╧═════════════════════╛

In [1]:
%%time
# without the change
windowed = cs.cut_into_windows(duration=30.0).to_eager()
len(windowed)

Out [1]:
CPU times: user 2min 51s, sys: 135 ms, total: 2min 52s
Wall time: 2min 52s

4278

In [2]:
%%time
# with the change
windowed = cs.cut_into_windows(duration=30.0).to_eager()
len(windowed)

Out [2]:
CPU times: user 3.7 s, sys: 44.2 ms, total: 3.74 s
Wall time: 3.7 s

4278
```

(Tested on Intel Xeon Gold 5315Y CPU @ 3.20GHz)
