### PR TITLE
WIP: Fix the bug about export_to_kaldi after wav resample

### DIFF
--- a/test/test_kaldi_dirs.py
+++ b/test/test_kaldi_dirs.py
@@ -161,6 +161,32 @@ def test_multi_channel_recording(
         assert segments == multi_channel_kaldi_dir["segments"]
 
 
+def test_resample_recording(
+    tmp_path, multi_channel_recording, multi_channel_kaldi_dir
+):
+    with working_directory(tmp_path):
+        recording = Recording.from_file(
+            recording_id='mono_c0',
+            path=join('test/fixtures/mono_c0.wav')
+        ).resample(16000)
+        segment = SupervisionSegment(
+            id='Segment-c0',
+            recording_id=recording.id,
+            start=0, duration=recording.duration, channel=0,
+            text='SIL',
+        )
+        lhotse.kaldi.export_to_kaldi(
+            [recording],
+            [segment],
+            output_dir=".",
+            map_underscores_to=None,
+            prefix_spk_id=False,
+        )
+
+        wavs = open_and_load("wav.scp")
+        assert '16000' in wavs['mono_c0']
+
+
 @contextlib.contextmanager
 def working_directory(path):
     """Changes working directory and returns to previous on exit."""

--- a/test/test_kaldi_dirs.py
+++ b/test/test_kaldi_dirs.py
@@ -10,6 +10,8 @@ import lhotse.audio.recording_set
 import lhotse.audio.source
 import lhotse.audio.utils
 from lhotse.audio import get_audio_duration_mismatch_tolerance
+from lhotse import RecordingSet, Recording
+from lhotse import SupervisionSet, SupervisionSegment
 
 pytest.importorskip(
     "kaldi_native_io", reason="Kaldi tests require kaldi_native_io to be installed."
@@ -167,7 +169,9 @@ def test_resample_recording(
     with working_directory(tmp_path):
         recording = Recording.from_file(
             recording_id='mono_c0',
-            path=join('test/fixtures/mono_c0.wav')
+            path=os.path.join(
+                os.path.dirname(__file__), 'fixtures', 'mono_c0.wav'
+            ),
         ).resample(16000)
         segment = SupervisionSegment(
             id='Segment-c0',
@@ -176,8 +180,8 @@ def test_resample_recording(
             text='SIL',
         )
         lhotse.kaldi.export_to_kaldi(
-            [recording],
-            [segment],
+            RecordingSet.from_recordings([recording]),
+            SupervisionSet.from_segments([segment]),
             output_dir=".",
             map_underscores_to=None,
             prefix_spk_id=False,


### PR DESCRIPTION
## Situation

When the 8kHz wav recording resampled to 16kHz was exported to kaldi_dir, the `wav.scp` should contain `ffmpeg -ar 16000`.

## Expectation

There is parameter about 16kHz in `wav.scp`

## Result

Only the file path.