### PR TITLE
Last mini-batch redistribution in distributed samplers

### DIFF
--- a/lhotse/audio/recording_set.py
+++ b/lhotse/audio/recording_set.py
@@ -237,19 +237,11 @@ class RecordingSet(Serializable, AlgorithmMixin):
         if first is not None:
             assert first > 0
             out = RecordingSet.from_items(islice(self, first))
-            if len(out) < first:
-                logging.warning(
-                    f"RecordingSet has only {len(out)} items but first {first} were requested."
-                )
             return out
 
         if last is not None:
             assert last > 0
             if last > len(self):
-                logging.warning(
-                    f"RecordingSet has only {len(self)} items but last {last} required; "
-                    f"not doing anything."
-                )
                 return self
             return RecordingSet.from_recordings(
                 islice(self, len(self) - last, len(self))

--- a/lhotse/cut/set.py
+++ b/lhotse/cut/set.py
@@ -903,18 +903,11 @@ class CutSet(Serializable, AlgorithmMixin):
         if first is not None:
             assert first > 0
             out = CutSet.from_cuts(islice(self, first))
-            if len(out) < first:
-                logging.warning(
-                    f"CutSet has only {len(out)} items but first {first} were requested."
-                )
             return out
 
         if last is not None:
             assert last > 0
             if last > len(self):
-                logging.warning(
-                    f"CutSet has only {len(self)} items but last {last} required; not doing anything."
-                )
                 return self
             N = len(self)
             return CutSet.from_cuts(islice(self, N - last, N))

--- a/lhotse/features/base.py
+++ b/lhotse/features/base.py
@@ -697,19 +697,11 @@ class FeatureSet(Serializable, AlgorithmMixin):
         if first is not None:
             assert first > 0
             out = FeatureSet.from_items(islice(self, first))
-            if len(out) < first:
-                logging.warning(
-                    f"FeatureSet has only {len(out)} items but first {first} were requested."
-                )
             return out
 
         if last is not None:
             assert last > 0
             if last > len(self):
-                logging.warning(
-                    f"FeatureSet has only {len(self)} items but last {last} required; "
-                    f"not doing anything."
-                )
                 return self
             return FeatureSet.from_features(self.features[-last:])
 

--- a/lhotse/supervision.py
+++ b/lhotse/supervision.py
@@ -805,19 +805,11 @@ class SupervisionSet(Serializable, AlgorithmMixin):
         if first is not None:
             assert first > 0
             out = SupervisionSet.from_items(islice(self, first))
-            if len(out) < first:
-                logging.warning(
-                    f"SupervisionSet has only {len(out)} items but first {first} were requested."
-                )
             return out
 
         if last is not None:
             assert last > 0
             if last > len(self):
-                logging.warning(
-                    f"SupervisionSet has only {len(self)} items but last {last} required; "
-                    f"not doing anything."
-                )
                 return self
             return SupervisionSet.from_segments(
                 islice(self, len(self) - last, len(self))

--- a/test/dataset/sampling/test_sampling.py
+++ b/test/dataset/sampling/test_sampling.py
@@ -1,3 +1,4 @@
+import math
 import random
 from copy import deepcopy
 from functools import partial
@@ -1015,21 +1016,63 @@ def test_time_constraint_strictness():
     [
         SimpleCutSampler,
         DynamicCutSampler,
-        partial(BucketingSampler, num_buckets=2),
+        pytest.param(
+            partial(BucketingSampler, num_buckets=2),
+            marks=pytest.mark.xfail(
+                reason="BucketingSampler will oversample cuts when world_size>1 and drop_last=False "
+                "more than other samplers due to its implementation."
+            ),
+        ),
         partial(DynamicBucketingSampler, num_buckets=2),
     ],
 )
-@pytest.mark.parametrize("world_size", [1, 2, 3, 4])
-def test_sampler_does_not_drop_cuts_with_multiple_ranks(world_size, sampler_fn):
+@pytest.mark.parametrize("world_size", [1, 2, 16])
+@pytest.mark.parametrize("batch_duration", [1, 2, 4, 8, 16])
+def test_sampler_does_not_drop_cuts_with_multiple_ranks(
+    sampler_fn, world_size, batch_duration
+):
     cuts = DummyManifest(CutSet, begin_id=0, end_id=10)
+    num_input_cuts = len(cuts)
 
-    tot_cuts = 0
+    tot_cuts = []
+    batches = []
     for rank in range(world_size):
-        sampler = sampler_fn(cuts, max_duration=1.0, world_size=world_size, rank=rank)
+        sampler = sampler_fn(
+            cuts, max_duration=batch_duration, world_size=world_size, rank=rank
+        )
         for batch in sampler:
-            tot_cuts += len(batch)
+            batches.append(batch)
+            tot_cuts.extend(batch)
 
-    assert tot_cuts == len(cuts)
+    if world_size < num_input_cuts:
+        # ws=1
+        #   bs=1 => 10 (10batches)
+        #   bs=2 => 10 (5batches)
+        #   bs=4 => 10 (3batches)
+        #   bs=8 => 10 (2batches)
+        #   bs=16 => 10 (1batch)
+        # ws=2
+        #   bs=1 => 10 (1+1, 1+1, 1+1, 1+1, 1+1)
+        #   bs=2 => 10 (2+2, 2+2, 1+1)
+        #   bs=4 => 10 (4+4, 1+1)
+        #   bs=8 => 10 (5+5)
+        #   bs=16 => 10 (5+5)
+        assert len(tot_cuts) == num_input_cuts
+        assert len(set(c.id for c in tot_cuts)) == len(tot_cuts)  # no duplicates
+    else:
+        # ws=16
+        #   bs=1 => 16 (1x16, 6 duplicated)
+        #   bs=2 => 16 (1x16, 6 duplicated)
+        #   bs=4 => 16 (1x16, 6 duplicated)
+        #   bs=8 => 16 (1x16, 6 duplicated)
+        #   bs=16 => 16 (1x16, 6 duplicated)
+        assert num_input_cuts < len(tot_cuts)
+        assert len(tot_cuts) == world_size
+        uniq_ids = set(c.id for c in tot_cuts)
+        assert len(uniq_ids) == num_input_cuts
+        assert len(tot_cuts) - len(uniq_ids) == world_size - num_input_cuts
+        assert len(batches) == world_size
+        assert all(len(b) == 1 for b in batches)
 
 
 def test_sampler_map():


### PR DESCRIPTION
This change is intended to prevent training/validation loops hanging in multi-GPU setups when samplers have the setting `drop_last=False`. When `drop_last=True` and the number of GPUs (`world_size`) is large, it leads to discarding up to `world_size - 1` mini-batches, which is not acceptable for validation data as it's typically small. 

The default (`drop_last=False`) will now redistribute the data across mini-batches intended for each rank (since each rank has the access to the all ranks mini-batch in the current step anyway) in a consistent way across ranks to yield a partial mini-batch everywhere. When the number of available examples is less than `world_size`, we will duplicate the examples to cover difference, ensuring each rank gets a 1-element mini-batch. Note: this duplication is consistent with PyTorch's `DistributedSampler` behaviour; we missed it when creating Lhotse samplers.