### PR TITLE
Extending Lhotse dataloading to text/multimodal data

### DIFF
--- a/lhotse/custom.py
+++ b/lhotse/custom.py
@@ -1,0 +1,131 @@
+from functools import partial
+from typing import Any, Dict, Optional
+
+import numpy as np
+
+from lhotse import Recording
+from lhotse.utils import ifnone
+
+
+class CustomFieldMixin:
+    """
+    :class:`CustomFieldMixin` is intended for classes such as Cut or SupervisionSegment
+    that support holding custom, user-defined fields.
+
+    .. caution:: Due to the way inheritance and dataclasses work before Python 3.10,
+        it is necessary to re-define ``custom`` attribute in dataclasses that
+        inherit from this mixin.
+    """
+
+    def __init__(self, custom: Optional[Dict[str, Any]]) -> None:
+        self.custom: Optional[Dict[str, Any]] = custom
+
+    def __setattr__(self, key: str, value: Any) -> None:
+        """
+        This magic function is called when the user tries to set an attribute.
+        We use it as syntactic sugar to store custom attributes in ``self.custom``
+        field, so that they can be (de)serialized later.
+        Setting a ``None`` value will remove the attribute from ``custom``.
+        """
+        if key in self.__dataclass_fields__:
+            super().__setattr__(key, value)
+        else:
+            custom = ifnone(self.custom, {})
+            if value is None:
+                custom.pop(key, None)
+            else:
+                custom[key] = value
+            if custom:
+                self.custom = custom
+
+    def __getattr__(self, name: str) -> Any:
+        """
+        This magic function is called when the user tries to access an attribute
+        of :class:`.MonoCut` that doesn't exist. It is used for accessing the custom
+        attributes of cuts.
+
+        We use it to look up the ``custom`` field: when it's None or empty,
+        we'll just raise AttributeError as usual.
+        If ``item`` is found in ``custom``, we'll return ``custom[item]``.
+        If ``item`` starts with "load_", we'll assume the name of the relevant
+        attribute comes after that, and that value of that field is of type
+        :class:`~lhotse.array.Array` or :class:`~lhotse.array.TemporalArray`.
+        We'll return its ``load`` method to call by the user.
+
+        Example of attaching and reading an alignment as TemporalArray::
+
+            >>> cut = MonoCut('cut1', start=0, duration=4, channel=0)
+            >>> cut.alignment = TemporalArray(...)
+            >>> ali = cut.load_alignment()
+
+        """
+        custom = self.custom
+        if custom is None:
+            raise AttributeError(f"No such attribute: {name}")
+        if name in custom:
+            # Somebody accesses raw [Temporal]Array manifest
+            # or wrote a custom piece of metadata into MonoCut.
+            return self.custom[name]
+        elif name.startswith("load_"):
+            # Return the method for loading [Temporal]Arrays,
+            # to be invoked by the user.
+            attr_name = name[5:]
+            return partial(self.load_custom, attr_name)
+        raise AttributeError(f"No such attribute: {name}")
+
+    def __delattr__(self, key: str) -> None:
+        """Used to support ``del cut.custom_attr`` syntax."""
+        if key in self.__dataclass_fields__:
+            super().__delattr__(key)
+        if self.custom is None or key not in self.custom:
+            raise AttributeError(f"No such member: '{key}'")
+        del self.custom[key]
+
+    def load_custom(self, name: str) -> np.ndarray:
+        """
+        Load custom data as numpy array. The custom data is expected to have
+        been stored in cuts ``custom`` field as an :class:`~lhotse.array.Array` or
+        :class:`~lhotse.array.TemporalArray` manifest.
+
+        .. note:: It works with Array manifests stored via attribute assignments,
+            e.g.: ``cut.my_custom_data = Array(...)``.
+
+        :param name: name of the custom attribute.
+        :return: a numpy array with the data.
+        """
+        from lhotse.array import Array, TemporalArray
+
+        value = self.custom.get(name)
+        if isinstance(value, Array):
+            # Array does not support slicing.
+            return value.load()
+        elif isinstance(value, TemporalArray):
+            # TemporalArray supports slicing.
+            return value.load(start=self.start, duration=self.duration)
+        elif isinstance(value, Recording):
+            # Recording supports slicing.
+            return value.load_audio(
+                channels=self.channel, offset=self.start, duration=self.duration
+            )
+        else:
+            raise ValueError(
+                f"To load {name}, the cut needs to have field {name} (or cut.custom['{name}']) "
+                f"defined, and its value has to be a manifest of type Array or TemporalArray."
+            )
+
+    def has_custom(self, name: str) -> bool:
+        """
+        Check if the Cut has a custom attribute with name ``name``.
+
+        :param name: name of the custom attribute.
+        :return: a boolean.
+        """
+        if self.custom is None:
+            return False
+        return name in self.custom
+
+    def drop_custom(self, name: str):
+        if self.custom is None or name not in self.custom:
+            return None
+        del self.custom[name]
+        return self

--- a/lhotse/cut/data.py
+++ b/lhotse/cut/data.py
@@ -2,7 +2,6 @@ import logging
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass, field
 from decimal import ROUND_DOWN
-from functools import partial
 from math import isclose
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 
@@ -12,6 +11,7 @@ from intervaltree import IntervalTree
 
 from lhotse.audio import Recording, VideoInfo
 from lhotse.augmentation import AugmentFn
+from lhotse.custom import CustomFieldMixin
 from lhotse.cut.base import Cut
 from lhotse.features import FeatureExtractor, Features
 from lhotse.features.io import FeaturesWriter
@@ -25,7 +25,6 @@ from lhotse.utils import (
     compute_num_frames,
     compute_num_samples,
     fastcopy,
-    ifnone,
     measure_overlap,
     overlaps,
     overspans,
@@ -36,7 +35,7 @@ from lhotse.utils import (
 
 
 @dataclass
-class DataCut(Cut, metaclass=ABCMeta):
+class DataCut(Cut, CustomFieldMixin, metaclass=ABCMeta):
     """
     :class:`~lhotse.cut.DataCut` is a base class for cuts that point to actual audio data.
     It can be either a :class:`~lhotse.cut.MonoCut` or a :class:`~lhotse.cut.MultiCut`.
@@ -70,110 +69,6 @@ class DataCut(Cut, metaclass=ABCMeta):
 
     # Store anything else the user might want.
     custom: Optional[Dict[str, Any]] = None
-
-    def __setattr__(self, key: str, value: Any) -> None:
-        """
-        This magic function is called when the user tries to set an attribute.
-        We use it as syntactic sugar to store custom attributes in ``self.custom``
-        field, so that they can be (de)serialized later.
-        Setting a ``None`` value will remove the attribute from ``custom``.
-        """
-        if key in self.__dataclass_fields__:
-            super().__setattr__(key, value)
-        else:
-            custom = ifnone(self.custom, {})
-            if value is None:
-                custom.pop(key, None)
-            else:
-                custom[key] = value
-            if custom:
-                self.custom = custom
-
-    def __getattr__(self, name: str) -> Any:
-        """
-        This magic function is called when the user tries to access an attribute
-        of :class:`.MonoCut` that doesn't exist. It is used for accessing the custom
-        attributes of cuts.
-
-        We use it to look up the ``custom`` field: when it's None or empty,
-        we'll just raise AttributeError as usual.
-        If ``item`` is found in ``custom``, we'll return ``custom[item]``.
-        If ``item`` starts with "load_", we'll assume the name of the relevant
-        attribute comes after that, and that value of that field is of type
-        :class:`~lhotse.array.Array` or :class:`~lhotse.array.TemporalArray`.
-        We'll return its ``load`` method to call by the user.
-
-        Example of attaching and reading an alignment as TemporalArray::
-
-            >>> cut = MonoCut('cut1', start=0, duration=4, channel=0)
-            >>> cut.alignment = TemporalArray(...)
-            >>> ali = cut.load_alignment()
-
-        """
-        custom = self.custom
-        if custom is None:
-            raise AttributeError(f"No such attribute: {name}")
-        if name in custom:
-            # Somebody accesses raw [Temporal]Array manifest
-            # or wrote a custom piece of metadata into MonoCut.
-            return self.custom[name]
-        elif name.startswith("load_"):
-            # Return the method for loading [Temporal]Arrays,
-            # to be invoked by the user.
-            attr_name = name[5:]
-            return partial(self.load_custom, attr_name)
-        raise AttributeError(f"No such attribute: {name}")
-
-    def __delattr__(self, key: str) -> None:
-        """Used to support ``del cut.custom_attr`` syntax."""
-        if key in self.__dataclass_fields__:
-            super().__delattr__(key)
-        if self.custom is None or key not in self.custom:
-            raise AttributeError(f"No such member: '{key}'")
-        del self.custom[key]
-
-    def load_custom(self, name: str) -> np.ndarray:
-        """
-        Load custom data as numpy array. The custom data is expected to have
-        been stored in cuts ``custom`` field as an :class:`~lhotse.array.Array` or
-        :class:`~lhotse.array.TemporalArray` manifest.
-
-        .. note:: It works with Array manifests stored via attribute assignments,
-            e.g.: ``cut.my_custom_data = Array(...)``.
-
-        :param name: name of the custom attribute.
-        :return: a numpy array with the data.
-        """
-        from lhotse.array import Array, TemporalArray
-
-        value = self.custom.get(name)
-        if isinstance(value, Array):
-            # Array does not support slicing.
-            return value.load()
-        elif isinstance(value, TemporalArray):
-            # TemporalArray supports slicing.
-            return value.load(start=self.start, duration=self.duration)
-        elif isinstance(value, Recording):
-            # Recording supports slicing.
-            return value.load_audio(
-                channels=self.channel, offset=self.start, duration=self.duration
-            )
-        else:
-            raise ValueError(
-                f"To load {name}, the cut needs to have field {name} (or cut.custom['{name}']) "
-                f"defined, and its value has to be a manifest of type Array or TemporalArray."
-            )
-
-    def has_custom(self, name: str) -> bool:
-        """
-        Check if the Cut has a custom attribute with name ``name``.
-
-        :param name: name of the custom attribute.
-        :return: a boolean.
-        """
-        if self.custom is None:
-            return False
-        return name in self.custom
 
     @property
     def recording_id(self) -> str:

--- a/lhotse/cut/set.py
+++ b/lhotse/cut/set.py
@@ -3483,7 +3483,7 @@ class LazyCutMixer(Dillable):
         for cut in self.source:
             # Check whether we're going to mix something into the current cut
             # or pass it through unchanged.
-            if rng.uniform(0.0, 1.0) > self.mix_prob:
+            if not is_cut(cut) or rng.uniform(0.0, 1.0) > self.mix_prob:
                 yield cut
                 continue
             to_mix = next(mix_in_cuts)

--- a/lhotse/dataset/sampling/base.py
+++ b/lhotse/dataset/sampling/base.py
@@ -12,6 +12,7 @@ from torch import distributed as dist
 from torch.utils.data import Sampler
 
 from lhotse.cut import Cut, CutSet
+from lhotse.cut.text import TextExample
 from lhotse.lazy import Dillable
 from lhotse.manipulation import combine
 from lhotse.utils import Seconds, ifnone, is_none_or_gt
@@ -549,6 +550,84 @@ class TimeConstraint(SamplingConstraint):
             and self.max_cuts == other.max_cuts
             and self.quadratic_duration == other.quadratic_duration
         )
+
+
+@dataclass
+class TokenConstraint(SamplingConstraint):
+    """
+    Represents a token-based constraint for sampler classes that sample text data.
+    It is defined as maximum total number of tokens in a mini-batch and/or max batch size.
+
+    Similarly to :class:`TimeConstraint`, we support ``quadratic_length`` for quadratic
+    token penalty when sampling longer texts.
+    """
+
+    max_tokens: int = None
+    max_examples: int = None
+    current: int = 0
+    num_examples: int = 0
+    longest_seen: int = 0
+    quadratic_length: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        assert is_none_or_gt(self.max_tokens, 0)
+        assert is_none_or_gt(self.max_examples, 0)
+        assert is_none_or_gt(self.quadratic_length, 0)
+
+    def add(self, example: TextExample) -> None:
+        """
+        Increment the internal token counter for the constraint,
+        selecting the right property from the input object.
+        """
+        if self.max_tokens is not None:
+            size = self._maybe_apply_quadratic_correction(self.measure_length(example))
+            self.current += size
+            self.longest_seen = max(self.longest_seen, size)
+        self.num_examples += 1
+
+    def _maybe_apply_quadratic_correction(self, size: int) -> int:
+        if self.quadratic_length is None:
+            return size
+        # For the quadratic complexity case, we add a term that accounts for
+        # extra memory occupied by the model. The 1/quadratic_length term causes
+        # the effective length to be doubled when it's equal to quadratic_length.
+        return size + (size**2) / self.quadratic_length
+
+    def exceeded(self) -> bool:
+        """Is the constraint exceeded or not."""
+        if self.max_examples is not None and self.num_examples > self.max_examples:
+            return True
+        if self.max_tokens is None:
+            return False
+        effective_duration = self.num_examples * self.longest_seen
+        return effective_duration > self.max_tokens
+
+    def close_to_exceeding(self) -> bool:
+        """
+        Check if the batch is close to satisfying the constraints.
+        We define "closeness" as: if we added one more cut that has
+        duration/num_frames/num_samples equal to the longest seen cut
+        in the current batch, then the batch would have exceeded the constraints.
+        """
+        if self.max_examples is not None and self.num_examples >= self.max_examples:
+            return True
+
+        if self.max_tokens is not None:
+            effective_size = (self.num_examples + 1) * self.longest_seen
+            return effective_size > self.max_tokens
+        return False
+
+    def reset(self) -> None:
+        """
+        Reset the internal counter (to be used after a batch was created,
+        to start collecting a new one).
+        """
+        self.current = 0
+        self.num_examples = 0
+        self.longest_seen = 0
+
+    def measure_length(self, example: TextExample) -> float:
+        return example.num_tokens
 
 
 @dataclass

--- a/lhotse/dataset/sampling/dynamic.py
+++ b/lhotse/dataset/sampling/dynamic.py
@@ -70,7 +70,7 @@ class DynamicCutSampler(CutSampler):
 
     def __init__(
         self,
-        *cuts: Iterable[Cut],
+        *cuts: Iterable,
         max_duration: Optional[Seconds] = None,
         max_cuts: Optional[int] = None,
         constraint: Optional[SamplingConstraint] = None,
@@ -391,4 +391,4 @@ def check_constraint(constraint: Optional, max_duration: Optional, max_cuts: Opt
     else:
         assert (
             max_duration is not None or max_cuts is not None
-        ), "At least one of max_duration= or max_cuts= has to be defined."
+        ), "At least one of max_duration= or max_cuts= has to be defined (or provide constraint=)."

--- a/lhotse/dataset/sampling/dynamic.py
+++ b/lhotse/dataset/sampling/dynamic.py
@@ -20,6 +20,7 @@ from lhotse.dataset.dataloading import resolve_seed
 from lhotse.dataset.sampling.base import (
     CutSampler,
     EpochDiagnostics,
+    SamplingConstraint,
     SamplingDiagnostics,
     TimeConstraint,
 )
@@ -72,6 +73,7 @@ class DynamicCutSampler(CutSampler):
         *cuts: Iterable[Cut],
         max_duration: Optional[Seconds] = None,
         max_cuts: Optional[int] = None,
+        constraint: Optional[SamplingConstraint] = None,
         shuffle: bool = False,
         drop_last: bool = False,
         consistent_ids: bool = True,
@@ -88,6 +90,12 @@ class DynamicCutSampler(CutSampler):
             Note: with multiple CutSets, ``max_duration`` constraint applies only to the first CutSet.
         :param max_cuts: The maximum total number of ``cuts`` per batch.
             When only ``max_duration`` is specified, this sampler yields static batch sizes.
+        :param constraint: Provide a :class:`~lhotse.dataset.sampling.base.SamplingConstraint` object
+            defining how the sampler decides when a mini-batch is complete. It also affects which
+            attribute of the input examples decides the "size" of the example (by default it's ``.duration``).
+            Before this parameter was introduced, Lhotse samplers used
+            :class:`~lhotse.dataset.sampling.base.TimeConstraint` implicitly.
+            Introduced in Lhotse v1.22.0.
         :param shuffle: When ``True``, the cuts will be shuffled dynamically with
             a reservoir-sampling-based algorithm.
             Convenient when mini-batch loop is inside an outer epoch-level loop, e.g.:
@@ -121,14 +129,12 @@ class DynamicCutSampler(CutSampler):
         self.cuts = cuts
         self.max_duration = max_duration
         self.max_cuts = max_cuts
+        self.constraint = constraint
         self.shuffle = shuffle
         self.consistent_ids = consistent_ids
         self.shuffle_buffer_size = shuffle_buffer_size
         self.quadratic_duration = quadratic_duration
         self.rng = None
-        assert any(
-            v is not None for v in (self.max_duration, self.max_cuts)
-        ), "At least one of max_duration or max_cuts has to be set."
 
         if strict is not None:
             warnings.warn(
@@ -138,6 +144,9 @@ class DynamicCutSampler(CutSampler):
             )
 
     def state_dict(self) -> Dict[str, Any]:
+        assert (
+            self.constraint is None
+        ), "state_dict() is not supported with samplers that use a custom constraint."
         sd = super().state_dict()
         sd.update(
             {
@@ -212,6 +221,7 @@ class DynamicCutSampler(CutSampler):
             self.cuts_iter,
             max_duration=self.max_duration,
             max_cuts=self.max_cuts,
+            constraint=self.constraint,
             drop_last=self.drop_last,
             quadratic_duration=self.quadratic_duration,
             diagnostics=self.diagnostics,
@@ -251,6 +261,7 @@ class DurationBatcher:
         datapipe: Iterable[Union[Cut, Tuple[Cut]]],
         max_duration: Seconds = None,
         max_cuts: Optional[int] = None,
+        constraint: Optional[SamplingConstraint] = None,
         drop_last: bool = False,
         quadratic_duration: Optional[Seconds] = None,
         diagnostics: Optional[SamplingDiagnostics] = None,
@@ -259,11 +270,15 @@ class DurationBatcher:
         self.reuse_cuts_buffer = deque()
         self.drop_last = drop_last
         self.diagnostics = ifnone(diagnostics, SamplingDiagnostics())
-        self.time_constraint = TimeConstraint(
-            max_duration=max_duration,
-            max_cuts=max_cuts,
-            quadratic_duration=quadratic_duration,
-        )
+        check_constraint(constraint, max_duration, max_cuts)
+        if constraint is not None:
+            self.constraint = constraint
+        else:
+            self.constraint = TimeConstraint(
+                max_duration=max_duration,
+                max_cuts=max_cuts,
+                quadratic_duration=quadratic_duration,
+            )
 
     def __iter__(self) -> Generator[Union[CutSet, Tuple[CutSet]], None, None]:
         self.cuts_iter = iter(self.datapipe)
@@ -289,7 +304,7 @@ class DurationBatcher:
             else:
                 return CutSet.from_cuts(cuts)
 
-        self.time_constraint.reset()
+        self.constraint.reset()
         cuts = []
         while True:
             # Check that we have not reached the end of the dataset.
@@ -301,7 +316,7 @@ class DurationBatcher:
                 # we may output it, unless the user requested to drop it.
                 # We also check if the batch is "almost there" to override drop_last.
                 if cuts and (
-                    not self.drop_last or self.time_constraint.close_to_exceeding()
+                    not self.drop_last or self.constraint.close_to_exceeding()
                 ):
                     # We have a partial batch and we can return it.
                     return detuplify(cuts)
@@ -316,16 +331,16 @@ class DurationBatcher:
 
             # Track the duration/frames/etc. constraints.
             cuts.append(next_cut_or_tpl)
-            self.time_constraint.add(
+            self.constraint.add(
                 next_cut_or_tpl[0]
                 if isinstance(next_cut_or_tpl, tuple)
                 else next_cut_or_tpl
             )
 
             # Did we exceed the max_frames and max_cuts constraints?
-            if self.time_constraint.close_to_exceeding():
+            if self.constraint.close_to_exceeding():
                 # Yes. Finish sampling this batch.
-                if self.time_constraint.exceeded() and len(cuts) == 1:
+                if self.constraint.exceeded() and len(cuts) == 1:
                     warnings.warn(
                         "We have exceeded the max_duration constraint during sampling but have only 1 cut. "
                         "This is likely because max_duration was set to a very low value ~10s, "
@@ -366,3 +381,14 @@ class Filter(Iterable):
                 yield item
             else:
                 self.diagnostics.discard(item)
+
+
+def check_constraint(constraint: Optional, max_duration: Optional, max_cuts: Optional):
+    if constraint is not None:
+        assert (
+            max_duration is None and max_cuts is None
+        ), "Cannot specify both constraint= and max_duration=/max_cuts="
+    else:
+        assert (
+            max_duration is not None or max_cuts is not None
+        ), "At least one of max_duration= or max_cuts= has to be defined."

--- a/test/dataset/sampling/test_text_sampling.py
+++ b/test/dataset/sampling/test_text_sampling.py
@@ -1,0 +1,138 @@
+import numpy as np
+import pytest
+import torch
+
+from lhotse import CutSet, Fbank, compute_num_frames
+from lhotse.cut import Cut
+from lhotse.cut.text import TextExample
+from lhotse.dataset import DynamicBucketingSampler, DynamicCutSampler
+from lhotse.dataset.collation import collate_audio
+from lhotse.dataset.sampling.base import TokenConstraint
+from lhotse.testing.dummies import DummyManifest
+
+
+@pytest.fixture
+def text_source():
+    def get_text_source():
+        while True:
+            for item in ("hello world", "example text", "this is my text data"):
+                # for this example, "bytes are all you need", could be BPE, etc.
+                yield TextExample(item, np.frombuffer(item.encode("utf-8"), np.int8))
+
+    return get_text_source()
+
+
+def test_text_dynamic_cut_sampler_static_batch_size(text_source):
+    sampler = DynamicCutSampler(
+        text_source, constraint=TokenConstraint(max_examples=16)
+    )
+    batch = next(iter(sampler))
+    assert len(batch) == 16
+    assert isinstance(batch[0], TextExample)
+    assert isinstance(batch[0].text, str)
+
+
+def test_text_dynamic_cut_sampler_dynamic_batch_size(text_source):
+    sampler = DynamicCutSampler(text_source, constraint=TokenConstraint(max_tokens=256))
+    batch = next(iter(sampler))
+    assert isinstance(batch[0], TextExample)
+    assert isinstance(batch[0].text, str)
+    assert len(batch) == 12
+
+
+def test_text_dynamic_bucketing_sampler(text_source):
+    sampler = DynamicBucketingSampler(
+        text_source,
+        num_buckets=2,
+        constraint=TokenConstraint(max_tokens=256, quadratic_length=128),
+    )
+    batch = next(iter(sampler))
+    assert isinstance(batch[0], TextExample)
+    assert isinstance(batch[0].text, str)
+    assert len(batch) == 11
+
+
+class TextDataset(torch.utils.data.Dataset):
+    def __getitem__(self, cuts: CutSet) -> tuple[torch.Tensor, torch.Tensor]:
+        from lhotse.dataset.collation import collate_vectors
+
+        tokens = collate_vectors(
+            [item.tokens.astype(np.int32) for item in cuts], padding_value=-1
+        )
+        token_lens = torch.LongTensor([item.tokens.shape[0] for item in cuts])
+        return tokens, token_lens
+
+
+def test_text_dataloader_with_dynamic_bucketing_sampler(text_source):
+    sampler = DynamicBucketingSampler(
+        text_source,
+        num_buckets=2,
+        constraint=TokenConstraint(max_tokens=256, quadratic_length=128),
+    )
+    dloader = torch.utils.data.DataLoader(
+        TextDataset(), sampler=sampler, batch_size=None
+    )
+    batch = next(iter(dloader))
+    assert isinstance(batch[0], torch.Tensor)
+    assert batch[0].shape == (11, 20)  # (batch_size, seq_len)
+    assert isinstance(batch[1], torch.Tensor)
+    assert batch[1].shape == (11,)
+
+
+class MixedAudioTextDataset(torch.utils.data.Dataset):
+    def __init__(self):
+        self.text_dataset = TextDataset()
+
+    def __getitem__(
+        self, cuts: CutSet
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+
+        text_cuts = cuts.filter(lambda c: isinstance(c, TextExample)).to_eager()
+        if text_cuts:
+            tokens, token_lens = self.text_dataset[text_cuts]
+        else:
+            tokens, token_lens = None, None
+
+        audio_cuts = cuts.filter(lambda c: isinstance(c, Cut)).to_eager()
+        if audio_cuts:
+            audio, audio_lens = collate_audio(audio_cuts)
+        else:
+            audio, audio_lens = None, None
+
+        return tokens, token_lens, audio, audio_lens
+
+
+def _assign_num_tokens_to_cut(cut, frame_shift=0.01):
+    cut.num_tokens = compute_num_frames(
+        cut.duration, frame_shift=frame_shift, sampling_rate=cut.sampling_rate
+    )
+    return cut
+
+
+@pytest.fixture
+def audio_source():
+    return (
+        DummyManifest(CutSet, begin_id=0, end_id=10, with_data=True)
+        .map(_assign_num_tokens_to_cut)
+        .repeat()
+    )
+
+
+def test_audio_and_text_dataloader_with_dynamic_sampler(text_source, audio_source):
+    mixed = CutSet.mux(text_source, audio_source, weights=[0.7, 0.3])
+    sampler = DynamicCutSampler(
+        mixed,
+        constraint=TokenConstraint(max_tokens=1024, quadratic_length=128),
+    )
+    dloader = torch.utils.data.DataLoader(
+        MixedAudioTextDataset(), sampler=sampler, batch_size=None
+    )
+    batch = next(iter(dloader))
+    assert isinstance(batch[0], torch.Tensor)
+    assert batch[0].shape == (3, 20)  # (batch_size, seq_len)
+    assert isinstance(batch[1], torch.Tensor)
+    assert batch[1].shape == (3,)
+    assert isinstance(batch[2], torch.Tensor)
+    assert batch[2].shape == (2, 16000)  # (batch_size, seq_len)
+    assert isinstance(batch[3], torch.Tensor)
+    assert batch[3].shape == (2,)


### PR DESCRIPTION
This PR adds a very basic support for incorporating text-only data into Lhotse samplers to enable text and multimodal dataloading. Highlights:
* new ABC `SamplingConstraint` that generalizes `TimeConstraint`, and allows to create other types of constraints to decide when to stop sampling a mini-batch as well as how to determine the "size" of an example (e.g. for audio its duration, but for text it may be sth like num tokens)
* dynamic samplers have a new argument called `constraint` where `SamplingConstraint` instances may be passed directly
* `TokenConstraint` which is almost identical to `TimeConstraint` but uses num_tokens / max_tokens
* very basic dataclass `TextExample` that wraps text/tokens, `CutSet` can be used to yield those (just pass text iterator to CutSet like `CutSet(text_example_iter)`) (it's not super clean but it works; trying to figure out if we can make this cleaner)
* unit tests illustrating how to use this for text dataloading and even for mixed modality dataloading (text and audio data together in a mini-batch)

This is stretching the original scope of Lhotse a bit, but I feel like it's worth it: we accumulated a bunch of solid techniques here and it'd be a pity to have to use something completely different for multimodal modeling. Would love to know your thoughts @danpovey @csukuangfj @desh2608 @m-wiesner 