### PR TITLE
Allow duplicate cut IDs in a CutSet (CutSet is list-like instead of dict-like)

### DIFF
--- a/lhotse/audio/recording_set.py
+++ b/lhotse/audio/recording_set.py
@@ -26,7 +26,7 @@ from lhotse.utils import (
 
 class RecordingSet(Serializable, AlgorithmMixin):
     """
-    :class:`~lhotse.audio.RecordingSet` represents a collection of recordings, indexed by recording IDs.
+    :class:`~lhotse.audio.RecordingSet` represents a collection of recordings.
     It does not contain any annotation such as the transcript or the speaker identity --
     just the information needed to retrieve a recording such as its path, URL, number of channels,
     and some recording metadata (duration, number of samples).
@@ -86,7 +86,7 @@ class RecordingSet(Serializable, AlgorithmMixin):
             >>> recs_24k = recs.resample(24000)
     """
 
-    def __init__(self, recordings: Optional[Mapping[str, Recording]] = None) -> None:
+    def __init__(self, recordings: Optional[Iterable[Recording]] = None) -> None:
         self.recordings = ifnone(recordings, {})
 
     def __eq__(self, other: "RecordingSet") -> bool:
@@ -99,11 +99,11 @@ class RecordingSet(Serializable, AlgorithmMixin):
 
     @property
     def ids(self) -> Iterable[str]:
-        return self.recordings.keys()
+        return (r.id for r in self)
 
     @staticmethod
     def from_recordings(recordings: Iterable[Recording]) -> "RecordingSet":
-        return RecordingSet(recordings=index_by_id_and_check(recordings))
+        return RecordingSet(list(recordings))
 
     from_items = from_recordings
 
@@ -254,7 +254,7 @@ class RecordingSet(Serializable, AlgorithmMixin):
         offset_seconds: float = 0.0,
         duration_seconds: Optional[float] = None,
     ) -> np.ndarray:
-        return self.recordings[recording_id].load_audio(
+        return self[recording_id].load_audio(
             channels=channels, offset=offset_seconds, duration=duration_seconds
         )
 
@@ -262,16 +262,16 @@ class RecordingSet(Serializable, AlgorithmMixin):
         return RecordingSet.from_recordings(r.with_path_prefix(path) for r in self)
 
     def num_channels(self, recording_id: str) -> int:
-        return self.recordings[recording_id].num_channels
+        return self[recording_id].num_channels
 
     def sampling_rate(self, recording_id: str) -> int:
-        return self.recordings[recording_id].sampling_rate
+        return self[recording_id].sampling_rate
 
     def num_samples(self, recording_id: str) -> int:
-        return self.recordings[recording_id].num_samples
+        return self[recording_id].num_samples
 
     def duration(self, recording_id: str) -> Seconds:
-        return self.recordings[recording_id].duration
+        return self[recording_id].duration
 
     def perturb_speed(self, factor: float, affix_id: bool = True) -> "RecordingSet":
         """
@@ -368,24 +368,25 @@ class RecordingSet(Serializable, AlgorithmMixin):
     def __repr__(self) -> str:
         return f"RecordingSet(len={len(self)})"
 
-    def __contains__(self, item: Union[str, Recording]) -> bool:
-        if isinstance(item, str):
-            return item in self.recordings
-        else:
-            return item.id in self.recordings
+    def __getitem__(self, index_or_id: Union[int, str]) -> Recording:
+        try:
+            return self.recordings[index_or_id]  # int passed, eager manifest, fast
+        except TypeError:
+            # either lazy manifest or str passed, both are slow
+            if self.is_lazy:
+                return next(item for idx, item in enumerate(self) if idx == index_or_id)
+            else:
+                # string id passed, support just for backward compatibility, not recommended
+                return next(item for item in self if item.id == index_or_id)
 
-    def __getitem__(self, recording_id_or_index: Union[int, str]) -> Recording:
-        if isinstance(recording_id_or_index, str):
-            return self.recordings[recording_id_or_index]
-        # ~100x faster than list(dict.values())[index] for 100k elements
-        return next(
-            val
-            for idx, val in enumerate(self.recordings.values())
-            if idx == recording_id_or_index
-        )
+    def __contains__(self, other: Union[str, Recording]) -> bool:
+        if isinstance(other, str):
+            return any(other == item.id for item in self)
+        else:
+            return any(other.id == item.id for item in self)
 
     def __iter__(self) -> Iterable[Recording]:
-        return iter(self.recordings.values())
+        yield from self.recordings
 
     def __len__(self) -> int:
         return len(self.recordings)

--- a/lhotse/audio/recording_set.py
+++ b/lhotse/audio/recording_set.py
@@ -18,7 +18,6 @@ from lhotse.utils import (
     Seconds,
     exactly_one_not_null,
     ifnone,
-    index_by_id_and_check,
     split_manifest_lazy,
     split_sequence,
 )

--- a/lhotse/cut/set.py
+++ b/lhotse/cut/set.py
@@ -44,7 +44,7 @@ from lhotse.features.base import StatsAccumulator, compute_global_stats
 from lhotse.features.io import FeaturesWriter, LilcomChunkyWriter
 from lhotse.lazy import (
     AlgorithmMixin,
-    BaseIterable,
+    Dillable,
     LazyFlattener,
     LazyIteratorChain,
     LazyManifestIterator,
@@ -3401,7 +3401,7 @@ def _export_to_shar_single(
     return writer.output_paths
 
 
-class LazyCutMixer(BaseIterable):
+class LazyCutMixer(Dillable):
     """
     Iterate over cuts from ``cuts`` CutSet while mixing randomly sampled ``mix_in_cuts`` into them.
     A typical application would be data augmentation with noise, music, babble, etc.

--- a/lhotse/cut/set.py
+++ b/lhotse/cut/set.py
@@ -65,7 +65,6 @@ from lhotse.utils import (
     exactly_one_not_null,
     fastcopy,
     ifnone,
-    index_by_id_and_check,
     split_manifest_lazy,
     split_sequence,
     uuid4,

--- a/lhotse/cut/set.py
+++ b/lhotse/cut/set.py
@@ -17,7 +17,6 @@ from typing import (
     Iterable,
     List,
     Literal,
-    Mapping,
     Optional,
     Sequence,
     Set,
@@ -45,7 +44,7 @@ from lhotse.features.base import StatsAccumulator, compute_global_stats
 from lhotse.features.io import FeaturesWriter, LilcomChunkyWriter
 from lhotse.lazy import (
     AlgorithmMixin,
-    ImitatesDict,
+    BaseIterable,
     LazyFlattener,
     LazyIteratorChain,
     LazyManifestIterator,
@@ -62,6 +61,7 @@ from lhotse.utils import (
     Seconds,
     compute_num_frames,
     compute_num_samples,
+    deprecated,
     exactly_one_not_null,
     fastcopy,
     ifnone,
@@ -76,9 +76,14 @@ FW = TypeVar("FW", bound=FeaturesWriter)
 
 class CutSet(Serializable, AlgorithmMixin):
     """
-    :class:`~lhotse.cut.CutSet` represents a collection of cuts, indexed by cut IDs.
+    :class:`~lhotse.cut.CutSet` represents a collection of cuts.
     CutSet ties together all types of data -- audio, features and supervisions, and is suitable to represent
     training/dev/test sets.
+
+    CutSet can be either "lazy" (acts as an iterable) which is best for representing full datasets,
+    or "eager" (acts as a list), which is best for representing individual mini-batches (and sometimes test/dev datasets).
+    Almost all operations are available for both modes, but some of them are more efficient depending on the mode
+    (e.g. indexing an "eager" manifest is O(1)).
 
     .. note::
         :class:`~lhotse.cut.CutSet` is the basic building block of PyTorch-style Datasets for speech/audio processing tasks.
@@ -242,34 +247,32 @@ class CutSet(Serializable, AlgorithmMixin):
         - :class:`~lhotse.cut.Cut`
     """
 
-    def __init__(
-        self, cuts: Optional[Union[Mapping[str, Cut], ImitatesDict]] = None
-    ) -> None:
-        self.cuts = ifnone(cuts, {})
+    def __init__(self, cuts: Optional[Iterable[Cut]] = None) -> None:
+        self.cuts = ifnone(cuts, [])
 
     def __eq__(self, other: "CutSet") -> bool:
         return self.cuts == other.cuts
 
     @property
-    def data(self) -> Union[Dict[str, Cut], Iterable[Cut]]:
+    def data(self) -> Iterable[Cut]:
         """Alias property for ``self.cuts``"""
         return self.cuts
 
     @property
-    def mixed_cuts(self) -> Dict[str, MixedCut]:
-        return {id_: cut for id_, cut in self.cuts.items() if isinstance(cut, MixedCut)}
+    def mixed_cuts(self) -> "CutSet":
+        return CutSet.from_cuts(cut for cut in self.cuts if isinstance(cut, MixedCut))
 
     @property
-    def simple_cuts(self) -> Dict[str, MonoCut]:
-        return {id_: cut for id_, cut in self.cuts.items() if isinstance(cut, MonoCut)}
+    def simple_cuts(self) -> "CutSet":
+        return CutSet.from_cuts(cut for cut in self.cuts if isinstance(cut, MonoCut))
 
     @property
-    def multi_cuts(self) -> Dict[str, MultiCut]:
-        return {id_: cut for id_, cut in self.cuts.items() if isinstance(cut, MultiCut)}
+    def multi_cuts(self) -> "CutSet":
+        return CutSet.from_cuts(cut for cut in self.cuts if isinstance(cut, MultiCut))
 
     @property
     def ids(self) -> Iterable[str]:
-        return self.cuts.keys()
+        return (c.id for c in self.cuts)
 
     @property
     def speakers(self) -> FrozenSet[str]:
@@ -307,7 +310,8 @@ class CutSet(Serializable, AlgorithmMixin):
 
     @staticmethod
     def from_cuts(cuts: Iterable[Cut]) -> "CutSet":
-        return CutSet(cuts=index_by_id_and_check(cuts))
+        """Left for backward compatibility, where it implicitly created an "eager" CutSet."""
+        return CutSet(list(cuts))
 
     from_items = from_cuts
 
@@ -827,7 +831,7 @@ class CutSet(Serializable, AlgorithmMixin):
         :return: A list of :class:`~lhotse.CutSet` pieces.
         """
         return [
-            CutSet.from_cuts(subset)
+            CutSet(subset)
             for subset in split_sequence(
                 self,
                 num_splits=num_splits,
@@ -925,14 +929,14 @@ class CutSet(Serializable, AlgorithmMixin):
             cut_ids = list(cut_ids)  # Remember the original order
             id_set = frozenset(cut_ids)  # Make a set for quick lookup
             # Iteration makes it possible to subset lazy manifests
-            cuts = CutSet.from_cuts(cut for cut in self if cut.id in id_set)
+            cuts = CutSet([cut for cut in self if cut.id in id_set])
             if len(cuts) < len(cut_ids):
                 logging.warning(
                     f"In CutSet.subset(cut_ids=...): expected {len(cut_ids)} cuts but got {len(cuts)} "
                     f"instead ({len(cut_ids) - len(cuts)} cut IDs were not in the CutSet)."
                 )
             # Restore the requested cut_ids order.
-            return CutSet.from_cuts(cuts[cid] for cid in cut_ids)
+            return cuts.sort_like(cut_ids)
 
     def filter_supervisions(
         self, predicate: Callable[[SupervisionSegment], bool]
@@ -1142,7 +1146,7 @@ class CutSet(Serializable, AlgorithmMixin):
             )
             for span in segments:
                 cuts.append(cut.truncate(offset=span.start, duration=span.duration))
-        return CutSet.from_cuts(cuts)
+        return CutSet(cuts)
 
     def trim_to_supervision_groups(
         self,
@@ -1245,7 +1249,7 @@ class CutSet(Serializable, AlgorithmMixin):
         This is advantageous before caling `save_audios()` on a `trim_to_supervision()`
         processed `CutSet`, also make sure that `set_caching_enabled(True)` was called.
         """
-        return CutSet.from_cuts(
+        return CutSet(
             sorted(self, key=(lambda cut: cut.recording.id), reverse=not ascending)
         )
 
@@ -1253,18 +1257,23 @@ class CutSet(Serializable, AlgorithmMixin):
         """
         Sort the CutSet according to cuts duration and return the result. Descending by default.
         """
-        return CutSet.from_cuts(
+        return CutSet(
             sorted(self, key=(lambda cut: cut.duration), reverse=not ascending)
         )
 
-    def sort_like(self, other: "CutSet") -> "CutSet":
+    def sort_like(self, other: Union["CutSet", Sequence[str]]) -> "CutSet":
         """
         Sort the CutSet according to the order of cut IDs in ``other`` and return the result.
         """
+        other_ids = list(other.ids if isinstance(other, CutSet) else other)
         assert set(self.ids) == set(
-            other.ids
+            other_ids
         ), "sort_like() expects both CutSet's to have identical cut IDs."
-        return CutSet.from_cuts(self[cid] for cid in other.ids)
+        index_map: Dict[str, int] = {v: index for index, v in enumerate(other_ids)}
+        ans: List[Cut] = [None] * len(other_ids)
+        for cut in self:
+            ans[index_map[cut.id]] = cut
+        return CutSet(ans)
 
     def index_supervisions(
         self, index_mixed_tracks: bool = False, keep_ids: Optional[Set[str]] = None
@@ -1397,7 +1406,7 @@ class CutSet(Serializable, AlgorithmMixin):
                     preserve_id=preserve_id,
                 )
             )
-        return CutSet.from_cuts(truncated_cuts)
+        return CutSet(truncated_cuts)
 
     def extend_by(
         self,
@@ -1513,13 +1522,11 @@ class CutSet(Serializable, AlgorithmMixin):
         When ``n_cuts`` is 1, will return a single cut instance; otherwise will return a ``CutSet``.
         """
         assert n_cuts > 0
-        # TODO: We might want to make this more efficient in the future
-        #  by holding a cached list of cut ids as a member of CutSet...
         cut_indices = random.sample(range(len(self)), min(n_cuts, len(self)))
         cuts = [self[idx] for idx in cut_indices]
         if n_cuts == 1:
             return cuts[0]
-        return CutSet.from_cuts(cuts)
+        return CutSet(cuts)
 
     def resample(self, sampling_rate: int, affix_id: bool = False) -> "CutSet":
         """
@@ -2194,7 +2201,7 @@ class CutSet(Serializable, AlgorithmMixin):
                 progress = partial(
                     tqdm, desc="Storing audio recordings", total=len(self)
                 )
-            return CutSet.from_cuts(
+            return CutSet(
                 progress(
                     cut.save_audio(
                         storage_path=file_storage_path(cut, storage_path),
@@ -2204,7 +2211,7 @@ class CutSet(Serializable, AlgorithmMixin):
                     )
                     for cut in self
                 )
-            )
+            ).to_eager()
 
         # Parallel execution: prepare the CutSet splits
         cut_sets = self.split(num_jobs, shuffle=shuffle_on_split)
@@ -2495,25 +2502,28 @@ class CutSet(Serializable, AlgorithmMixin):
             len_val = "<unknown>"
         return f"CutSet(len={len_val}) [underlying data type: {type(self.data)}]"
 
-    def __contains__(self, item: Union[str, Cut]) -> bool:
-        if isinstance(item, str):
-            return item in self.cuts
+    def __contains__(self, other: Union[str, Cut]) -> bool:
+        if isinstance(other, str):
+            return any(other == item.id for item in self)
         else:
-            return item.id in self.cuts
+            return any(other.id == item.id for item in self)
 
-    def __getitem__(self, cut_id_or_index: Union[int, str]) -> "Cut":
-        if isinstance(cut_id_or_index, str):
-            return self.cuts[cut_id_or_index]
-        # ~100x faster than list(dict.values())[index] for 100k elements
-        return next(
-            val for idx, val in enumerate(self.cuts.values()) if idx == cut_id_or_index
-        )
+    def __getitem__(self, index_or_id: Union[int, str]) -> Cut:
+        try:
+            return self.cuts[index_or_id]  # int passed, eager manifest, fast
+        except TypeError:
+            # either lazy manifest or str passed, both are slow
+            if self.is_lazy:
+                return next(item for idx, item in enumerate(self) if idx == index_or_id)
+            else:
+                # string id passed, support just for backward compatibility, not recommended
+                return next(item for item in self if item.id == index_or_id)
 
     def __len__(self) -> int:
         return len(self.cuts)
 
     def __iter__(self) -> Iterable[Cut]:
-        return iter(self.cuts.values())
+        yield from self.cuts
 
 
 def mix(
@@ -2993,7 +3003,7 @@ def create_cut_set_eager(
                     else [],
                 )
             )
-    cuts = CutSet.from_cuts(cuts)
+    cuts = CutSet(cuts)
     if output_path is not None:
         cuts.to_file(output_path)
     return cuts
@@ -3391,7 +3401,7 @@ def _export_to_shar_single(
     return writer.output_paths
 
 
-class LazyCutMixer(ImitatesDict):
+class LazyCutMixer(BaseIterable):
     """
     Iterate over cuts from ``cuts`` CutSet while mixing randomly sampled ``mix_in_cuts`` into them.
     A typical application would be data augmentation with noise, music, babble, etc.

--- a/lhotse/lazy.py
+++ b/lhotse/lazy.py
@@ -242,17 +242,6 @@ def dill_enabled(value: bool):
     set_dill_enabled(previous)
 
 
-class BaseIterable(Dillable):
-    """
-    Helper base class for lazy iterators defined below.
-    It exists to make them drop-in replacements for data-holding dicts
-    in Lhotse's CutSet, RecordingSet, etc. classes.
-    """
-
-    def __iter__(self):
-        raise NotImplemented
-
-
 class LazyJsonlIterator:
     """
     LazyJsonlIterator provides the ability to read JSON lines as Python dicts.
@@ -279,7 +268,7 @@ class LazyJsonlIterator:
         return self._len
 
 
-class LazyManifestIterator(BaseIterable):
+class LazyManifestIterator(Dillable):
     """
     LazyManifestIterator provides the ability to read Lhotse objects from a
     JSONL file on-the-fly, without reading its full contents into memory.
@@ -308,7 +297,7 @@ class LazyManifestIterator(BaseIterable):
         return LazyIteratorChain(self, other)
 
 
-class LazyIteratorChain(BaseIterable):
+class LazyIteratorChain(Dillable):
     """
     A thin wrapper over multiple iterators that enables to combine lazy manifests
     in Lhotse. It iterates all underlying iterables sequentially.
@@ -361,7 +350,7 @@ class LazyIteratorChain(BaseIterable):
         return LazyIteratorChain(self, other)
 
 
-class LazyIteratorMultiplexer(BaseIterable):
+class LazyIteratorMultiplexer(Dillable):
     """
     A wrapper over multiple iterators that enables to combine lazy manifests in Lhotse.
     During iteration, unlike :class:`.LazyIteratorChain`, :class:`.LazyIteratorMultiplexer`
@@ -430,7 +419,7 @@ class LazyIteratorMultiplexer(BaseIterable):
         return LazyIteratorChain(self, other)
 
 
-class LazyInfiniteApproximateMultiplexer(BaseIterable):
+class LazyInfiniteApproximateMultiplexer(Dillable):
     """
     A variant of :class:`.LazyIteratorMultiplexer` that allows to control the number of
     iterables that are simultaneously open.
@@ -551,7 +540,7 @@ class LazyInfiniteApproximateMultiplexer(BaseIterable):
                 yield item
 
 
-class LazyShuffler(BaseIterable):
+class LazyShuffler(Dillable):
     """
     A wrapper over an iterable that enables lazy shuffling.
     The shuffling algorithm is reservoir-sampling based.
@@ -584,7 +573,7 @@ class LazyShuffler(BaseIterable):
         return LazyIteratorChain(self, other)
 
 
-class LazyFilter(BaseIterable):
+class LazyFilter(Dillable):
     """
     A wrapper over an iterable that enables lazy filtering.
     It works like Python's `filter` built-in by applying the filter predicate
@@ -623,7 +612,7 @@ class LazyFilter(BaseIterable):
         )
 
 
-class LazyMapper(BaseIterable):
+class LazyMapper(Dillable):
     """
     A wrapper over an iterable that enables lazy function evaluation on each item.
     It works like Python's `map` built-in by applying a callable ``fn``
@@ -655,7 +644,7 @@ class LazyMapper(BaseIterable):
         return LazyIteratorChain(self, other)
 
 
-class LazyFlattener(BaseIterable):
+class LazyFlattener(Dillable):
     """
     A wrapper over an iterable of collections that flattens it to an iterable of items.
 
@@ -684,7 +673,7 @@ class LazyFlattener(BaseIterable):
         )
 
 
-class LazyRepeater(BaseIterable):
+class LazyRepeater(Dillable):
     """
     A wrapper over an iterable that enables to repeat it N times or infinitely (default).
     """
@@ -719,7 +708,7 @@ class LazyRepeater(BaseIterable):
         return LazyIteratorChain(self, other)
 
 
-class LazySlicer(BaseIterable):
+class LazySlicer(Dillable):
     """
     A wrapper over an iterable that enables selecting k-th element every n elements.
     """

--- a/lhotse/shar/readers/lazy.py
+++ b/lhotse/shar/readers/lazy.py
@@ -19,7 +19,7 @@ import torch
 from lhotse.cut import Cut
 from lhotse.dataset.dataloading import LHOTSE_PROCESS_SEED, resolve_seed
 from lhotse.lazy import (
-    ImitatesDict,
+    BaseIterable,
     LazyIteratorChain,
     LazyJsonlIterator,
     LazyManifestIterator,
@@ -30,7 +30,7 @@ from lhotse.shar.readers.tar import TarIterator
 from lhotse.utils import Pathlike, exactly_one_not_null, ifnone
 
 
-class LazySharIterator(ImitatesDict):
+class LazySharIterator(BaseIterable):
     """
     LazySharIterator reads cuts and their corresponding data from multiple shards,
     also recognized as the Lhotse Shar format.

--- a/lhotse/shar/readers/lazy.py
+++ b/lhotse/shar/readers/lazy.py
@@ -1,6 +1,4 @@
-import os
 import random
-import secrets
 from pathlib import Path
 from typing import (
     Callable,
@@ -14,12 +12,10 @@ from typing import (
     Union,
 )
 
-import torch
-
 from lhotse.cut import Cut
-from lhotse.dataset.dataloading import LHOTSE_PROCESS_SEED, resolve_seed
+from lhotse.dataset.dataloading import resolve_seed
 from lhotse.lazy import (
-    BaseIterable,
+    Dillable,
     LazyIteratorChain,
     LazyJsonlIterator,
     LazyManifestIterator,
@@ -30,7 +26,7 @@ from lhotse.shar.readers.tar import TarIterator
 from lhotse.utils import Pathlike, exactly_one_not_null, ifnone
 
 
-class LazySharIterator(BaseIterable):
+class LazySharIterator(Dillable):
     """
     LazySharIterator reads cuts and their corresponding data from multiple shards,
     also recognized as the Lhotse Shar format.

--- a/lhotse/supervision.py
+++ b/lhotse/supervision.py
@@ -28,7 +28,6 @@ from lhotse.utils import (
     exactly_one_not_null,
     fastcopy,
     ifnone,
-    index_by_id_and_check,
     is_equal_or_contains,
     overspans,
     perturb_num_samples,

--- a/lhotse/utils.py
+++ b/lhotse/utils.py
@@ -704,14 +704,6 @@ def merge_items_with_delimiter(
     return delimiter.join(chain([prefix], values))
 
 
-def index_by_id_and_check(manifests: Iterable[T]) -> Dict[str, T]:
-    id2man = {}
-    for m in manifests:
-        assert m.id not in id2man, f"Duplicated manifest ID: {m.id}"
-        id2man[m.id] = m
-    return id2man
-
-
 def exactly_one_not_null(*args) -> bool:
     not_null = [arg is not None for arg in args]
     return sum(not_null) == 1

--- a/lhotse/workflows/meeting_simulation/conversational.py
+++ b/lhotse/workflows/meeting_simulation/conversational.py
@@ -179,7 +179,7 @@ class ConversationalMeetingSimulator(BaseMeetingSimulator):
         ]
         diff_spk_bernoulli = self.bernoulli.rvs(p=self.prob_diff_spk_overlap, size=N)
 
-        utterances = list(utterances.data.values())
+        utterances = list(utterances)
         # First sample offsets for each utterance. These are w.r.t. start of the meeting.
         # For each subsequent utterance, we sample a pause or overlap time from the
         # corresponding distribution. Then, we add the pause/overlap time to the offset

--- a/lhotse/workflows/meeting_simulation/speaker_independent.py
+++ b/lhotse/workflows/meeting_simulation/speaker_independent.py
@@ -104,7 +104,7 @@ class SpeakerIndependentMeetingSimulator(BaseMeetingSimulator):
             zip(utterances, silence_durations)
         ):
             # Get list of cuts from CutSet
-            spk_utterances = list(spk_utterances.data.values())
+            spk_utterances = list(spk_utterances)
             track = spk_utterances[0]
             for sil, utt in zip(spk_silences[1:], spk_utterances[1:]):
                 track = mix(track, utt, offset=track.duration + sil, allow_padding=True)

--- a/test/cut/test_cut.py
+++ b/test/cut/test_cut.py
@@ -38,14 +38,14 @@ def libri_cut(libri_cut_set) -> MonoCut:
 
 def test_load_none_feats_cut_set():
     cutset = CutSet.from_json("test/fixtures/libri/cuts_no_feats.json")
-    cut = list(cutset.cuts.values())[0]
+    cut = cutset[0]
     assert cut.features is None
     assert cut.recording is not None
 
 
 def test_load_none_recording_cut_set():
     cutset = CutSet.from_json("test/fixtures/libri/cuts_no_recording.json")
-    cut = list(cutset.cuts.values())[0]
+    cut = cutset[0]
     assert cut.recording is None
     assert cut.features is not None
 
@@ -185,7 +185,7 @@ def test_make_cuts_from_recordings(dummy_recording_set):
     assert len(cut1.supervisions) == 0
 
     assert cut1.has_recording
-    assert cut1.recording == dummy_recording_set.recordings["rec1"]
+    assert cut1.recording == dummy_recording_set["rec1"]
     assert cut1.sampling_rate == 16000
     assert cut1.recording_id == "rec1"
     assert cut1.num_samples == 160000
@@ -215,7 +215,7 @@ def test_make_cuts_from_features(dummy_feature_set):
     assert cut1.num_samples is None
 
     assert cut1.has_features
-    assert cut1.features == dummy_feature_set.features[0]
+    assert cut1.features == dummy_feature_set[0]
     assert cut1.frame_shift == 0.01
     assert cut1.num_frames == 1000
     assert cut1.num_features == 23
@@ -235,13 +235,13 @@ def test_make_cuts_from_features_recordings(dummy_recording_set, dummy_feature_s
     assert len(cut1.supervisions) == 0
 
     assert cut1.has_recording
-    assert cut1.recording == dummy_recording_set.recordings["rec1"]
+    assert cut1.recording == dummy_recording_set["rec1"]
     assert cut1.sampling_rate == 16000
     assert cut1.recording_id == "rec1"
     assert cut1.num_samples == 160000
 
     assert cut1.has_features
-    assert cut1.features == dummy_feature_set.features[0]
+    assert cut1.features == dummy_feature_set[0]
     assert cut1.frame_shift == 0.01
     assert cut1.num_frames == 1000
     assert cut1.num_features == 23
@@ -295,7 +295,7 @@ class TestCutOnSupervisions:
         assert cut1.supervisions[0].text == "dummy text"
 
         assert cut1.has_recording
-        assert cut1.recording == dummy_recording_set.recordings["rec1"]
+        assert cut1.recording == dummy_recording_set["rec1"]
         assert cut1.sampling_rate == 16000
         assert cut1.recording_id == "rec1"
         assert cut1.num_samples == 16000 * 4
@@ -335,7 +335,7 @@ class TestCutOnSupervisions:
         assert cut1.num_samples is None
 
         assert cut1.has_features
-        assert cut1.features == dummy_feature_set.features[0]
+        assert cut1.features == dummy_feature_set[0]
         assert cut1.frame_shift == 0.01
         assert cut1.num_frames == 400
         assert cut1.num_features == 23
@@ -365,13 +365,13 @@ class TestCutOnSupervisions:
         assert cut1.supervisions[0].text == "dummy text"
 
         assert cut1.has_recording
-        assert cut1.recording == dummy_recording_set.recordings["rec1"]
+        assert cut1.recording == dummy_recording_set["rec1"]
         assert cut1.sampling_rate == 16000
         assert cut1.recording_id == "rec1"
         assert cut1.num_samples == 16000 * 4
 
         assert cut1.has_features
-        assert cut1.features == dummy_feature_set.features[0]
+        assert cut1.features == dummy_feature_set[0]
         assert cut1.frame_shift == 0.01
         assert cut1.num_frames == 400
         assert cut1.num_features == 23
@@ -400,7 +400,7 @@ class TestNoCutOnSupervisions:
         assert cut1.supervisions[0].text == "dummy text"
 
         assert cut1.has_recording
-        assert cut1.recording == dummy_recording_set.recordings["rec1"]
+        assert cut1.recording == dummy_recording_set["rec1"]
         assert cut1.sampling_rate == 16000
         assert cut1.recording_id == "rec1"
         assert cut1.num_samples == 160000
@@ -439,7 +439,7 @@ class TestNoCutOnSupervisions:
         assert cut1.num_samples is None
 
         assert cut1.has_features
-        assert cut1.features == dummy_feature_set.features[0]
+        assert cut1.features == dummy_feature_set[0]
         assert cut1.frame_shift == 0.01
         assert cut1.num_frames == 1000
         assert cut1.num_features == 23
@@ -468,13 +468,13 @@ class TestNoCutOnSupervisions:
         assert cut1.supervisions[0].text == "dummy text"
 
         assert cut1.has_recording
-        assert cut1.recording == dummy_recording_set.recordings["rec1"]
+        assert cut1.recording == dummy_recording_set["rec1"]
         assert cut1.sampling_rate == 16000
         assert cut1.recording_id == "rec1"
         assert cut1.num_samples == 160000
 
         assert cut1.has_features
-        assert cut1.features == dummy_feature_set.features[0]
+        assert cut1.features == dummy_feature_set[0]
         assert cut1.frame_shift == 0.01
         assert cut1.num_frames == 1000
         assert cut1.num_features == 23

--- a/test/cut/test_cut_set.py
+++ b/test/cut/test_cut_set.py
@@ -48,7 +48,7 @@ def cut_set_with_mixed_cut(cut1, cut2):
         id="mixed-cut-id",
         tracks=[MixTrack(cut=cut1), MixTrack(cut=cut2, offset=1.0, snr=10)],
     )
-    return CutSet({cut.id: cut for cut in [cut1, cut2, mixed_cut]})
+    return CutSet([cut1, cut2, mixed_cut])
 
 
 @pytest.mark.parametrize(
@@ -82,10 +82,10 @@ def test_cut_set_iteration(cut_set_with_mixed_cut):
 
 
 def test_cut_set_holds_both_simple_and_mixed_cuts(cut_set_with_mixed_cut):
-    simple_cuts = cut_set_with_mixed_cut.simple_cuts.values()
+    simple_cuts = cut_set_with_mixed_cut.simple_cuts
     assert all(isinstance(c, MonoCut) for c in simple_cuts)
     assert len(simple_cuts) == 2
-    mixed_cuts = cut_set_with_mixed_cut.mixed_cuts.values()
+    mixed_cuts = cut_set_with_mixed_cut.mixed_cuts
     assert all(isinstance(c, MixedCut) for c in mixed_cuts)
     assert len(mixed_cuts) == 1
 
@@ -725,3 +725,10 @@ def test_cut_set_from_files():
         assert cs[0].id == "dummy-mono-cut-0000"
         # On second iteration, we see a different order
         assert cs[0].id == "dummy-mono-cut-0010"
+
+
+def test_cut_set_duplicate_ids_allowed():
+    cut = dummy_cut(0)
+    cuts = CutSet.from_cuts([cut, cut])
+    assert len(cuts) == 2
+    assert cuts[0].id == cuts[1].id

--- a/test/test_lazy.py
+++ b/test/test_lazy.py
@@ -103,9 +103,9 @@ def test_filter(manifest_type):
 
     with as_lazy(data) as lazy_data:
         lazy_result = lazy_data.filter(predicate)
-        with pytest.raises(NotImplementedError):
-            assert list(lazy_result) == list(expected)
-        assert list(lazy_result.to_eager()) == list(expected)
+        with pytest.raises(TypeError):
+            len(lazy_result)
+        assert list(lazy_result) == list(expected)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Despite the title, this is not a breaking API change.

CutSet (and other sets) supported int and str based indexing almost since the start, but int-based indexing was inefficient (it just iterated the dict). Now position based indexing will be more efficient since it's the main usage pattern that I observed.

In addition, this change allows having duplicated cut IDs in the CutSet. Ever since we started introduced lazy manifests, this duplicated IDs were actually implicitly allowed, only as long as the manifest was lazy, since we only checked it for eager manifests. I've seen several use cases now where duplicated IDs are either expected, or at least not harmful - this pops us quite often in anything involving infinite cut sets. I'd rather have duplication checks being explicit in cases where they are required.