### PR TITLE
Fixing recording move to memory

### DIFF
--- a/lhotse/audio/recording.py
+++ b/lhotse/audio/recording.py
@@ -295,10 +295,10 @@ class Recording:
             return x
 
         # Case #1: no opts specified, read audio without decoding and move it in memory.
-        if all(opt is None for opt in (channels, offset, duration)) or (
+        if format is None and (all(opt is None for opt in (channels, offset, duration)) or (
             (channels is None or _aslist(channels) == self.channel_ids)
             and (offset is None or isclose(offset, 0.0))
-            and (duration is None or isclose(duration, self.duration))
+            and (duration is None or isclose(duration, self.duration)))
         ):
             memory_sources = []
             for old_source in self.sources:


### PR DESCRIPTION
`move_to_memory` seems to fail for some cuts that have other audio soruce than `file`, no offset and duration matching the whole recording. I am fixing this for the `url` type, but probably still fails with the `command` or `shar` sources.

Also, I dont understand why there are `Case #1` and `Case #2` in this method  (I suppose case 1 is here to avoid additional decoding), especially when the user specifies a format that does not match the format of the original source. It looks like the case 1 condition should check also for the formats. 🤔 So feel free to fix it properly. 