### PR TITLE
Add Chinese TTS dataset `baker`.

### DIFF
--- a/lhotse/bin/modes/recipes/__init__.py
+++ b/lhotse/bin/modes/recipes/__init__.py
@@ -10,6 +10,7 @@ from .aspire import *
 from .atcosim import *
 from .audio_mnist import *
 from .babel import *
+from .baker_zh import *
 from .bengaliai_speech import *
 from .broadcast_news import *
 from .but_reverb_db import *

--- a/lhotse/bin/modes/recipes/baker_zh.py
+++ b/lhotse/bin/modes/recipes/baker_zh.py
@@ -1,0 +1,25 @@
+import click
+
+from lhotse.bin.modes import download, prepare
+from lhotse.recipes.baker_zh import download_baker_zh, prepare_baker_zh
+from lhotse.utils import Pathlike
+
+__all__ = ["baker_zh"]
+
+
+@download.command(context_settings=dict(show_default=True))
+@click.argument("target_dir", type=click.Path(), default=".")
+def baker_zh(target_dir: Pathlike):
+    """bazker_zh download."""
+    download_baker_zh(target_dir)
+
+
+@prepare.command(context_settings=dict(show_default=True))
+@click.argument("corpus_dir", type=click.Path(exists=True, dir_okay=True))
+@click.argument("output_dir", type=click.Path())
+def baker_zh(
+    corpus_dir: Pathlike,
+    output_dir: Pathlike,
+):
+    """bazker_zh data preparation."""
+    prepare_baker_zh(corpus_dir, output_dir=output_dir)

--- a/lhotse/recipes/__init__.py
+++ b/lhotse/recipes/__init__.py
@@ -7,6 +7,7 @@ from .ami import download_ami, prepare_ami
 from .aspire import prepare_aspire
 from .atcosim import download_atcosim, prepare_atcosim
 from .babel import prepare_single_babel_language
+from .baker_zh import download_baker_zh, prepare_baker_zh
 from .bengaliai_speech import prepare_bengaliai_speech
 from .broadcast_news import prepare_broadcast_news
 from .but_reverb_db import download_but_reverb_db, prepare_but_reverb_db

--- a/lhotse/recipes/baker_zh.py
+++ b/lhotse/recipes/baker_zh.py
@@ -1,0 +1,113 @@
+"""
+See https://en.data-baker.com/datasets/freeDatasets/
+
+It is a Chinese TTS dataset, containing 12 hours of data.
+"""
+
+import logging
+import re
+import shutil
+import tarfile
+from pathlib import Path
+from typing import Dict, Optional, Union
+
+from lhotse import fix_manifests, validate_recordings_and_supervisions
+from lhotse.audio import Recording, RecordingSet
+from lhotse.supervision import SupervisionSegment, SupervisionSet
+from lhotse.utils import Pathlike, resumable_download, safe_extract
+
+
+def download_baker_zh(
+    target_dir: Pathlike = ".", force_download: Optional[bool] = False
+) -> Path:
+    target_dir = Path(target_dir)
+    target_dir.mkdir(parents=True, exist_ok=True)
+    dataset_name = "BZNSYP"
+    tar_path = target_dir / f"{dataset_name}.tar.bz2"
+    corpus_dir = target_dir / dataset_name
+    completed_detector = corpus_dir / ".completed"
+    if completed_detector.is_file():
+        logging.info(f"Skipping {dataset_name} because {completed_detector} exists.")
+        return corpus_dir
+    resumable_download(
+        f"https://huggingface.co/openspeech/BZNSYP/resolve/main/{dataset_name}.tar.bz2",
+        filename=tar_path,
+        force_download=force_download,
+    )
+    shutil.rmtree(corpus_dir, ignore_errors=True)
+    with tarfile.open(tar_path) as tar:
+        safe_extract(tar, path=target_dir)
+    completed_detector.touch()
+
+    return corpus_dir
+
+
+def prepare_baker_zh(
+    corpus_dir: Pathlike, output_dir: Optional[Pathlike] = None
+) -> Dict[str, Union[RecordingSet, SupervisionSet]]:
+    """
+    Returns the manifests which consist of the Recordings and Supervisions
+
+    :param corpus_dir: Pathlike, the path of the data dir.
+    :param output_dir: Pathlike, the path where to write the manifests.
+    :return: The RecordingSet and SupervisionSet with the keys 'audio' and 'supervisions'.
+    """
+    corpus_dir = Path(corpus_dir)
+    assert corpus_dir.is_dir(), f"No such directory: {corpus_dir}"
+    if output_dir is not None:
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+    # The corpus_dir contains three sub directories
+    # PhoneLabeling  ProsodyLabeling  Wave
+
+    # Generate a mapping: utt_id -> (audio_path, audio_info, text)
+    labeling_file = corpus_dir / "ProsodyLabeling" / "000001-010000.txt"
+    if not labeling_file.is_file():
+        raise ValueError(f"{labeling_file} does not exist")
+
+    recordings = []
+    supervisions = []
+    logging.info("Started preparing. It may take 30 seconds")
+    pattern = re.compile("#[12345]")
+    with open(labeling_file) as f:
+        try:
+            while True:
+                first = next(f).strip()
+                pinyin = next(f).strip()
+                recording_id, original_text = first.split(None, maxsplit=1)
+                normalized_text = re.sub(pattern, "", original_text)
+                audio_path = corpus_dir / "Wave" / f"{recording_id}.wav"
+
+                if not audio_path.is_file():
+                    logging.warning(f"No such file: {audio_path}")
+                    continue
+                recording = Recording.from_file(audio_path)
+
+                segment = SupervisionSegment(
+                    id=recording_id,
+                    recording_id=recording_id,
+                    start=0.0,
+                    duration=recording.duration,
+                    channel=0,
+                    language="Chinese",
+                    gender="female",
+                    text=original_text,
+                    custom={"pinyin": pinyin, "normalized_text": normalized_text},
+                )
+                recordings.append(recording)
+                supervisions.append(segment)
+        except StopIteration:
+            pass
+
+    recording_set = RecordingSet.from_recordings(recordings)
+    supervision_set = SupervisionSet.from_segments(supervisions)
+
+    recording_set, supervision_set = fix_manifests(recording_set, supervision_set)
+    validate_recordings_and_supervisions(recording_set, supervision_set)
+
+    if output_dir is not None:
+        supervision_set.to_file(output_dir / "baker_zh_supervisions_all.jsonl.gz")
+        recording_set.to_file(output_dir / "baker_zh_recordings_all.jsonl.gz")
+
+    return {"recordings": recording_set, "supervisions": supervision_set}


### PR DESCRIPTION
# Example labelling file
```
000001	卡尔普#2陪外孙#1玩滑梯#4。
	ka2 er2 pu3 pei2 wai4 sun1 wan2 hua2 ti1
000002	假语村言#2别再#1拥抱我#4。
	jia2 yu3 cun1 yan2 bie2 zai4 yong1 bao4 wo3
000003	宝马#1配挂#1跛骡鞍#3，貂蝉#1怨枕#2董翁榻#4。
	bao2 ma3 pei4 gua4 bo3 luo2 an1 diao1 chan2 yuan4 zhen3 dong3 weng1 ta4
000004	邓小平#2与#1撒切尔#2会晤#4。
	deng4 xiao3 ping2 yu3 sa4 qie4 er3 hui4 wu4
000005	老虎#1幼崽#2与#1宠物犬#1玩耍#4。
	lao2 hu3 you4 zai3 yu2 chong3 wu4 quan3 wan2 shua3
```

# Example baker_zh_supervisions_all.jsonl
```
{"id": "000001", "recording_id": "000001", "start": 0.0, "duration": 2.66, "channel": 0, "text": "卡尔普#2陪外孙#1玩滑梯#4。", "language": "Chinese", "gender": "female", "custom": {"pinyin": "ka2 er2 pu3 pei2 wai4 sun1 wan2 hua2 ti1", "normalized_text": "卡尔普陪外孙玩滑梯。"}}
{"id": "000002", "recording_id": "000002", "start": 0.0, "duration": 2.86, "channel": 0, "text": "假语村言#2别再#1拥抱我#4。", "language": "Chinese", "gender": "female", "custom": {"pinyin": "jia2 yu3 cun1 yan2 bie2 zai4 yong1 bao4 wo3", "normalized_text": "假语村言别再拥抱我。"}}
{"id": "000003", "recording_id": "000003", "start": 0.0, "duration": 4.4, "channel": 0, "text": "宝马#1配挂#1跛骡鞍#3，貂蝉#1怨枕#2董翁榻#4。", "language": "Chinese", "gender": "female", "custom": {"pinyin": "bao2 ma3 pei4 gua4 bo3 luo2 an1 diao1 chan2 yuan4 zhen3 dong3 weng1 ta4", "normalized_text": "宝马配挂跛骡鞍，貂蝉怨枕董翁榻。"}}
{"id": "000004", "recording_id": "000004", "start": 0.0, "duration": 2.6, "channel": 0, "text": "邓小平#2与#1撒切尔#2会晤#4。", "language": "Chinese", "gender": "female", "custom": {"pinyin": "deng4 xiao3 ping2 yu3 sa4 qie4 er3 hui4 wu4", "normalized_text": "邓小平与撒切尔会晤。"}}
{"id": "000005", "recording_id": "000005", "start": 0.0, "duration": 3.09, "channel": 0, "text": "老虎#1幼崽#2与#1宠物犬#1玩耍#4。", "language": "Chinese", "gender": "female", "custom": {"pinyin": "lao2 hu3 you4 zai3 yu2 chong3 wu4 quan3 wan2 shua3", "normalized_text": "老虎幼崽与宠物犬玩耍。"}}
```

# Example baker_zh_recordings_all.jsonl
```
{"id": "000001", "sources": [{"type": "file", "channels": [0], "source": "BZNSYP/Wave/000001.wav"}], "sampling_rate": 48000, "num_samples": 127680, "duration": 2.66, "channel_ids": [0]}
{"id": "000002", "sources": [{"type": "file", "channels": [0], "source": "BZNSYP/Wave/000002.wav"}], "sampling_rate": 48000, "num_samples": 137280, "duration": 2.86, "channel_ids": [0]}
{"id": "000003", "sources": [{"type": "file", "channels": [0], "source": "BZNSYP/Wave/000003.wav"}], "sampling_rate": 48000, "num_samples": 211200, "duration": 4.4, "channel_ids": [0]}
{"id": "000004", "sources": [{"type": "file", "channels": [0], "source": "BZNSYP/Wave/000004.wav"}], "sampling_rate": 48000, "num_samples": 124800, "duration": 2.6, "channel_ids": [0]}
{"id": "000005", "sources": [{"type": "file", "channels": [0], "source": "BZNSYP/Wave/000005.wav"}], "sampling_rate": 48000, "num_samples": 148320, "duration": 3.09, "channel_ids": [0]}
```
# Cutset info

```
wc -l *
  10000 baker_zh_recordings_all.jsonl
  10000 baker_zh_supervisions_all.jsonl
  20000 total
```

```
lhotse cut simple  -r ./baker_zh_recordings_all.jsonl.gz  -s ./baker_zh_supervisions_all.jsonl.gz baker_zh_cuts.jsonl.gz
```

```
total 2.5M
-rw-r--r-- 1 kuangfangjun root 1.4M Mar 13 21:21 baker_zh_cuts.jsonl.gz
-rw-r--r-- 1 kuangfangjun root 127K Mar 13 21:19 baker_zh_recordings_all.jsonl.gz
-rw-r--r-- 1 kuangfangjun root 1.1M Mar 13 21:19 baker_zh_supervisions_all.jsonl.gz
```

---


```
lhotse cut describe ./baker_zh_cuts.jsonl.gz
```

```
Cut statistics:
╒═══════════════════════════╤══════════╕
│ Cuts count:               │ 10000    │
├───────────────────────────┼──────────┤
│ Total duration (hh:mm:ss) │ 11:51:21 │
├───────────────────────────┼──────────┤
│ mean                      │ 4.3      │
├───────────────────────────┼──────────┤
│ std                       │ 1.3      │
├───────────────────────────┼──────────┤
│ min                       │ 1.4      │
├───────────────────────────┼──────────┤
│ 25%                       │ 3.2      │
├───────────────────────────┼──────────┤
│ 50%                       │ 4.2      │
├───────────────────────────┼──────────┤
│ 75%                       │ 5.2      │
├───────────────────────────┼──────────┤
│ 99%                       │ 7.0      │
├───────────────────────────┼──────────┤
│ 99.5%                     │ 7.3      │
├───────────────────────────┼──────────┤
│ 99.9%                     │ 7.7      │
├───────────────────────────┼──────────┤
│ max                       │ 8.3      │
├───────────────────────────┼──────────┤
│ Recordings available:     │ 10000    │
├───────────────────────────┼──────────┤
│ Features available:       │ 0        │
├───────────────────────────┼──────────┤
│ Supervisions available:   │ 10000    │
╘═══════════════════════════╧══════════╛
SUPERVISION custom fields:
Speech duration statistics:
╒══════════════════════════════╤══════════╤══════════════════════╕
│ Total speech duration        │ 11:51:21 │ 100.00% of recording │
├──────────────────────────────┼──────────┼──────────────────────┤
│ Total speaking time duration │ 11:51:21 │ 100.00% of recording │
├──────────────────────────────┼──────────┼──────────────────────┤
│ Total silence duration       │ 00:00:01 │ 0.00% of recording   │
╘══════════════════════════════╧══════════╧══════════════════════╛
```