### PR TITLE
#1203 Update supervision_frame_masks() to skip negative end indices

### DIFF
--- a/lhotse/cut/set.py
+++ b/lhotse/cut/set.py
@@ -2912,6 +2912,7 @@ def compute_supervisions_frame_mask(
                     if ali.end < cut.duration
                     else num_frames
                 )
+                if et <= 0: continue
                 mask[st:et] = 1.0
         else:
             st = round(supervision.start / frame_shift) if supervision.start > 0 else 0
@@ -2920,6 +2921,7 @@ def compute_supervisions_frame_mask(
                 if supervision.end < cut.duration
                 else num_frames
             )
+            if et <= 0: continue
             mask[st:et] = 1.0
     return mask
 


### PR DESCRIPTION
When flipping mask digits to 1.0, negative indices should never be used.