### PR TITLE
Add recipe for Medical Corpus

### DIFF
--- a/docs/corpus.rst
+++ b/docs/corpus.rst
@@ -143,6 +143,8 @@ a CLI tool that create the manifests given a corpus directory.
     - :func:`lhotse.recipes.prepare_librittsr`
   * - LJ Speech
     - :func:`lhotse.recipes.prepare_ljspeech`
+  * - Medical
+    - :func:`lhotse.recipes.prepare_medical`
   * - MiniLibriMix
     - :func:`lhotse.recipes.prepare_librimix`
   * - MTEDx

--- a/lhotse/bin/modes/recipes/__init__.py
+++ b/lhotse/bin/modes/recipes/__init__.py
@@ -52,6 +52,7 @@ from .librispeech import *
 from .libritts import *
 from .ljspeech import *
 from .magicdata import *
+from .medical import *
 from .mgb2 import *
 from .mls import *
 from .mtedx import *

--- a/lhotse/bin/modes/recipes/medical.py
+++ b/lhotse/bin/modes/recipes/medical.py
@@ -18,11 +18,15 @@ from lhotse.utils import Pathlike
     help="How many threads to use (can give good speed-ups with slow disks).",
 )
 def medical(
-    corpus_dir: Pathlike, output_dir: Optional[Pathlike] = None, num_jobs: int = 1,
+    corpus_dir: Pathlike,
+    output_dir: Optional[Pathlike] = None,
+    num_jobs: int = 1,
 ):
     """Medical data preparation."""
     prepare_medical(
-        corpus_dir=corpus_dir, output_dir=output_dir, num_jobs=num_jobs,
+        corpus_dir=corpus_dir,
+        output_dir=output_dir,
+        num_jobs=num_jobs,
     )
 
 
@@ -30,9 +34,11 @@ def medical(
 @click.argument("target_dir", type=click.Path())
 @click.option("--force-download", is_flag=True, default=False, help="Force download")
 def medical(
-    target_dir: Pathlike, force_download: Optional[bool] = False,
+    target_dir: Pathlike,
+    force_download: Optional[bool] = False,
 ):
     """Medical download."""
     download_medical(
-        target_dir=target_dir, force_download=force_download,
+        target_dir=target_dir,
+        force_download=force_download,
     )

--- a/lhotse/bin/modes/recipes/medical.py
+++ b/lhotse/bin/modes/recipes/medical.py
@@ -1,0 +1,38 @@
+from typing import Dict, List, Optional, Tuple, Union
+
+import click
+
+from lhotse.bin.modes import download, prepare
+from lhotse.recipes.medical import download_medical, prepare_medical
+from lhotse.utils import Pathlike
+
+
+@prepare.command(context_settings=dict(show_default=True))
+@click.argument("corpus_dir", type=click.Path(exists=True, dir_okay=True))
+@click.argument("output_dir", type=click.Path())
+@click.option(
+    "-j",
+    "--num-jobs",
+    type=int,
+    default=1,
+    help="How many threads to use (can give good speed-ups with slow disks).",
+)
+def medical(
+    corpus_dir: Pathlike, output_dir: Optional[Pathlike] = None, num_jobs: int = 1,
+):
+    """Medical data preparation."""
+    prepare_medical(
+        corpus_dir=corpus_dir, output_dir=output_dir, num_jobs=num_jobs,
+    )
+
+
+@download.command(context_settings=dict(show_default=True))
+@click.argument("target_dir", type=click.Path())
+@click.option("--force-download", is_flag=True, default=False, help="Force download")
+def medical(
+    target_dir: Pathlike, force_download: Optional[bool] = False,
+):
+    """Medical download."""
+    download_medical(
+        target_dir=target_dir, force_download=force_download,
+    )

--- a/lhotse/recipes/__init__.py
+++ b/lhotse/recipes/__init__.py
@@ -54,6 +54,7 @@ from .libritts import (
 )
 from .ljspeech import download_ljspeech, prepare_ljspeech
 from .magicdata import download_magicdata, prepare_magicdata
+from .medical import download_medical, prepare_medical
 from .mgb2 import prepare_mgb2
 from .mls import prepare_mls
 from .mobvoihotwords import download_mobvoihotwords, prepare_mobvoihotwords

--- a/lhotse/recipes/medical.py
+++ b/lhotse/recipes/medical.py
@@ -38,7 +38,10 @@ MEDICAL_SPLITS = (
 )
 
 
-def download_medical(target_dir: Pathlike = ".", force_download: bool = False,) -> Path:
+def download_medical(
+    target_dir: Pathlike = ".",
+    force_download: bool = False,
+) -> Path:
     """
     Download and unzip Medical dataset
 
@@ -58,7 +61,9 @@ def download_medical(target_dir: Pathlike = ".", force_download: bool = False,) 
         part_path = target_dir / part
         part_dir = str(part_path).replace(".tar.gz", "")
         resumable_download(
-            MEDICAL_BASE_URL + part, filename=part_path, force_download=force_download,
+            MEDICAL_BASE_URL + part,
+            filename=part_path,
+            force_download=force_download,
         )
         # Remove partial unpacked files, if any, and unpack everything.
         if "tar.gz" in part:
@@ -70,7 +75,8 @@ def download_medical(target_dir: Pathlike = ".", force_download: bool = False,) 
 
 
 def _parse_utterance(
-    corpus_dir: Pathlike, audio_info: str,
+    corpus_dir: Pathlike,
+    audio_info: str,
 ) -> Optional[Tuple[Recording, SupervisionSegment]]:
     audio_path, start, end, text = (
         audio_info.replace(",", "\t").replace("[", "\t").replace("]", "").split("\t")
@@ -97,7 +103,9 @@ def _parse_utterance(
 
 
 def _prepare_subset(
-    subset: str, corpus_dir: Pathlike, num_jobs: int = 1,
+    subset: str,
+    corpus_dir: Pathlike,
+    num_jobs: int = 1,
 ) -> Tuple[RecordingSet, SupervisionSet]:
     """
     Returns the RecodingSet and SupervisionSet given a dataset part.
@@ -138,7 +146,9 @@ def _prepare_subset(
 
 
 def prepare_medical(
-    corpus_dir: Pathlike, output_dir: Optional[Pathlike] = None, num_jobs: int = 1,
+    corpus_dir: Pathlike,
+    output_dir: Optional[Pathlike] = None,
+    num_jobs: int = 1,
 ) -> Dict[str, Dict[str, Union[RecordingSet, SupervisionSet]]]:
     """
     Returns the manifests which consist of the Recordings and Supervisions
@@ -163,7 +173,10 @@ def prepare_medical(
     for part in tqdm(subsets, desc="Dataset parts"):
         logging.info(f"Processing Medical subset: {part}")
         if manifests_exist(
-            part=part, output_dir=output_dir, prefix="medical", suffix="jsonl.gz",
+            part=part,
+            output_dir=output_dir,
+            prefix="medical",
+            suffix="jsonl.gz",
         ):
             logging.info(f"Medical subset: {part} already prepared - skipping.")
             continue

--- a/lhotse/recipes/medical.py
+++ b/lhotse/recipes/medical.py
@@ -2,10 +2,13 @@
 About the medical corpus
 
 A dataset of simulated patient-physician medical interviews with a focus on respiratory cases.
+The simulated medical conversation dataset is available on figshare.com.
+The dataset is divided into two sets of files: audio files of the simulated conversations in mp3 format, and the transcripts of the audio files as text files.
+There are 272 mp3 audio files and 272 corresponding transcript text files.
+Each file is titled with three characters and four digits.
+RES stands for respiratory, GAS represents gastrointestinal, CAR is cardiovascular, MSK is musculoskeletal, DER is dermatological, and the four following digits represent the case number of the respective disease category.
 
-The simulated medical conversation dataset is available on figshare.com. The dataset is divided into two sets of files: audio files of the simulated conversations in mp3 format, and the transcripts of the audio files as text files. There are 272 mp3 audio files and 272 corresponding transcript text files. Each file is titled with three characters and four digits. RES stands for respiratory, GAS represents gastrointestinal, CAR is cardiovascular, MSK is musculoskeletal, DER is dermatological, and the four following digits represent the case number of the respective disease category.
-
-It is covered in more detail at https://www.nature.com/articles/s41597-022-01423-1
+It is covered in more detail at https://www.nature.com/articles/s41597-022-01423-1.pdf
 """
 
 import logging
@@ -26,9 +29,6 @@ from lhotse.supervision import SupervisionSegment, SupervisionSet
 from lhotse.utils import Pathlike, resumable_download
 
 MEDICAL = ("test", "dev", "train")
-
-MEDICAL_BASE_URL = "https://huggingface.co/datasets/yfyeung/medical/resolve/main/"
-
 MEDICAL_SPLITS = (
     "audio.tar.gz",
     "cleantext.tar.gz",
@@ -36,6 +36,7 @@ MEDICAL_SPLITS = (
     "medical_dev.info",
     "medical_train.info",
 )
+MEDICAL_BASE_URL = "https://huggingface.co/datasets/yfyeung/medical/resolve/main/"
 
 
 def download_medical(
@@ -43,7 +44,7 @@ def download_medical(
     force_download: bool = False,
 ) -> Path:
     """
-    Download and unzip Medical dataset
+    Download and unzip Medical dataset.
 
     :param target_dir: Pathlike, the path of the dir to store the dataset.
     :param force_download: bool, if True, download the archive even if it already exists.
@@ -151,7 +152,7 @@ def prepare_medical(
     num_jobs: int = 1,
 ) -> Dict[str, Dict[str, Union[RecordingSet, SupervisionSet]]]:
     """
-    Returns the manifests which consist of the Recordings and Supervisions
+    Returns the manifests which consist of the Recordings and Supervisions.
     :param corpus_dir: Path to the Medical dataset.
     :param output_dir: Pathlike, the path where to write the manifests.
     :return: a Dict whose key is the dataset part, and the value is Dicts with the keys 'recordings' and 'supervisions'.

--- a/lhotse/recipes/medical.py
+++ b/lhotse/recipes/medical.py
@@ -1,0 +1,181 @@
+"""
+About the medical corpus
+
+A dataset of simulated patient-physician medical interviews with a focus on respiratory cases.
+
+The simulated medical conversation dataset is available on figshare.com. The dataset is divided into two sets of files: audio files of the simulated conversations in mp3 format, and the transcripts of the audio files as text files. There are 272 mp3 audio files and 272 corresponding transcript text files. Each file is titled with three characters and four digits. RES stands for respiratory, GAS represents gastrointestinal, CAR is cardiovascular, MSK is musculoskeletal, DER is dermatological, and the four following digits represent the case number of the respective disease category.
+
+It is covered in more detail at https://www.nature.com/articles/s41597-022-01423-1
+"""
+
+import logging
+import os
+import shutil
+import tarfile
+from collections import defaultdict
+from concurrent.futures.process import ProcessPoolExecutor
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple, Union
+
+from tqdm.auto import tqdm
+
+from lhotse.audio import Recording, RecordingSet
+from lhotse.qa import fix_manifests, validate_recordings_and_supervisions
+from lhotse.recipes.utils import manifests_exist
+from lhotse.supervision import SupervisionSegment, SupervisionSet
+from lhotse.utils import Pathlike, resumable_download
+
+MEDICAL = ("test", "dev", "train")
+
+MEDICAL_BASE_URL = "https://huggingface.co/datasets/yfyeung/medical/resolve/main/"
+
+MEDICAL_SPLITS = (
+    "audio.tar.gz",
+    "cleantext.tar.gz",
+    "medical_test.info",
+    "medical_dev.info",
+    "medical_train.info",
+)
+
+
+def download_medical(target_dir: Pathlike = ".", force_download: bool = False,) -> Path:
+    """
+    Download and unzip Medical dataset
+
+    :param target_dir: Pathlike, the path of the dir to store the dataset.
+    :param force_download: bool, if True, download the archive even if it already exists.
+
+    :return: the path to downloaded and extracted directory with data.
+    """
+    target_dir = Path(target_dir)
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    dataset_parts = MEDICAL_SPLITS
+
+    for part in tqdm(dataset_parts, desc="Downloading Medical"):
+        logging.info(f"Downloading part: {part}")
+        # Process the archive.
+        part_path = target_dir / part
+        part_dir = str(part_path).replace(".tar.gz", "")
+        resumable_download(
+            MEDICAL_BASE_URL + part, filename=part_path, force_download=force_download,
+        )
+        # Remove partial unpacked files, if any, and unpack everything.
+        if "tar.gz" in part:
+            shutil.rmtree(part_dir, ignore_errors=True)
+            with tarfile.open(part_path) as tar:
+                tar.extractall(target_dir)
+
+    return target_dir
+
+
+def _parse_utterance(
+    corpus_dir: Pathlike, audio_info: str,
+) -> Optional[Tuple[Recording, SupervisionSegment]]:
+    audio_path, start, end, text = (
+        audio_info.replace(",", "\t").replace("[", "\t").replace("]", "").split("\t")
+    )
+    file_name = str(audio_path).replace(".mp3", "").replace("audio/", "")
+    audio_path = (corpus_dir / audio_path).resolve()
+
+    if not audio_path.is_file():
+        logging.warning(f"No such file: {audio_path}")
+        return None
+
+    recording = Recording.from_file(path=audio_path, recording_id=file_name)
+    segment = SupervisionSegment(
+        id=file_name + "_" + str(hash(audio_info)),
+        recording_id=file_name,
+        start=float(start),
+        duration=float(end) - float(start),
+        channel=0,
+        language="English",
+        text=text,
+    )
+
+    return recording, segment
+
+
+def _prepare_subset(
+    subset: str, corpus_dir: Pathlike, num_jobs: int = 1,
+) -> Tuple[RecordingSet, SupervisionSet]:
+    """
+    Returns the RecodingSet and SupervisionSet given a dataset part.
+    :param subset: str, the name of the subset.
+    :param corpus_dir: Pathlike, the path of the data dir.
+    :return: the RecodingSet and SupervisionSet for train and valid.
+    """
+    corpus_dir = Path(corpus_dir)
+    text_path = corpus_dir / ("medical_" + subset + ".info")
+
+    with open(text_path) as f:
+        audio_infos = f.read().splitlines()
+
+    with ProcessPoolExecutor(num_jobs) as ex:
+        futures = []
+        recordings = []
+        supervisions = []
+        for audio_info in tqdm(audio_infos, desc="Distributing tasks"):
+            futures.append(ex.submit(_parse_utterance, corpus_dir, audio_info))
+
+        for future in tqdm(futures, desc="Processing"):
+            result = future.result()
+            if result is None:
+                continue
+            recording, segment = result
+            if recording not in recordings:
+                recordings.append(recording)
+            supervisions.append(segment)
+
+        recording_set = RecordingSet.from_recordings(recordings)
+        supervision_set = SupervisionSet.from_segments(supervisions)
+
+        # Fix manifests
+        recording_set, supervision_set = fix_manifests(recording_set, supervision_set)
+        validate_recordings_and_supervisions(recording_set, supervision_set)
+
+    return recording_set, supervision_set
+
+
+def prepare_medical(
+    corpus_dir: Pathlike, output_dir: Optional[Pathlike] = None, num_jobs: int = 1,
+) -> Dict[str, Dict[str, Union[RecordingSet, SupervisionSet]]]:
+    """
+    Returns the manifests which consist of the Recordings and Supervisions
+    :param corpus_dir: Path to the Medical dataset.
+    :param output_dir: Pathlike, the path where to write the manifests.
+    :return: a Dict whose key is the dataset part, and the value is Dicts with the keys 'recordings' and 'supervisions'.
+    """
+    corpus_dir = Path(corpus_dir)
+
+    assert corpus_dir.is_dir(), f"No such directory: {corpus_dir}"
+
+    logging.info("Preparing Medical...")
+
+    subsets = MEDICAL
+
+    if output_dir is not None:
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+    manifests = defaultdict(dict)
+
+    for part in tqdm(subsets, desc="Dataset parts"):
+        logging.info(f"Processing Medical subset: {part}")
+        if manifests_exist(
+            part=part, output_dir=output_dir, prefix="medical", suffix="jsonl.gz",
+        ):
+            logging.info(f"Medical subset: {part} already prepared - skipping.")
+            continue
+
+        recording_set, supervision_set = _prepare_subset(part, corpus_dir, num_jobs)
+
+        if output_dir is not None:
+            supervision_set.to_file(
+                output_dir / f"medical_supervisions_{part}.jsonl.gz"
+            )
+            recording_set.to_file(output_dir / f"medical_recordings_{part}.jsonl.gz")
+
+        manifests[part] = {"recordings": recording_set, "supervisions": supervision_set}
+
+    return manifests


### PR DESCRIPTION
This PR adds a recipe for [A dataset of simulated patient-physician medical interviews with a focus on respiratory cases](https://www.nature.com/articles/s41597-022-01423-1).
Corpus: https://huggingface.co/datasets/yfyeung/medical
Paper: https://www.nature.com/articles/s41597-022-01423-1

## Dataset Description
The simulated medical conversation dataset is available on figshare.com. The dataset is divided into two sets of files: audio files of the simulated conversations in mp3 format, and the transcripts of the audio files as text files. There are 272 mp3 audio files and 272 corresponding transcript text files. Each file is titled with three characters and four digits. RES stands for respiratory, GAS represents gastrointestinal, CAR is cardiovascular, MSK is musculoskeletal, DER is dermatological, and the four following digits represent the case number of the respective disease category.