### PR TITLE
Two new options: `CutSet.from_shar(seed="trng")` and `DynamicCutSampler(quadratic_duration=...)`

### DIFF
--- a/lhotse/cut/set.py
+++ b/lhotse/cut/set.py
@@ -525,6 +525,11 @@ class CutSet(Serializable, AlgorithmMixin):
             argument. It will cause the iterator to shuffle shards differently on each node
             and dataloading worker in PyTorch training. This is mutually exclusive with
             ``split_for_dataloading=True``.
+            Seed can be set to ``'trng'`` which, like ``'randomized'``, shuffles the shards
+            differently on each iteration, but is not possible to control (and is not reproducible).
+            ``trng`` mode is mostly useful when the user has limited control over the training loop
+            and may not be able to guarantee internal Shar epoch is being incremented, but needs
+            randomness on each iteration (e.g. useful with PyTorch Lightning).
         :param stateful_shuffle: bool, by default ``False``. When ``True``, every
             time this object is fully iterated, it increments an internal epoch counter
             and triggers shard reshuffling with RNG seeded by ``seed`` + ``epoch``.

--- a/lhotse/dataset/sampling/dynamic_bucketing.py
+++ b/lhotse/dataset/sampling/dynamic_bucketing.py
@@ -63,7 +63,7 @@ class DynamicBucketingSampler(CutSampler):
     def __init__(
         self,
         *cuts: Iterable[Cut],
-        max_duration: float,
+        max_duration: Seconds,
         max_cuts: Optional[int] = None,
         num_buckets: int = 10,
         shuffle: bool = False,

--- a/lhotse/shar/readers/lazy.py
+++ b/lhotse/shar/readers/lazy.py
@@ -234,7 +234,7 @@ class LazySharIterator(ImitatesDict):
                     seed = int(os.environ[LHOTSE_PROCESS_SEED])
 
             if seed == "trng":
-                seed = secrets.randbelow(2 ** 32)
+                seed = secrets.randbelow(2**32)
 
             if self.stateful_shuffle:
                 seed += self.epoch

--- a/test/dataset/sampling/test_sampling.py
+++ b/test/dataset/sampling/test_sampling.py
@@ -51,6 +51,28 @@ def test_dynamic_cut_sampler_max_cuts():
     assert tot == 4
 
 
+def test_dynamic_cut_sampler_quadratic_duration():
+    # 2 cuts of 2s followed by 3 cuts of 1s
+    cut_set = DummyManifest(CutSet, begin_id=0, end_id=5)
+    for i, c in enumerate(cut_set):
+        if i < 2:
+            c.duration = 2.0
+
+    # at quadratic_duration=2.0, cuts of 1s have 1.5s and cuts of 2s have 4s
+    sampler = DynamicCutSampler(cut_set, max_duration=8.0, quadratic_duration=2.0)
+
+    batches = [b for b in sampler]
+    assert len(batches) == 2
+
+    b = batches[0]
+    assert len(b) == 2
+    assert sum(c.duration for c in b) == 4.0
+
+    b = batches[1]
+    assert len(b) == 3
+    assert sum(c.duration for c in b) == 3.0
+
+
 @pytest.mark.parametrize("sampler_cls", [SimpleCutSampler, DynamicCutSampler])
 def test_single_cut_sampler_shuffling(sampler_cls):
     # The dummy cuts have a duration of 1 second each


### PR DESCRIPTION
+ TRNG is useful when dataloading from shar but for any reason the training dataloader has to be recreated between every validation (shar typically depends keeping track of epochs internally to reshuffle the shards, with TRNG it doesn't have to at the cost of lack of exact reproducibility). 

+ exposed quadratic duration in dynamic cut sampler (useful when cutset is sorted by duration, then dynamic cut sampler can act as optimal pseudo-bucketing, and using quadratic_duration can help tune max_duration to an optimal value)