### PR TITLE
Move window tensor to proper device

### DIFF
--- a/lhotse/features/kaldi/layers.py
+++ b/lhotse/features/kaldi/layers.py
@@ -167,7 +167,7 @@ class Wav2Win(nn.Module):
             x_strided = x_strided - self.preemph_coeff * x_offset[:, :, :-1]
 
         # Apply window_function to each frame
-        x_strided = x_strided * self._window
+        x_strided = x_strided * self._window.to(x_strided.device)
 
         # Pad columns with zero until we reach size (batch, num_frames, pad_length)
         if self.pad_length != self._length:


### PR DESCRIPTION
When running inference on GPU, `Wav2Win._forward_strided` fails if `x_strided` and `self._window` are on different device. Therefore, `self._window` should move into the same device as that of `x_strided`