### PR TITLE
PrecomputedFeatures: take the durations in `x` and `x_lens` from same source

### DIFF
--- a/lhotse/dataset/input_strategies.py
+++ b/lhotse/dataset/input_strategies.py
@@ -148,7 +148,14 @@ class PrecomputedFeatures(BatchIO):
                 for sup in cut.supervisions
             )
         )
+
         sequence_idx = [i for i, c in enumerate(cuts) for s in c.supervisions]
+
+        # Take `nums_frames` from `cut.num_frames` not from `cut.supervisions`
+        # -> `cut.num_frames` is also used in `collate_features()` for loading feature matrices
+        # -> this is to avoid +/- 1 frame error for `x`, `x_lens` in `Zipformer::forward()`
+        nums_frames = [cut.num_frames for cut in cuts]
+
         return {
             "sequence_idx": torch.tensor(sequence_idx, dtype=torch.int32),
             "start_frame": torch.tensor(start_frames, dtype=torch.int32),


### PR DESCRIPTION
Hi Piotr,
recently, i observed a bug that was caused by tiny inconsistency between values in `Cut.num_frames` and `Cut.supervisions[0].duration`.

The log-print of the error was this:
```
  File "/mnt/matylda5/iveselyk/CNECT_TENDER/MODEL_BUILDS/k2/k2_streaming_training-czech_v3_punct-truecase_downscaled/training/pruned_transducer_stateless7_streaming/model.py", line 118, in forward
    assert x.size(1) == x_lens.max().item(), (x.shape, x_lens, x_lens.max())
AssertionError: (torch.Size([71, 563, 80]), tensor([562, 562, 562, 562, 562, 561, 561, 560, 560, 559, 558, 558, 558, 556,
        556, 555, 554, 554, 554, 554, 554, 553, 553, 552, 552, 551, 551, 550,
        550, 548, 548, 547, 546, 544, 544, 543, 542, 542, 542, 540, 540, 540,
        538, 538, 535, 533, 532, 531, 531, 531, 529, 529, 529, 528, 528, 527,
        526, 526, 524, 524, 524, 523, 523, 522, 522, 522, 522, 521, 521, 520,
        520], device='cuda:3', dtype=torch.int32), tensor(562, device='cuda:3', dtype=torch.int32))
```

By diving into the code I realized that the feature files are loaded into `x` with lenghts taken from `Cut.num_frames` in [collate_features()](https://github.com/lhotse-speech/lhotse/blob/master/lhotse/dataset/collation.py#L131C1-L131C1) .
But for the `x_lens` the lengths are computed from `Cut.supervisions[0].duration` in [PrecomputedFeatures::supervision_intervals()](
https://github.com/lhotse-speech/lhotse/blob/287de1dbadcb70bf7398d3d482c1f730d2c5407f/lhotse/dataset/input_strategies.py#L145) via [utils::supervision_to_frames()](https://github.com/lhotse-speech/lhotse/blob/287de1dbadcb70bf7398d3d482c1f730d2c5407f/lhotse/utils.py#L732) and via [utils::compute_num_frames()](https://github.com/lhotse-speech/lhotse/blob/287de1dbadcb70bf7398d3d482c1f730d2c5407f/lhotse/utils.py#L390) .

The problem disappears after the change proposed in this PR.
However, the question is if this might back-fire in some way or not,
and if it is a good way to solve it this way...

Other solution is to check CutSet manifest and remove the utterances where `Cut.num_frames` and `compute_num_frames(Cut.supervisions[0].duration, ...)` disagree.

Piotr, what would be your view on this ?

Thanks & cheers,
Karel