### PR TITLE
Enable seed randomization in dynamic samplers

### DIFF
--- a/lhotse/dataset/dataloading.py
+++ b/lhotse/dataset/dataloading.py
@@ -1,6 +1,10 @@
 import os
+import random
+import secrets
 from functools import partial
-from typing import Callable, Optional
+from typing import Callable, Literal, Optional, Union
+
+import torch
 
 from lhotse.utils import fix_random_seed
 
@@ -57,3 +61,44 @@ def worker_init_fn(
     # because DataLoader workers did not initialize torch.distributed.
     os.environ["RANK"] = str(rank)
     os.environ["WORLD_SIZE"] = str(world_size)
+
+
+def resolve_seed(seed: Union[int, Literal["trng", "randomized"]]) -> int:
+    """
+    Resolves the special values of random seed supported in Lhotse.
+
+    If it's an integer, we'll just return it.
+
+    If it's "trng", we'll use the ``secrets`` module to generate a random seed
+    using a true RNG (to the extend supported by the OS).
+
+    If it's "randomized", we'll check whether we're in a dataloading worker of ``torch.utils.data.DataLoader``.
+    If we are, we expect that it was passed the result of :func:``lhotse.dataset.dataloading.make_worker_init_fn``
+    into its ``worker_init_fn`` argument, in which case we'll return a special seed exclusive to that worker.
+    If we are not in a dataloading worker (or ``num_workers`` was set to ``0``), we'll return Python's ``random``
+    module global seed.
+    """
+    if isinstance(seed, int):
+        return seed
+
+    if seed == "randomized":
+        worker_info = torch.utils.data.get_worker_info()
+        if worker_info is None:
+            # not in a dataloader sub-process: get python global random seed
+            return random.getstate()[1][0]
+        else:
+            # in a dataloader sub-process: read out the seed we assigned to it
+            assert LHOTSE_PROCESS_SEED in os.environ, (
+                "Requested seed='randomized' for shuffling shards differently "
+                "on each DataLoader node and worker, "
+                "but lhotse.dataset.dataloading.worker_init_fn was not called."
+            )
+            return int(os.environ[LHOTSE_PROCESS_SEED])
+
+    if seed == "trng":
+        return secrets.randbelow(2**32)
+
+    raise ValueError(
+        f"Unexpected type or value of seed: {type(seed)=} {seed=}. "
+        f"Supported values are: int, 'trng', and 'randomized'."
+    )

--- a/lhotse/dataset/dataloading.py
+++ b/lhotse/dataset/dataloading.py
@@ -5,6 +5,7 @@ from functools import partial
 from typing import Callable, Literal, Optional, Union
 
 import torch
+from torch import distributed as dist
 
 from lhotse.utils import fix_random_seed
 
@@ -102,3 +103,23 @@ def resolve_seed(seed: Union[int, Literal["trng", "randomized"]]) -> int:
         f"Unexpected type or value of seed: {type(seed)=} {seed=}. "
         f"Supported values are: int, 'trng', and 'randomized'."
     )
+
+
+def get_world_size() -> int:
+    """Source: https://github.com/danpovey/icefall/blob/74bf02bba6016c1eb37858a4e0e8a40f7d302bdb/icefall/dist.py#L56"""
+    if "WORLD_SIZE" in os.environ:
+        return int(os.environ["WORLD_SIZE"])
+    if dist.is_available() and dist.is_initialized():
+        return dist.get_world_size()
+    else:
+        return 1
+
+
+def get_rank() -> int:
+    """Source: https://github.com/danpovey/icefall/blob/74bf02bba6016c1eb37858a4e0e8a40f7d302bdb/icefall/dist.py#L56"""
+    if "RANK" in os.environ:
+        return int(os.environ["RANK"])
+    elif dist.is_available() and dist.is_initialized():
+        return dist.get_rank()
+    else:
+        return 0

--- a/lhotse/dataset/sampling/base.py
+++ b/lhotse/dataset/sampling/base.py
@@ -3,7 +3,7 @@ import warnings
 from copy import deepcopy
 from dataclasses import asdict, dataclass
 from math import isclose
-from typing import Any, Callable, Dict, Iterable, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, Literal, Optional, Tuple, Union
 
 from torch import distributed as dist
 from torch.utils.data import Sampler
@@ -57,7 +57,7 @@ class CutSampler(Sampler, Dillable):
         drop_last: bool = False,
         world_size: Optional[int] = None,
         rank: Optional[int] = None,
-        seed: int = 0,
+        seed: Union[int, Literal["randomized", "trng"]] = 0,
     ) -> None:
         """
         :param shuffle: When ``True``, the cuts will be shuffled at the start of iteration.

--- a/lhotse/dataset/sampling/base.py
+++ b/lhotse/dataset/sampling/base.py
@@ -5,6 +5,7 @@ from dataclasses import asdict, dataclass
 from math import isclose
 from typing import Any, Callable, Dict, Iterable, Literal, Optional, Tuple, Union
 
+import torch
 from torch import distributed as dist
 from torch.utils.data import Sampler
 
@@ -325,6 +326,7 @@ class CutSampler(Sampler, Dillable):
         self._log_diagnostics(selected)
         for tfn in self._transforms:
             selected = tfn(selected)
+        attach_dataloading_info(selected, rank=self.rank, world_size=self.world_size)
         return selected
 
     def _log_diagnostics(self, batch: Union[CutSet, Tuple[CutSet, ...]]) -> None:
@@ -345,6 +347,23 @@ def mark_as_duplicate(iteration: int) -> Callable[[str], str]:
         return f"{cut_id}_dup{iteration}"
 
     return inner
+
+
+def attach_dataloading_info(cuts: CutSet, rank: int, world_size: int) -> None:
+    """
+    Attaches diagnostic info about dataloading to each cut under ``dataloading_info`` custom field.
+    This information contains the rank, world_size, and worker_id.
+    If the training is not distributed, rank and world_size are 0 and 1.
+    If the num_workers argument in DataLoader was 0, worker_id is None.
+    """
+    worker_info = torch.utils.data.get_worker_info()
+    if worker_info is None:
+        worker_id = None
+    else:
+        worker_id = worker_info.id
+    info = {"rank": rank, "world_size": world_size, "worker_id": worker_id}
+    for cut in cuts:
+        cut.dataloading_info = info
 
 
 @dataclass

--- a/lhotse/dataset/sampling/stateless.py
+++ b/lhotse/dataset/sampling/stateless.py
@@ -1,15 +1,14 @@
 import logging
-import os
 import random
 from pathlib import Path
 from typing import Callable, Dict, Generator, Iterable, Optional, Sequence, Tuple, Union
 
 import torch
-import torch.distributed as dist
 from cytoolz import compose_left
 
 from lhotse import CutSet, Seconds
 from lhotse.cut.set import deserialize_cut
+from lhotse.dataset.dataloading import get_rank, get_world_size
 from lhotse.dataset.sampling.base import SamplingDiagnostics
 from lhotse.lazy import Dillable
 from lhotse.serialization import decode_json_line
@@ -314,23 +313,3 @@ class ManifestIndex:
                 print(offsets[-1], file=index_f)
                 line = cuts_f.readline()
         return tuple(offsets)
-
-
-def get_world_size() -> int:
-    """Source: https://github.com/danpovey/icefall/blob/74bf02bba6016c1eb37858a4e0e8a40f7d302bdb/icefall/dist.py#L56"""
-    if "WORLD_SIZE" in os.environ:
-        return int(os.environ["WORLD_SIZE"])
-    if dist.is_available() and dist.is_initialized():
-        return dist.get_world_size()
-    else:
-        return 1
-
-
-def get_rank() -> int:
-    """Source: https://github.com/danpovey/icefall/blob/74bf02bba6016c1eb37858a4e0e8a40f7d302bdb/icefall/dist.py#L56"""
-    if "RANK" in os.environ:
-        return int(os.environ["RANK"])
-    elif dist.is_available() and dist.is_initialized():
-        return dist.get_rank()
-    else:
-        return 0

--- a/test/dataset/sampling/test_sampling.py
+++ b/test/dataset/sampling/test_sampling.py
@@ -112,27 +112,74 @@ class IdentityDataset:
 def test_shuffle_seed_strategies(sampler_cls, seed):
     cut_set = DummyManifest(CutSet, begin_id=0, end_id=100)
 
-    sampler = sampler_cls(
-        cut_set,
-        shuffle=True,
-        max_duration=10.0,
-        seed=seed,
-    )
-    dloader = DataLoader(
-        IterableDatasetWrapper(IdentityDataset(), sampler),
-        num_workers=2,
-        batch_size=None,
-        worker_init_fn=make_worker_init_fn(),
-    )
+    world_size = 2
     sampled_cuts = []
-    for batch in dloader:
-        sampled_cuts.extend(batch)
+    for rank in range(world_size):
+        sampler = sampler_cls(
+            cut_set,
+            shuffle=True,
+            max_duration=10.0,
+            seed=seed,
+            rank=0,
+            world_size=1,
+        )
+        dloader = DataLoader(
+            IterableDatasetWrapper(IdentityDataset(), sampler),
+            num_workers=2,
+            batch_size=None,
+            worker_init_fn=make_worker_init_fn(rank=rank, world_size=world_size),
+        )
+        for batch in dloader:
+            sampled_cuts.extend(batch)
 
-    assert len(sampled_cuts) == 2 * len(cut_set)
+    # Since we're using 2 nodes * 2 workers, an iterable dataset, and do not do anything to de-duplicate,
+    # we have 4 copies of the input data.
+    assert len(sampled_cuts) == 4 * len(cut_set)
     uniq_ids = Counter()
     for c in sampled_cuts:
         uniq_ids[c.id] += 1
-    assert all(v == 2 for v in uniq_ids.values())
+    assert all(v == 4 for v in uniq_ids.values())
+
+    input_ids = list(cut_set.ids)
+    node0_worker0 = [
+        c.id
+        for c in sampled_cuts
+        if c.dataloading_info["worker_id"] == 0 and c.dataloading_info["rank"] == 0
+    ]
+    node0_worker1 = [
+        c.id
+        for c in sampled_cuts
+        if c.dataloading_info["worker_id"] == 1 and c.dataloading_info["rank"] == 0
+    ]
+    node1_worker0 = [
+        c.id
+        for c in sampled_cuts
+        if c.dataloading_info["worker_id"] == 0 and c.dataloading_info["rank"] == 1
+    ]
+    node1_worker1 = [
+        c.id
+        for c in sampled_cuts
+        if c.dataloading_info["worker_id"] == 1 and c.dataloading_info["rank"] == 1
+    ]
+
+    if seed == 0:
+        # When seed=0, ensure each copy is shuffled in the same order (but different than the input).
+        assert node0_worker0 == node0_worker1
+        assert node0_worker0 == node1_worker0
+        assert node0_worker0 == node1_worker1
+        assert node0_worker0 != input_ids
+    else:
+        # Otherwise, we expect each worker to shuffle in a different order.
+        assert node0_worker0 != node0_worker1
+        assert node0_worker0 != node1_worker0
+        assert node0_worker0 != node1_worker1
+        assert node0_worker1 != node1_worker0
+        assert node0_worker1 != node1_worker1
+        assert node1_worker0 != node1_worker1
+        assert node0_worker0 != input_ids
+        assert node0_worker1 != input_ids
+        assert node1_worker0 != input_ids
+        assert node1_worker1 != input_ids
 
 
 def test_single_cut_sampler_time_constraints():


### PR DESCRIPTION
This PR enables specifying `seed="randomized"` and `seed="trng"` for `DynamicCutSampler` and `DynamicBucketingSampler`. 

Both options are intended for use with `IterableDatasetWrapper` and cause the samplers to iterate with different random seeds in each node and dataloading worker. Note that for bucketing this will have the effect of de-synchronizing batch sizes across GPUs from the start of iteration (before the change, this occurs anyway after a number of training steps as observed in https://github.com/lhotse-speech/lhotse/discussions/857).

From now on, the sampler also attaches a custom field called `dataloading_info` to each cut which is a dict containing `rank`, `world_size`, and `worker_id` keys that help diagnose the dataloading.