### PR TITLE
Faster initialization option in `DynamicBucketingSampler` + various fixes

### DIFF
--- a/lhotse/audio/backend.py
+++ b/lhotse/audio/backend.py
@@ -431,10 +431,10 @@ def torchaudio_2_0_ffmpeg_enabled() -> bool:
     from packaging import version
 
     ver = version.parse(torchaudio.__version__)
-    if ver >= version.parse("2.0"):
-        return os.environ.get("TORCHAUDIO_USE_BACKEND_DISPATCHER", "0") == "1"
     if ver >= version.parse("2.1.0"):
         return True
+    if ver >= version.parse("2.0"):
+        return os.environ.get("TORCHAUDIO_USE_BACKEND_DISPATCHER", "0") == "1"
     return False
 
 

--- a/lhotse/audio/utils.py
+++ b/lhotse/audio/utils.py
@@ -46,6 +46,15 @@ class VideoInfo:
 
 def get_audio_duration_mismatch_tolerance() -> Seconds:
     """Retrieve the current audio duration mismatch tolerance in seconds."""
+    if (
+        _LHOTSE_AUDIO_DURATION_MISMATCH_TOLERANCE
+        != _DEFAULT_LHOTSE_AUDIO_DURATION_MISMATCH_TOLERANCE
+    ):
+        return _LHOTSE_AUDIO_DURATION_MISMATCH_TOLERANCE
+
+    if "LHOTSE_AUDIO_DURATION_MISMATCH_TOLERANCE" in os.environ:
+        return float(os.environ["LHOTSE_AUDIO_DURATION_MISMATCH_TOLERANCE"])
+
     return _LHOTSE_AUDIO_DURATION_MISMATCH_TOLERANCE
 
 

--- a/lhotse/bin/modes/shar.py
+++ b/lhotse/bin/modes/shar.py
@@ -49,6 +49,11 @@ def shar():
     default=True,
     help="Should we shuffle the cuts before splitting into shards.",
 )
+@click.option(
+    "--fault-tolerant/--fast-fail",
+    default=False,
+    help="Should we skip over cuts that failed to load data or raise an error.",
+)
 @click.option("--seed", default=0, type=int, help="Random seed.")
 @click.option(
     "-j",
@@ -66,6 +71,7 @@ def export(
     features: str,
     shard_size: int,
     shuffle: bool,
+    fault_tolerant: bool,
     seed: int,
     num_jobs: int,
     verbose: bool,
@@ -99,6 +105,7 @@ def export(
         fields=fields,
         shard_size=shard_size,
         num_jobs=num_jobs,
+        fault_tolerant=fault_tolerant,
         verbose=verbose,
     )
 

--- a/lhotse/serialization.py
+++ b/lhotse/serialization.py
@@ -601,7 +601,12 @@ def deserialize_custom_field(data: Optional[dict]) -> Optional[dict]:
 if is_module_available("orjson"):
     import orjson
 
-    decode_json_line = orjson.loads
+    def decode_json_line(line):
+        try:
+            return orjson.loads(line)
+        except:
+            return json.loads(line)
+
 else:
     decode_json_line = json.loads
 

--- a/test/dataset/sampling/test_dynamic_bucketing.py
+++ b/test/dataset/sampling/test_dynamic_bucketing.py
@@ -143,6 +143,48 @@ def test_dynamic_bucketing_sampler():
     assert sum(c.duration for c in batches[3]) == 2
 
 
+def test_dynamic_bucketing_sampler_precomputed_duration_bins():
+    cuts = DummyManifest(CutSet, begin_id=0, end_id=10)
+    for i, c in enumerate(cuts):
+        if i < 5:
+            c.duration = 1
+        else:
+            c.duration = 2
+
+    # all cuts actually go into bucket 1 and bucket 0 is always empty
+    sampler = DynamicBucketingSampler(
+        cuts, max_duration=5, num_buckets=2, duration_bins=[0.5], seed=0, shuffle=True,
+    )
+    next(iter(sampler))
+
+    batches = [b for b in sampler]
+    sampled_cuts = [c for b in batches for c in b]
+
+    # Invariant: no duplicated cut IDs
+    assert len(set(c.id for b in batches for c in b)) == len(sampled_cuts)
+
+    # Same number of sampled and source cuts.
+    assert len(sampled_cuts) == len(cuts)
+
+    # We sampled 5 batches with this RNG, like the following:
+    assert len(batches) == 5
+
+    assert len(batches[0]) == 2
+    assert sum(c.duration for c in batches[0]) == 2
+
+    assert len(batches[1]) == 2
+    assert sum(c.duration for c in batches[1]) == 3
+
+    assert len(batches[2]) == 2
+    assert sum(c.duration for c in batches[2]) == 3
+
+    assert len(batches[3]) == 2
+    assert sum(c.duration for c in batches[3]) == 3
+
+    assert len(batches[4]) == 2
+    assert sum(c.duration for c in batches[4]) == 4
+
+
 def test_dynamic_bucketing_sampler_max_duration_and_max_cuts():
     cuts = DummyManifest(CutSet, begin_id=0, end_id=10)
     for i, c in enumerate(cuts):

--- a/test/dataset/sampling/test_dynamic_bucketing.py
+++ b/test/dataset/sampling/test_dynamic_bucketing.py
@@ -153,7 +153,12 @@ def test_dynamic_bucketing_sampler_precomputed_duration_bins():
 
     # all cuts actually go into bucket 1 and bucket 0 is always empty
     sampler = DynamicBucketingSampler(
-        cuts, max_duration=5, num_buckets=2, duration_bins=[0.5], seed=0, shuffle=True,
+        cuts,
+        max_duration=5,
+        num_buckets=2,
+        duration_bins=[0.5],
+        seed=0,
+        shuffle=True,
     )
     next(iter(sampler))
 


### PR DESCRIPTION
Specifically:
- user may pass precomputed `duration_bins` into `DynamicBucketingSampler` to avoid the initial iteration over cuts
- user may override default audio loading duration mismatch tolerance vs manifest metadata with env var `LHOTSE_AUDIO_DURATION_MISMATCH_TOLERANCE=<value-in-seconds>`
- fix torchaudio version detection
- fault tolerant Shar audio export 
- fault tolerant orjson loading
- `IterableDatasetWrapper` by default won't reset the sampler when `__iter__` is called again, unless the sampler finished iteration