### PR TITLE
Install kaldi-native-io explicitly in the kaldi doc example.

### DIFF
--- a/docs/kaldi.rst
+++ b/docs/kaldi.rst
@@ -60,6 +60,11 @@ to a directory with Lhotse manifests called ``train_manifests``:
 Example
 *******
 
+.. hint::
+
+   Before you continue, make sure you have run ``pip install kaldi-native-io``;
+   otherwise, you won't be able to get ``features.jsonl.gz`` below.
+
 In the following, we demonstrate how to import a Kaldi data directory using
 the ``yesno`` dataset.
 


### PR DESCRIPTION
Many users have forgotten to install `kaldi-native-io` when they convert features from kaldi to lhotse.
This PR puts an explicit command in the doc to mention that.