### PR TITLE
`MixedCut.truncate`: fix the case when only `PaddingCut`s are left

### DIFF
--- a/lhotse/cut/mixed.py
+++ b/lhotse/cut/mixed.py
@@ -497,14 +497,15 @@ class MixedCut(Cut):
                 )
             )
 
-        # Edge case: no tracks left after truncation. This can happen if we truncated an offset region.
+        # Edge case: no tracks with data left after truncation. This can happen if we truncated an offset region.
         # In this case, return a PaddingCut of the requested duration
-        if len(new_tracks) == 0:
+        if len([t for t in new_tracks if not isinstance(t.cut, PaddingCut)]) == 0:
             return PaddingCut(
                 id=self.id if preserve_id else str(uuid4()),
                 duration=duration,
                 sampling_rate=self.sampling_rate,
                 feat_value=0.0,
+                num_samples=compute_num_samples(duration, self.sampling_rate),
             )
 
         if len(new_tracks) == 1:

--- a/test/cut/test_cut_truncate.py
+++ b/test/cut/test_cut_truncate.py
@@ -146,7 +146,7 @@ def gapped_mixed_cut():
         id="gapped-mixed-cut",
         tracks=[
             MixTrack(cut=dummy_cut(0, duration=10.0)),
-            MixTrack(cut=dummy_cut(1, duration=10.0), offset=15.0),
+            MixTrack(cut=dummy_cut(1, duration=10.0).pad(12.0).pad(15.0), offset=15.0),
         ],
     )
 
@@ -226,12 +226,16 @@ def test_truncate_mixed_cut_with_small_offset_and_duration(simple_mixed_cut):
     assert truncated_cut.duration == 13.0
 
 
-def test_truncate_mixed_cut_inside_gap(gapped_mixed_cut):
-    truncated_cut = gapped_mixed_cut.truncate(offset=11.0, duration=3.0)
+@pytest.mark.parametrize("offset", [11.0, 26.0])
+def test_truncate_mixed_cut_gap_or_padding(gapped_mixed_cut, offset):
+    print(gapped_mixed_cut.duration)
+    truncated_cut = gapped_mixed_cut.truncate(offset=offset, duration=3.0)
     assert isinstance(truncated_cut, PaddingCut)
     assert truncated_cut.start == 0.0
     assert truncated_cut.duration == 3.0
     assert truncated_cut.end == 3.0
+    audio = truncated_cut.load_audio()
+    assert audio is not None
 
 
 def test_truncate_cut_set_offset_start(cut_set):


### PR DESCRIPTION
I encountered another couple of bugs after simulating long conversations with `ConversationalMeetingSimulator`, cutting them into windows and loading the windows' audios:

- If a window happened to be inside an offset region without any cuts, a `PaddingCut` was returned for which the audio (zeros array) could not be loaded, since `num_samples` property was not defined;
- If it happened so that only `PaddingCut`s remained after truncation, this case was not properly handled (in the same way as "no cuts remained" case), which resulted in the `IndexError` exception at the last lines of `truncate` method (where we attempt to set SNR of first non-padding track to `None`)

This PR fixes those.