### PR TITLE
Fix feature_dim of Spectrogram extractors.

### DIFF
--- a/lhotse/features/kaldi/extractors.py
+++ b/lhotse/features/kaldi/extractors.py
@@ -309,7 +309,7 @@ class Spectrogram(FeatureExtractor):
         return self.config.frame_shift
 
     def feature_dim(self, sampling_rate: int) -> int:
-        return self.config.num_ceps
+        return self.extractor.fft_length // 2 + 1
 
     def extract(
         self, samples: Union[np.ndarray, torch.Tensor], sampling_rate: int
@@ -415,7 +415,7 @@ class LogSpectrogram(FeatureExtractor):
         return self.config.frame_shift
 
     def feature_dim(self, sampling_rate: int) -> int:
-        return self.config.num_ceps
+        return self.extractor.fft_length // 2 + 1
 
     def extract(
         self, samples: Union[np.ndarray, torch.Tensor], sampling_rate: int


### PR DESCRIPTION
There is no `num_ceps` in `SpectrogramConfig`.

---

This PR fixes the following error:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/fangjun/open-source/lhotse/lhotse/features/kaldi/extractors.py", line 312, in feature_dim
    return self.config.num_ceps
AttributeError: 'SpectrogramConfig' object has no attribute 'num_ceps'
```