### PR TITLE
Use `attacut` module for Thai word tokenization (in MMS forced alignment)

### DIFF
--- a/lhotse/workflows/forced_alignment/mms_aligner.py
+++ b/lhotse/workflows/forced_alignment/mms_aligner.py
@@ -143,19 +143,15 @@ def _word_tokenize(text: str, language: Optional[str] = None) -> List[str]:
         return kss.split_morphemes(text, return_pos=False)
 
     elif language == "th":
-        # `pythainlp` is alive and much better, but it is a huge package bloated with dependencies
-        if not is_module_available("tltk"):
+        if not is_module_available("attacut"):
             raise ImportError(
-                "MMSForcedAligner requires the 'tltk' module to be installed to align Thai text."
-                "Please install it with 'pip install tltk'."
+                "MMSForcedAligner requires the 'attacut' module to be installed to align Thai text."
+                "Please install it with 'pip install attacut'."
             )
 
-        from tltk import nlp
+        import attacut
 
-        pieces = nlp.pos_tag(text)
-        return [
-            word if word != "<s/>" else " " for piece in pieces for word, _ in piece
-        ]
+        return attacut.tokenize(text)
 
     elif language == "my":
         if not is_module_available("pyidaungsu"):


### PR DESCRIPTION
`tltk` module is not really maintained now, and it contains deprecated dependencies (`sklearn` vs. `scikit-learn`), which complicates its usage greatly. `attacut` module is fresher and has no problems with dependencies.