### PR TITLE
Support controllable `CutSet.mux` weights in multiprocess dataloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Lhotse uses several environment variables to customize it's behavior. They are a
 - `LHOTSE_AUDIO_DURATION_MISMATCH_TOLERANCE` - used when we load audio from a file and receive a different number of samples than declared in `Recording.num_samples`. This is sometimes necessary because different codecs (or even different versions of the same codec) may use different padding when decoding compressed audio. Typically values up to 0.1, or even 0.3 (second) are still reasonable, and anything beyond that indicates a serious issue.
 - `LHOTSE_AUDIO_BACKEND` - may be set to any of the values returned from CLI `lhotse list-audio-backends` to override the default behavior of trial-and-error and always use a specific audio backend.
 - `LHOTSE_AUDIO_LOADING_EXCEPTION_VERBOSE` - when set to `1` we'll emit full exception stack traces when every available audio backend fails to load a given file (they might be very large).
+- `LHOTSE_DILL_ENABLED` - when it's set to `1|True|true|yes`, we will enable `dill`-based serialization of `CutSet` and `Sampler` across processes (it's disabled by default even when `dill` is installed).
 - `LHOTSE_PREPARING_RELEASE` - used internally by developers when releasing a new version of Lhotse.
 - `TORCHAUDIO_USE_BACKEND_DISPATCHER` - when set to `1` and torchaudio version is below 2.1, we'll enable the experimental ffmpeg backend of torchaudio.
 - `RANK`, `WORLD_SIZE`, `WORKER`, and `NUM_WORKERS` are internally used to inform Lhotse Shar dataloading subprocesses.

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -125,6 +125,8 @@ Lhotse uses several environment variables to customize it's behavior. They are a
 
 * ``LHOTSE_AUDIO_LOADING_EXCEPTION_VERBOSE`` - when set to 1 we'll emit full exception stack traces when every available audio backend fails to load a given file (they might be very large).
 
+* ``LHOTSE_DILL_ENABLED`` - when it's set to ``1|True|true|yes``, we will enable ``dill``-based serialization of ``CutSet`` and ``Sampler`` across processes (it's disabled by default even when ``dill`` is installed).
+
 * ``LHOTSE_PREPARING_RELEASE`` - used internally by developers when releasing a new version of Lhotse.
 
 * ``TORCHAUDIO_USE_BACKEND_DISPATCHER`` - when set to 1 and torchaudio version is below 2.1, we'll enable the experimental ffmpeg backend of torchaudio.

--- a/lhotse/__init__.py
+++ b/lhotse/__init__.py
@@ -16,6 +16,7 @@ from .caching import is_caching_enabled, set_caching_enabled
 from .cut import CutSet, MonoCut, MultiCut, create_cut_set_eager, create_cut_set_lazy
 from .features import *
 from .kaldi import load_kaldi_data_dir
+from .lazy import dill_enabled, is_dill_enabled, set_dill_enabled
 from .manipulation import combine, split_parallelize_combine, to_manifest
 from .qa import fix_manifests, validate, validate_recordings_and_supervisions
 from .serialization import load_manifest, load_manifest_lazy, store_manifest

--- a/lhotse/cut/set.py
+++ b/lhotse/cut/set.py
@@ -3318,15 +3318,15 @@ def _perturb_speed(cut, *args, **kwargs):
 
 
 def _perturb_tempo(cut, *args, **kwargs):
-    return cut.perturb_speed(*args, **kwargs)
+    return cut.perturb_tempo(*args, **kwargs)
 
 
 def _perturb_volume(cut, *args, **kwargs):
-    return cut.perturb_speed(*args, **kwargs)
+    return cut.perturb_volume(*args, **kwargs)
 
 
 def _reverb_rir(cut, *args, **kwargs):
-    return cut.perturb_speed(*args, **kwargs)
+    return cut.reverb_rir(*args, **kwargs)
 
 
 def _normalize_loudness(cut, *args, **kwargs):

--- a/lhotse/cut/set.py
+++ b/lhotse/cut/set.py
@@ -2439,7 +2439,7 @@ class CutSet(Serializable, AlgorithmMixin):
         a new string (new cut ID).
         :return: a new ``CutSet`` with cuts with modified IDs.
         """
-        return self.map(lambda cut: cut.with_id(transform_fn(cut.id)))
+        return self.map(partial(_with_id, transform_fn=transform_fn))
 
     def fill_supervisions(
         self, add_empty: bool = True, shrink_ok: bool = False
@@ -3263,6 +3263,10 @@ def _add_recording_path_prefix_single(cut, path):
 
 def _add_features_path_prefix_single(cut, path):
     return cut.with_features_path_prefix(path)
+
+
+def _with_id(cut, transform_fn):
+    return cut.with_id(transform_fn(cut.id))
 
 
 def _call(obj, member_fn: str, *args, **kwargs) -> Callable:

--- a/lhotse/dataset/sampling/base.py
+++ b/lhotse/dataset/sampling/base.py
@@ -383,10 +383,9 @@ class TimeConstraint:
         if self.max_cuts is not None and self.num_cuts >= self.max_cuts:
             return True
 
-        thresh = self.longest_seen
-
         if self.max_duration is not None:
-            return self.current + thresh >= self.max_duration - 1e-3  # float precision
+            effective_duration = (self.num_cuts + 1) * self.longest_seen
+            return effective_duration > self.max_duration
         return False
 
     def reset(self) -> None:

--- a/lhotse/lazy.py
+++ b/lhotse/lazy.py
@@ -202,7 +202,7 @@ class Dillable:
     def __setstate__(self, state):
         if (
             is_module_available("dill")
-            and os.environ.get("LHOTSE_DILL_ENABLED", "0") not in self._ENABLED_VALUES
+            and os.environ.get("LHOTSE_DILL_ENABLED", "0") in self._ENABLED_VALUES
         ):
             import dill
 
@@ -481,9 +481,10 @@ class LazyInfiniteApproximateMultiplexer(ImitatesDict):
             # towards the beginning of an "epoch" and then keep yielding
             # from it1 shards until the epoch is finished and we can sample
             # from it0 again...
-            zipped_iter_weights = list(zip(self.iterators, self.weights))
+            indexes = list(range(len(self.iterators)))
             while True:
-                yield rng.choices(zipped_iter_weights, self.weights, k=1)[0]
+                selected = rng.choices(indexes, self.weights, k=1)[0]
+                yield self.iterators[selected], self.weights[selected]
 
         # Initialize an infinite sequence of finite streams.
         # It is sampled with weights and replacement from ``self.iterators``,

--- a/lhotse/lazy.py
+++ b/lhotse/lazy.py
@@ -1,5 +1,5 @@
+import os
 import random
-import secrets
 import types
 import warnings
 from functools import partial
@@ -186,8 +186,13 @@ class Dillable:
     If ``dill`` is not installed, it defers to what ``pickle`` does by default.
     """
 
+    _ENABLED_VALUES = {"1", "True", "true", "yes"}
+
     def __getstate__(self):
-        if is_module_available("dill"):
+        if (
+            is_module_available("dill")
+            and os.environ.get("LHOTSE_DILL_ENABLED", "0") in self._ENABLED_VALUES
+        ):
             import dill
 
             return dill.dumps(self.__dict__)
@@ -195,7 +200,10 @@ class Dillable:
             return self.__dict__
 
     def __setstate__(self, state):
-        if is_module_available("dill"):
+        if (
+            is_module_available("dill")
+            and os.environ.get("LHOTSE_DILL_ENABLED", "0") not in self._ENABLED_VALUES
+        ):
             import dill
 
             self.__dict__ = dill.loads(state)

--- a/lhotse/testing/fixtures.py
+++ b/lhotse/testing/fixtures.py
@@ -4,6 +4,7 @@ from tempfile import NamedTemporaryFile, TemporaryDirectory
 from typing import Dict, List
 
 import numpy as np
+import pytest
 import torch
 
 from lhotse import (
@@ -20,6 +21,11 @@ from lhotse import (
 from lhotse.array import seconds_to_frames
 from lhotse.supervision import AlignmentItem
 from lhotse.utils import Seconds, uuid4
+
+
+@pytest.fixture()
+def with_dill_enabled():
+    os.environ["LHOTSE_ENABLE_DILL"] = "1"
 
 
 def random_cut_set(n_cuts=100) -> CutSet:

--- a/lhotse/testing/fixtures.py
+++ b/lhotse/testing/fixtures.py
@@ -25,7 +25,7 @@ from lhotse.utils import Seconds, uuid4
 
 @pytest.fixture()
 def with_dill_enabled():
-    os.environ["LHOTSE_ENABLE_DILL"] = "1"
+    os.environ["LHOTSE_DILL_ENABLED"] = "1"
 
 
 def random_cut_set(n_cuts=100) -> CutSet:

--- a/lhotse/utils.py
+++ b/lhotse/utils.py
@@ -1100,3 +1100,10 @@ def build_rng(seed: Union[int, Literal["trng"]]) -> random.Random:
         return secrets.SystemRandom()
     else:
         return random.Random(seed)
+
+
+_LHOTSE_DILL_ENABLED = False
+
+
+def is_dill_enabled() -> bool:
+    return _LHOTSE_DILL_ENABLED or os.environ["LHOTSE_DILL_ENABLED"]

--- a/lhotse/workflows/meeting_simulation/conversational.py
+++ b/lhotse/workflows/meeting_simulation/conversational.py
@@ -6,7 +6,7 @@ from typing import Any, List, Optional, Union
 import numpy as np
 from tqdm import tqdm
 
-from lhotse import RecordingSet, SupervisionSet
+from lhotse import RecordingSet, SupervisionSet, dill_enabled
 from lhotse.cut import CutSet, MixedCut, MixTrack
 from lhotse.cut.set import mix
 from lhotse.parallel import parallel_map
@@ -88,6 +88,7 @@ class ConversationalMeetingSimulator(BaseMeetingSimulator):
         hist, bin_edges = np.histogram(values, bins=100, density=True)
         return rv_histogram((hist, bin_edges))
 
+    @dill_enabled(True)
     def fit(self, meetings: Optional[SupervisionSet] = None) -> None:
         """
         Learn the distribution of the meeting parameters from a given dataset.
@@ -261,6 +262,7 @@ class ConversationalMeetingSimulator(BaseMeetingSimulator):
         tracks = sorted(tracks, key=lambda x: x.offset)
         return MixedCut(id=str(uuid4()), tracks=tracks)
 
+    @dill_enabled(True)
     def simulate(
         self,
         cuts: CutSet,

--- a/lhotse/workflows/meeting_simulation/speaker_independent.py
+++ b/lhotse/workflows/meeting_simulation/speaker_independent.py
@@ -6,7 +6,8 @@ from typing import List, Optional, Union
 import numpy as np
 from tqdm import tqdm
 
-from lhotse import RecordingSet, SupervisionSet
+import lhotse
+from lhotse import RecordingSet, SupervisionSet, dill_enabled
 from lhotse.cut import CutSet, MixedCut, MixTrack
 from lhotse.cut.set import mix
 from lhotse.parallel import parallel_map
@@ -51,6 +52,7 @@ class SpeakerIndependentMeetingSimulator(BaseMeetingSimulator):
     def __repr__(self):
         return self.__class__.__name__ + f"(loc={self.loc}, scale={self.scale})"
 
+    @dill_enabled(True)
     def fit(self, meetings: Optional[SupervisionSet] = None) -> None:
         """
         Learn the distribution of the meeting parameters from a given dataset.
@@ -113,6 +115,7 @@ class SpeakerIndependentMeetingSimulator(BaseMeetingSimulator):
             tracks.append(track)
         return MixedCut(id=str(uuid4()), tracks=tracks)
 
+    @dill_enabled(True)
     def simulate(
         self,
         cuts: CutSet,

--- a/test/dataset/sampling/test_dynamic_bucketing.py
+++ b/test/dataset/sampling/test_dynamic_bucketing.py
@@ -174,8 +174,8 @@ def test_dynamic_bucketing_sampler_precomputed_duration_bins():
     # We sampled 5 batches with this RNG, like the following:
     assert len(batches) == 5
 
-    assert len(batches[0]) == 2
-    assert sum(c.duration for c in batches[0]) == 2
+    assert len(batches[0]) == 3
+    assert sum(c.duration for c in batches[0]) == 4
 
     assert len(batches[1]) == 2
     assert sum(c.duration for c in batches[1]) == 3
@@ -186,8 +186,8 @@ def test_dynamic_bucketing_sampler_precomputed_duration_bins():
     assert len(batches[3]) == 2
     assert sum(c.duration for c in batches[3]) == 3
 
-    assert len(batches[4]) == 2
-    assert sum(c.duration for c in batches[4]) == 4
+    assert len(batches[4]) == 1
+    assert sum(c.duration for c in batches[4]) == 2
 
 
 def test_dynamic_bucketing_sampler_max_duration_and_max_cuts():

--- a/test/dataset/sampling/test_sampler_pickling.py
+++ b/test/dataset/sampling/test_sampler_pickling.py
@@ -14,6 +14,8 @@ from lhotse.dataset import (
 )
 from lhotse.dataset.sampling.dynamic import DynamicCutSampler
 from lhotse.testing.dummies import DummyManifest
+from lhotse.testing.fixtures import with_dill_enabled
+from lhotse.utils import is_module_available
 
 CUTS = DummyManifest(CutSet, begin_id=0, end_id=100)
 CUTS_MOD = CUTS.modify_ids(lambda cid: cid + "_alt")
@@ -120,8 +122,13 @@ def test_sampler_pickling_with_filter(sampler):
     assert batches_restored[0][0].id == "dummy-mono-cut-0000"
 
 
+@pytest.mark.xfail(
+    not is_module_available("dill"),
+    reason="This test will fail when 'dill' module is not installed as it won't be able to pickle a closure.",
+    raises=AttributeError,
+)
 @pytest.mark.parametrize("sampler", create_samplers_to_test_filter())
-def test_sampler_pickling_with_filter_local_closure(sampler):
+def test_sampler_pickling_with_filter_local_closure(with_dill_enabled, sampler):
 
     selected_id = "dummy-mono-cut-0000"
 

--- a/test/dataset/test_controllable_weights.py
+++ b/test/dataset/test_controllable_weights.py
@@ -1,3 +1,5 @@
+from uuid import uuid4
+
 import numpy as np
 import pytest
 import torch
@@ -5,6 +7,7 @@ import torch
 from lhotse import CutSet
 from lhotse.dataset import DynamicCutSampler, IterableDatasetWrapper
 from lhotse.testing.dummies import DummyManifest
+from lhotse.testing.random import deterministic_rng
 
 
 class DummyDataset(torch.utils.data.Dataset):
@@ -20,13 +23,17 @@ def mark(val: int):
     return _inner
 
 
+def random_id(*args):
+    return str(uuid4())
+
+
 def assert_sources_are(cuts: CutSet, expected: list[int]):
     actual = [c.source for c in cuts]
     assert actual == expected
 
 
 @pytest.mark.parametrize("weight_type", [list, np.array, torch.tensor])
-def test_mux_with_controllable_weights(weight_type):
+def test_mux_with_controllable_weights(deterministic_rng, weight_type):
     """The sampler and the worker are both in the main process."""
 
     # 3 infinite iterables
@@ -59,7 +66,7 @@ def test_mux_with_controllable_weights(weight_type):
     assert_sources_are(b, [2, 2])
 
 
-def test_mux_with_controllable_weights_subprocess_worker():
+def test_mux_with_controllable_weights_subprocess_worker(deterministic_rng):
     """
     The sampler is in the main process but the worker is in a sub-process.
 
@@ -106,7 +113,9 @@ def test_mux_with_controllable_weights_subprocess_worker():
     assert_sources_are(b, [2, 2])
 
 
-def test_mux_with_controllable_weights_subprocess_sampler_shared_memory():
+def test_mux_with_controllable_weights_subprocess_sampler_shared_memory(
+    deterministic_rng,
+):
     """
     The sampler is placed in the dataloading subprocess.
 
@@ -138,12 +147,59 @@ def test_mux_with_controllable_weights_subprocess_sampler_shared_memory():
     b = next(dloader)
     assert_sources_are(b, [0, 0])
 
-    weights[0] = 0.0
-    weights[1] = 1.0
+    weights[:] = torch.tensor([0, 1, 0])  # atomic update
     b = next(dloader)
     assert_sources_are(b, [1, 1])
 
-    weights[1] = 0.0
-    weights[2] = 1.0
+    weights[:] = torch.tensor([0, 0, 1])  # atomic update
+    b = next(dloader)
+    assert_sources_are(b, [2, 2])
+
+
+@pytest.mark.skip(
+    reason="Infinite mux is not yet fully supported for shared memory weights."
+)
+def test_infinite_mux_with_controllable_weights_subprocess_sampler_shared_memory(
+    deterministic_rng,
+):
+    """
+    The sampler is placed in the dataloading subprocess.
+
+    Note: we are using PyTorch shared memory to share the weight tensor across processes.
+
+    In general expect a latency of ``prefetch_factor * num_workers`` in the propagation
+    of weights between the main process and the dataloading subprocesses.
+    """
+
+    # 3 infinite iterables
+    cuts1 = DummyManifest(CutSet, begin_id=0, end_id=3).map(mark(0))
+    cuts2 = DummyManifest(CutSet, begin_id=10, end_id=13).map(mark(1))
+    cuts3 = DummyManifest(CutSet, begin_id=100, end_id=103).map(mark(2))
+
+    weights = torch.tensor([1, 0, 0]).share_memory_()
+    assert weights.is_shared()
+    # randomize_id is required because infinite_mux may sample the same cut in a mini batch
+    muxd = CutSet.infinite_mux(cuts1, cuts2, cuts3, weights=weights).modify_ids(
+        random_id
+    )
+
+    dloader = torch.utils.data.DataLoader(
+        dataset=IterableDatasetWrapper(
+            dataset=DummyDataset(), sampler=DynamicCutSampler(muxd, max_cuts=2)
+        ),
+        batch_size=None,
+        num_workers=1,
+        prefetch_factor=1,
+    )
+
+    dloader = iter(dloader)
+    b = next(dloader)
+    assert_sources_are(b, [0, 0])
+
+    weights[:] = torch.tensor([0, 1, 0])  # atomic update
+    b = next(dloader)
+    assert_sources_are(b, [1, 1])
+
+    weights[:] = torch.tensor([0, 0, 1])  # atomic update
     b = next(dloader)
     assert_sources_are(b, [2, 2])

--- a/test/dataset/test_controllable_weights.py
+++ b/test/dataset/test_controllable_weights.py
@@ -1,0 +1,80 @@
+import torch
+
+from lhotse import CutSet
+from lhotse.dataset import DynamicCutSampler, IterableDatasetWrapper
+from lhotse.testing.dummies import DummyManifest
+
+
+class DummyDataset(torch.utils.data.Dataset):
+    def __getitem__(self, item):
+        return item
+
+
+def test_mux_with_controllable_weights():
+    def mark(val: int):
+        def _inner(cut):
+            cut.source = val
+            return cut
+
+        return _inner
+
+    # 3 infinite iterables
+    cuts1 = DummyManifest(CutSet, begin_id=0, end_id=3).map(mark(0)).repeat()
+    cuts2 = DummyManifest(CutSet, begin_id=10, end_id=13).map(mark(1)).repeat()
+    cuts3 = DummyManifest(CutSet, begin_id=100, end_id=103).map(mark(2)).repeat()
+
+    def assert_sources_are(cuts: CutSet, expected: list[int]):
+        actual = [c.source for c in cuts]
+        assert actual == expected
+
+    # TODO: initialize weights
+    weights = [1, 0, 0]
+
+    muxd = CutSet.mux(cuts1, cuts2, cuts3, weights=weights)
+
+    sampler = DynamicCutSampler(muxd, max_cuts=2)
+
+    # locate the sampler in a sub-process
+    dloader = torch.utils.data.DataLoader(
+        dataset=DummyDataset(),
+        sampler=sampler,
+        batch_size=None,
+        num_workers=0,
+    )
+
+    dloader = iter(dloader)
+    b = next(dloader)
+    assert_sources_are(b, [0, 0])
+
+    # TODO: set the weight
+    weights[0] = 0
+    weights[1] = 1
+    b = next(dloader)
+    assert_sources_are(b, [1, 1])
+
+    # TODO: set the weight
+    weights[1] = 0
+    weights[2] = 1
+    b = next(dloader)
+    assert_sources_are(b, [2, 2])
+
+
+def test_mux_with_controllable_weights_multiprocess():
+    return
+    # # 3 infinite iterables
+    # cuts1 = DummyManifest(CutSet, begin_id=0, end_id=3).repeat()
+    # cuts2 = DummyManifest(CutSet, begin_id=10, end_id=13).repeat()
+    # cuts3 = DummyManifest(CutSet, begin_id=100, end_id=103).repeat()
+    #
+    # weights = [1, 1, 1]
+    #
+    # muxd = CutSet.mux(cuts1, cuts2, cuts3, weights=weights)
+    #
+    # sampler = DynamicCutSampler(muxd, max_cuts=2)
+    #
+    # # locate the sampler in a sub-process
+    # dloader = torch.utils.data.DataLoader(
+    #     dataset=IterableDatasetWrapper(dataset=DummyDataset(), sampler=sampler),
+    #     batch_size=None,
+    #     num_workers=1,
+    # )

--- a/test/dataset/test_controllable_weights.py
+++ b/test/dataset/test_controllable_weights.py
@@ -33,7 +33,7 @@ def assert_sources_are(cuts: CutSet, expected: List[int]):
     assert actual == expected
 
 
-@pytest.mark.parametrize("weight_type", [List, np.array, torch.tensor])
+@pytest.mark.parametrize("weight_type", [list, np.array, torch.tensor])
 def test_mux_with_controllable_weights(deterministic_rng, weight_type):
     """The sampler and the worker are both in the main process."""
 

--- a/test/dataset/test_controllable_weights.py
+++ b/test/dataset/test_controllable_weights.py
@@ -1,3 +1,4 @@
+from typing import List
 from uuid import uuid4
 
 import numpy as np
@@ -27,12 +28,12 @@ def random_id(*args):
     return str(uuid4())
 
 
-def assert_sources_are(cuts: CutSet, expected: list[int]):
+def assert_sources_are(cuts: CutSet, expected: List[int]):
     actual = [c.source for c in cuts]
     assert actual == expected
 
 
-@pytest.mark.parametrize("weight_type", [list, np.array, torch.tensor])
+@pytest.mark.parametrize("weight_type", [List, np.array, torch.tensor])
 def test_mux_with_controllable_weights(deterministic_rng, weight_type):
     """The sampler and the worker are both in the main process."""
 

--- a/test/features/test_kaldi_layers.py
+++ b/test/features/test_kaldi_layers.py
@@ -15,9 +15,10 @@ from lhotse.features.kaldi.layers import (
     _get_strided_batch,
     _get_strided_batch_streaming,
 )
+from lhotse.testing.random import deterministic_rng
 
 
-def test_wav2win():
+def test_wav2win(deterministic_rng):
     x = torch.randn(1, 16000, dtype=torch.float32)
     t = Wav2Win()
     y, _ = t(x)
@@ -25,7 +26,7 @@ def test_wav2win():
     assert y.dtype == torch.float32
 
 
-def test_wav2fft():
+def test_wav2fft(deterministic_rng):
     x = torch.randn(1, 16000, dtype=torch.float32)
     t = Wav2FFT()
     y = t(x)
@@ -33,7 +34,7 @@ def test_wav2fft():
     assert y.dtype == torch.complex64
 
 
-def test_wav2spec():
+def test_wav2spec(deterministic_rng):
     x = torch.randn(1, 16000, dtype=torch.float32)
     t = Wav2Spec()
     y = t(x)
@@ -41,7 +42,7 @@ def test_wav2spec():
     assert y.dtype == torch.float32
 
 
-def test_wav2logspec():
+def test_wav2logspec(deterministic_rng):
     x = torch.randn(1, 16000, dtype=torch.float32)
     t = Wav2LogSpec()
     y = t(x)
@@ -49,7 +50,7 @@ def test_wav2logspec():
     assert y.dtype == torch.float32
 
 
-def test_wav2logfilterbank():
+def test_wav2logfilterbank(deterministic_rng):
     x = torch.randn(1, 16000, dtype=torch.float32)
     t = Wav2LogFilterBank()
     y = t(x)
@@ -57,7 +58,7 @@ def test_wav2logfilterbank():
     assert y.dtype == torch.float32
 
 
-def test_wav2mfcc():
+def test_wav2mfcc(deterministic_rng):
     x = torch.randn(1, 16000, dtype=torch.float32)
     t = Wav2MFCC()
     y = t(x)
@@ -65,7 +66,7 @@ def test_wav2mfcc():
     assert y.dtype == torch.float32
 
 
-def test_wav2win_is_torchscriptable():
+def test_wav2win_is_torchscriptable(deterministic_rng):
     x = torch.randn(1, 16000, dtype=torch.float32)
     t = torch.jit.script(Wav2Win())
     y, _ = t(x)
@@ -73,7 +74,7 @@ def test_wav2win_is_torchscriptable():
     assert y.dtype == torch.float32
 
 
-def test_wav2fft_is_torchscriptable():
+def test_wav2fft_is_torchscriptable(deterministic_rng):
     x = torch.randn(1, 16000, dtype=torch.float32)
     t = torch.jit.script(Wav2FFT())
     y = t(x)
@@ -81,7 +82,7 @@ def test_wav2fft_is_torchscriptable():
     assert y.dtype == torch.complex64
 
 
-def test_wav2spec_is_torchscriptable():
+def test_wav2spec_is_torchscriptable(deterministic_rng):
     x = torch.randn(1, 16000, dtype=torch.float32)
     t = torch.jit.script(Wav2Spec())
     y = t(x)
@@ -89,7 +90,7 @@ def test_wav2spec_is_torchscriptable():
     assert y.dtype == torch.float32
 
 
-def test_wav2logspec_is_torchscriptable():
+def test_wav2logspec_is_torchscriptable(deterministic_rng):
     x = torch.randn(1, 16000, dtype=torch.float32)
     t = torch.jit.script(Wav2LogSpec())
     y = t(x)
@@ -97,7 +98,7 @@ def test_wav2logspec_is_torchscriptable():
     assert y.dtype == torch.float32
 
 
-def test_wav2logfilterbank_is_torchscriptable():
+def test_wav2logfilterbank_is_torchscriptable(deterministic_rng):
     x = torch.randn(1, 16000, dtype=torch.float32)
     t = torch.jit.script(Wav2LogFilterBank())
     y = t(x)
@@ -105,7 +106,7 @@ def test_wav2logfilterbank_is_torchscriptable():
     assert y.dtype == torch.float32
 
 
-def test_wav2mfcc_is_torchscriptable():
+def test_wav2mfcc_is_torchscriptable(deterministic_rng):
     x = torch.randn(1, 16000, dtype=torch.float32)
     t = torch.jit.script(Wav2MFCC())
     y = t(x)
@@ -113,7 +114,7 @@ def test_wav2mfcc_is_torchscriptable():
     assert y.dtype == torch.float32
 
 
-def test_strided_waveform_batch_streaming_snip_edges_false():
+def test_strided_waveform_batch_streaming_snip_edges_false(deterministic_rng):
     x = torch.arange(16000).unsqueeze(0)
     window_length = 400
     window_shift = 160
@@ -158,7 +159,7 @@ def test_strided_waveform_batch_streaming_snip_edges_false():
     torch.testing.assert_allclose(y_online, y)
 
 
-def test_strided_waveform_batch_streaming_snip_edges_true():
+def test_strided_waveform_batch_streaming_snip_edges_true(deterministic_rng):
     x = torch.arange(16000).unsqueeze(0)
     window_length = 400
     window_shift = 160
@@ -199,7 +200,7 @@ def test_strided_waveform_batch_streaming_snip_edges_true():
     torch.testing.assert_allclose(y_online, y)
 
 
-def test_wav2win_streaming():
+def test_wav2win_streaming(deterministic_rng):
     x = torch.randn(1, 16000, dtype=torch.float32)
     t = Wav2Win()
     window_length = 400
@@ -243,7 +244,7 @@ def test_wav2win_streaming():
         (Wav2MFCC, 13),
     ],
 )
-def test_wav2logfilterbank_streaming(layer_type, feat_dim):
+def test_wav2logfilterbank_streaming(deterministic_rng, layer_type, feat_dim):
     x = torch.randn(1, 16000, dtype=torch.float32)
     t = layer_type()
     window_length = 400

--- a/test/test_lazy.py
+++ b/test/test_lazy.py
@@ -11,6 +11,7 @@ import pytest
 from lhotse import CutSet, FeatureSet, RecordingSet, SupervisionSet, combine
 from lhotse.lazy import LazyJsonlIterator
 from lhotse.testing.dummies import DummyManifest, as_lazy
+from lhotse.testing.fixtures import with_dill_enabled
 from lhotse.utils import fastcopy, is_module_available
 
 
@@ -235,7 +236,7 @@ def _get_ids(cuts):
     reason="This test will fail when 'dill' module is not installed as it won't be able to pickle a lambda.",
     raises=AttributeError,
 )
-def test_dillable():
+def test_dillable(with_dill_enabled):
     cuts = DummyManifest(CutSet, begin_id=0, end_id=2)
     with as_lazy(cuts) as lazy_cuts:
         lazy_cuts = lazy_cuts.map(lambda c: fastcopy(c, id=c.id + "-random-suffix"))


### PR DESCRIPTION
Several changes:
- as in the title, it's possible to use torch's shared memory tensor to supply mux weights and change them in a way that syncs across processes
- simplified DurationBatcher sampling logic (no changes in sampling behavior)
- fixed inconsistency between time constraint `exceeded()` and `close_to_exceeding()` (I think it was reported in some issue)
- leveraging `dill` for CutSet/Sampler inter-process serialization now has to be explicitly enabled with `LHOTSE_DILL_ENABLED=1`; the library is now less dependent on `dill` for making CutSet transforms work across main/dataloading processes (you'd only need it if you as the user provide lambdas instead of global functions / partials to map/filter-style functions)