### PR TITLE
Prevent accidental renaming when using with_suffix

### DIFF
--- a/lhotse/features/io.py
+++ b/lhotse/features/io.py
@@ -281,7 +281,9 @@ class LilcomFilesWriter(FeaturesWriter):
         subdir = self.storage_path_ / key[:3]
         subdir.mkdir(exist_ok=True)
         p = subdir / key
-        output_features_path = p.with_suffix(p.suffix + ".llc" if p.suffix != ".llc" else ".llc")
+        output_features_path = p.with_suffix(
+            p.suffix + ".llc" if p.suffix != ".llc" else ".llc"
+        )
         serialized_feats = lilcom.compress(value, tick_power=self.tick_power)
         with open(output_features_path, "wb") as f:
             f.write(serialized_feats)
@@ -345,7 +347,9 @@ class NumpyFilesWriter(FeaturesWriter):
         subdir = self.storage_path_ / key[:3]
         subdir.mkdir(exist_ok=True)
         p = subdir / key
-        output_features_path = p.with_suffix(p.suffix + ".npy" if p.suffix != ".npy" else ".npy")
+        output_features_path = p.with_suffix(
+            p.suffix + ".npy" if p.suffix != ".npy" else ".npy"
+        )
         np.save(output_features_path, value, allow_pickle=False)
         # Include sub-directory in the key, e.g. "abc/abcdef.npy"
         return "/".join(output_features_path.parts[-2:])
@@ -451,8 +455,11 @@ class NumpyHdf5Writer(FeaturesWriter):
         super().__init__()
         check_h5py_installed()
         import h5py
+
         p = Path(storage_path)
-        self.storage_path_ = p.with_suffix(p.suffix + ".h5" if p.suffix != ".h5" else ".h5")
+        self.storage_path_ = p.with_suffix(
+            p.suffix + ".h5" if p.suffix != ".h5" else ".h5"
+        )
         self.hdf = h5py.File(self.storage_path, mode=mode)
 
     @property
@@ -542,7 +549,9 @@ class LilcomHdf5Writer(FeaturesWriter):
         import h5py
 
         p = Path(storage_path)
-        self.storage_path_ = p.with_suffix(p.suffix + ".h5" if p.suffix != ".h5" else ".h5")
+        self.storage_path_ = p.with_suffix(
+            p.suffix + ".h5" if p.suffix != ".h5" else ".h5"
+        )
         self.hdf = h5py.File(self.storage_path, mode=mode)
         self.tick_power = tick_power
 
@@ -668,7 +677,9 @@ class ChunkedLilcomHdf5Writer(FeaturesWriter):
         import h5py
 
         p = Path(storage_path)
-        self.storage_path_ = p.with_suffix(p.suffix + ".h5" if p.suffix != ".h5" else ".h5")
+        self.storage_path_ = p.with_suffix(
+            p.suffix + ".h5" if p.suffix != ".h5" else ".h5"
+        )
         self.tick_power = tick_power
         self.chunk_size = chunk_size
         self.hdf = h5py.File(self.storage_path, mode=mode)
@@ -831,7 +842,9 @@ class LilcomChunkyWriter(FeaturesWriter):
 
         # ".lca" -> "lilcom chunky archive"
         p = Path(storage_path)
-        self.storage_path_ = p.with_suffix(p.suffix + ".lca" if p.suffix != ".lca" else ".lca")
+        self.storage_path_ = p.with_suffix(
+            p.suffix + ".lca" if p.suffix != ".lca" else ".lca"
+        )
         self.tick_power = tick_power
         self.file = open(self.storage_path, mode=mode)
         self.curr_offset = self.file.tell()

--- a/lhotse/features/io.py
+++ b/lhotse/features/io.py
@@ -280,7 +280,8 @@ class LilcomFilesWriter(FeaturesWriter):
         # too many files in a single directory.
         subdir = self.storage_path_ / key[:3]
         subdir.mkdir(exist_ok=True)
-        output_features_path = (subdir / key).with_suffix(".llc")
+        p = subdir / key
+        output_features_path = p.with_suffix(p.suffix + ".llc" if p.suffix != ".llc" else ".llc")
         serialized_feats = lilcom.compress(value, tick_power=self.tick_power)
         with open(output_features_path, "wb") as f:
             f.write(serialized_feats)
@@ -343,7 +344,8 @@ class NumpyFilesWriter(FeaturesWriter):
         # too many files in a single directory.
         subdir = self.storage_path_ / key[:3]
         subdir.mkdir(exist_ok=True)
-        output_features_path = (subdir / key).with_suffix(".npy")
+        p = subdir / key
+        output_features_path = p.with_suffix(p.suffix + ".npy" if p.suffix != ".npy" else ".npy")
         np.save(output_features_path, value, allow_pickle=False)
         # Include sub-directory in the key, e.g. "abc/abcdef.npy"
         return "/".join(output_features_path.parts[-2:])
@@ -449,8 +451,8 @@ class NumpyHdf5Writer(FeaturesWriter):
         super().__init__()
         check_h5py_installed()
         import h5py
-
-        self.storage_path_ = Path(storage_path).with_suffix(".h5")
+        p = Path(storage_path)
+        self.storage_path_ = p.with_suffix(p.suffix + ".h5" if p.suffix != ".h5" else ".h5")
         self.hdf = h5py.File(self.storage_path, mode=mode)
 
     @property
@@ -539,7 +541,8 @@ class LilcomHdf5Writer(FeaturesWriter):
         check_h5py_installed()
         import h5py
 
-        self.storage_path_ = Path(storage_path).with_suffix(".h5")
+        p = Path(storage_path)
+        self.storage_path_ = p.with_suffix(p.suffix + ".h5" if p.suffix != ".h5" else ".h5")
         self.hdf = h5py.File(self.storage_path, mode=mode)
         self.tick_power = tick_power
 
@@ -664,7 +667,8 @@ class ChunkedLilcomHdf5Writer(FeaturesWriter):
         check_h5py_installed()
         import h5py
 
-        self.storage_path_ = Path(storage_path).with_suffix(".h5")
+        p = Path(storage_path)
+        self.storage_path_ = p.with_suffix(p.suffix + ".h5" if p.suffix != ".h5" else ".h5")
         self.tick_power = tick_power
         self.chunk_size = chunk_size
         self.hdf = h5py.File(self.storage_path, mode=mode)
@@ -826,7 +830,8 @@ class LilcomChunkyWriter(FeaturesWriter):
         assert mode in ("wb", "ab")
 
         # ".lca" -> "lilcom chunky archive"
-        self.storage_path_ = Path(storage_path).with_suffix(".lca")
+        p = Path(storage_path)
+        self.storage_path_ = p.with_suffix(p.suffix + ".lca" if p.suffix != ".lca" else ".lca")
         self.tick_power = tick_power
         self.file = open(self.storage_path, mode=mode)
         self.curr_offset = self.file.tell()

--- a/test/features/test_feature_writer.py
+++ b/test/features/test_feature_writer.py
@@ -1,0 +1,83 @@
+from tempfile import TemporaryDirectory
+
+import numpy as np
+import pytest
+from pathlib import Path
+
+from lhotse import (
+    LilcomFilesWriter, 
+    NumpyFilesWriter,
+    NumpyHdf5Writer,
+    LilcomHdf5Writer,
+    ChunkedLilcomHdf5Writer, 
+    LilcomChunkyWriter, 
+    )
+from lhotse.utils import is_module_available
+
+
+@pytest.mark.parametrize(
+    ["writer_type", "ext"],
+    [
+        (LilcomFilesWriter, '.llc'),
+        (NumpyFilesWriter, '.npy'),
+    ],
+)
+def test_writer_saved_file(writer_type, ext):
+    # Generate small random numbers that are nicely compressed with lilcom
+    arr = np.log(np.random.uniform(size=(11, 80)).astype(np.float32) / 100)
+
+    with TemporaryDirectory() as d, writer_type(d) as writer:
+
+        #testing that words after . is not replace
+        input_key = "random0.3_vad.alpha"
+        key = writer.write(input_key, arr)
+        assert key == f"ran/{input_key}{ext}"
+
+        #Testing when end with extension it is not added again
+        input_key = f"temp0.2.alpha{ext}"
+        key = writer.write(input_key, arr)
+        assert key == f"tem/{input_key}"
+
+@pytest.mark.parametrize(
+    ["writer_type", "ext"],
+    [
+        pytest.param(
+            NumpyHdf5Writer,
+            ".h5",
+            marks=pytest.mark.skipif(
+                not is_module_available("h5py"),
+                reason="Requires h5py to run HDF5 tests.",
+            ),
+        ),
+        pytest.param(
+            LilcomHdf5Writer,
+            ".h5",
+            marks=pytest.mark.skipif(
+                not is_module_available("h5py"),
+                reason="Requires h5py to run HDF5 tests.",
+            ),
+        ),
+        pytest.param(
+            ChunkedLilcomHdf5Writer,
+            ".h5",
+            marks=pytest.mark.skipif(
+                not is_module_available("h5py"),
+                reason="Requires h5py to run HDF5 tests.",
+            ),
+        ),
+        (LilcomChunkyWriter, ".lca")
+    ],
+)
+def test_chunk_writer_saved_file(writer_type, ext):
+
+    with TemporaryDirectory() as d:
+
+        #testing that words after . is not replace
+        filename = "random0.3_vad.alpha"
+        with writer_type(f"{d}/{filename}") as writer:
+            assert writer.storage_path_ == Path(f"{d}/{filename}{ext}")
+
+        #Testing when end with extension it is not added again
+        filename = f"random0.3_vad.alpha{ext}"
+        with writer_type(f"{d}/{filename}") as writer:
+            assert writer.storage_path_ == Path(f"{d}/{filename}")

--- a/test/features/test_feature_writer.py
+++ b/test/features/test_feature_writer.py
@@ -1,8 +1,8 @@
+from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import numpy as np
 import pytest
-from pathlib import Path
 
 from lhotse import (
     ChunkedLilcomHdf5Writer,

--- a/test/features/test_feature_writer.py
+++ b/test/features/test_feature_writer.py
@@ -5,21 +5,21 @@ import pytest
 from pathlib import Path
 
 from lhotse import (
-    LilcomFilesWriter, 
+    ChunkedLilcomHdf5Writer,
+    LilcomChunkyWriter,
+    LilcomFilesWriter,
+    LilcomHdf5Writer,
     NumpyFilesWriter,
     NumpyHdf5Writer,
-    LilcomHdf5Writer,
-    ChunkedLilcomHdf5Writer, 
-    LilcomChunkyWriter, 
-    )
+)
 from lhotse.utils import is_module_available
 
 
 @pytest.mark.parametrize(
     ["writer_type", "ext"],
     [
-        (LilcomFilesWriter, '.llc'),
-        (NumpyFilesWriter, '.npy'),
+        (LilcomFilesWriter, ".llc"),
+        (NumpyFilesWriter, ".npy"),
     ],
 )
 def test_writer_saved_file(writer_type, ext):
@@ -27,16 +27,16 @@ def test_writer_saved_file(writer_type, ext):
     arr = np.log(np.random.uniform(size=(11, 80)).astype(np.float32) / 100)
 
     with TemporaryDirectory() as d, writer_type(d) as writer:
-
-        #testing that words after . is not replace
+        # testing that words after . is not replace
         input_key = "random0.3_vad.alpha"
         key = writer.write(input_key, arr)
         assert key == f"ran/{input_key}{ext}"
 
-        #Testing when end with extension it is not added again
+        # Testing when end with extension it is not added again
         input_key = f"temp0.2.alpha{ext}"
         key = writer.write(input_key, arr)
         assert key == f"tem/{input_key}"
+
 
 @pytest.mark.parametrize(
     ["writer_type", "ext"],
@@ -65,19 +65,17 @@ def test_writer_saved_file(writer_type, ext):
                 reason="Requires h5py to run HDF5 tests.",
             ),
         ),
-        (LilcomChunkyWriter, ".lca")
+        (LilcomChunkyWriter, ".lca"),
     ],
 )
 def test_chunk_writer_saved_file(writer_type, ext):
-
     with TemporaryDirectory() as d:
-
-        #testing that words after . is not replace
+        # testing that words after . is not replace
         filename = "random0.3_vad.alpha"
         with writer_type(f"{d}/{filename}") as writer:
             assert writer.storage_path_ == Path(f"{d}/{filename}{ext}")
 
-        #Testing when end with extension it is not added again
+        # Testing when end with extension it is not added again
         filename = f"random0.3_vad.alpha{ext}"
         with writer_type(f"{d}/{filename}") as writer:
             assert writer.storage_path_ == Path(f"{d}/{filename}")


### PR DESCRIPTION
Fixes #1183 

The use of `.with_suffix` replaces the strings after the `.`, which leads to issues when the key/path contains `.` in the name.