### PR TITLE
Fix librispeech manifest caching

### DIFF
--- a/lhotse/recipes/librispeech.py
+++ b/lhotse/recipes/librispeech.py
@@ -166,7 +166,7 @@ def prepare_librispeech(
     with ThreadPoolExecutor(num_jobs) as ex:
         for part in tqdm(dataset_parts, desc="Dataset parts"):
             logging.info(f"Processing LibriSpeech subset: {part}")
-            if manifests_exist(part=part, output_dir=output_dir):
+            if manifests_exist(part=part, output_dir=output_dir, prefix="librispeech"):
                 logging.info(f"LibriSpeech subset: {part} already prepared - skipping.")
                 continue
             recordings = []


### PR DESCRIPTION
Before, `prepare_librispeech` would always process manifests, regardless of whether or not the manifests were previously saved on disk. This fix passes the correct prefix to `manifests_exist`, which allows skipping.