### PR TITLE
Utils for discovering attached data and dropping in-memory data

### DIFF
--- a/lhotse/array.py
+++ b/lhotse/array.py
@@ -7,7 +7,7 @@ from typing import List, Optional, Union
 
 import numpy as np
 
-from lhotse.utils import Pathlike, Seconds, fastcopy, ifnone
+from lhotse.utils import Pathlike, Seconds, fastcopy
 
 
 @dataclass
@@ -50,6 +50,16 @@ class Array:
     @property
     def ndim(self) -> int:
         return len(self.shape)
+
+    @property
+    def is_in_memory(self) -> bool:
+        from lhotse.features.io import is_in_memory
+
+        return is_in_memory(self.storage_type)
+
+    @property
+    def is_placeholder(self) -> bool:
+        return self.storage_type == "shar"
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -156,6 +166,14 @@ class TemporalArray:
     # We only need to specify start, as duration can be computed from
     # the shape, temporal_dim, and frame_shift.
     start: Seconds
+
+    @property
+    def is_in_memory(self) -> bool:
+        return self.array.is_in_memory
+
+    @property
+    def is_placeholder(self) -> bool:
+        return self.array.is_placeholder
 
     @property
     def shape(self) -> List[int]:

--- a/lhotse/audio/recording.py
+++ b/lhotse/audio/recording.py
@@ -156,6 +156,14 @@ class Recording:
         return None
 
     @property
+    def is_in_memory(self) -> bool:
+        return any(s.type == "memory" for s in self.sources)
+
+    @property
+    def is_placeholder(self) -> bool:
+        return any(s.type == "shar" for s in self.sources)
+
+    @property
     def num_channels(self) -> int:
         return len(self.channel_ids)
 

--- a/lhotse/cut/base.py
+++ b/lhotse/cut/base.py
@@ -177,6 +177,9 @@ class Cut:
     drop_features: Callable
     drop_recording: Callable
     drop_supervisions: Callable
+    drop_alignments: Callable
+    drop_in_memory_data: Callable
+    iter_data: Callable
     truncate: Callable
     pad: Callable
     extend_by: Callable

--- a/lhotse/cut/padding.py
+++ b/lhotse/cut/padding.py
@@ -1,6 +1,6 @@
 import logging
 from dataclasses import dataclass
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -85,6 +85,10 @@ class PaddingCut(Cut):
     def num_channels(self) -> int:
         return 1
 
+    @property
+    def is_in_memory(self) -> bool:
+        return False
+
     def has(self, field: str) -> bool:
         if field == "recording":
             return self.has_recording
@@ -98,6 +102,10 @@ class PaddingCut(Cut):
     @property
     def recording_id(self) -> str:
         return "PAD"
+
+    def iter_data(self) -> Iterable:
+        """Empty iterable."""
+        return ()
 
     # noinspection PyUnusedLocal
     def load_features(self, *args, **kwargs) -> Optional[np.ndarray]:
@@ -421,11 +429,15 @@ class PaddingCut(Cut):
         return fastcopy(self, num_samples=None)
 
     def drop_supervisions(self) -> "PaddingCut":
-        """Return a copy of the current :class:`.PaddingCut`, detached from ``supervisions``."""
+        """No-op"""
         return self
 
     def drop_alignments(self) -> "PaddingCut":
-        """Return a copy of the current :class:`.PaddingCut`, detached from ``alignments``."""
+        """No-op"""
+        return self
+
+    def drop_in_memory_data(self) -> "PaddingCut":
+        """No-op."""
         return self
 
     def compute_and_store_features(

--- a/lhotse/cut/set.py
+++ b/lhotse/cut/set.py
@@ -1743,6 +1743,14 @@ class CutSet(Serializable, AlgorithmMixin):
         """
         return self.map(_drop_alignments)
 
+    def drop_in_memory_data(self) -> "CutSet":
+        """
+        Return a new :class:`.CutSet`, where each :class:`.Cut` is copied and detached from any in-memory data it held.
+        The manifests for in-memory data are converted into placeholders that can still be looked up for
+        metadata, but will fail on attempts to load the data.
+        """
+        return self.map(_drop_in_memory_data)
+
     def compute_and_store_features(
         self,
         extractor: FeatureExtractor,
@@ -3353,6 +3361,10 @@ def _drop_alignments(cut, *args, **kwargs):
 
 def _drop_supervisions(cut, *args, **kwargs):
     return cut.drop_supervisions(*args, **kwargs)
+
+
+def _drop_in_memory_data(cut, *args, **kwargs):
+    return cut.drop_in_memory_data(*args, **kwargs)
 
 
 def _truncate_single(

--- a/lhotse/features/base.py
+++ b/lhotse/features/base.py
@@ -16,7 +16,7 @@ from tqdm.auto import tqdm
 
 from lhotse.audio import Recording
 from lhotse.augmentation import AugmentFn
-from lhotse.features.io import FeaturesWriter, get_reader
+from lhotse.features.io import FeaturesWriter, get_reader, is_in_memory
 from lhotse.lazy import AlgorithmMixin
 from lhotse.serialization import LazyMixin, Serializable, load_yaml, save_to_yaml
 from lhotse.utils import (
@@ -457,6 +457,14 @@ class Features:
     @property
     def end(self) -> Seconds:
         return self.start + self.duration
+
+    @property
+    def is_in_memory(self) -> bool:
+        return is_in_memory(self.storage_type)
+
+    @property
+    def is_placeholder(self) -> bool:
+        return self.storage_type == "shar"
 
     def load(
         self,

--- a/lhotse/features/io.py
+++ b/lhotse/features/io.py
@@ -1108,6 +1108,10 @@ In-memory reader/writer
 """
 
 
+def is_in_memory(storage_type: str) -> bool:
+    return "memory" in storage_type
+
+
 def get_memory_writer(name: str):
     assert "memory" in name
     return get_writer(name)


### PR DESCRIPTION
This PR adds the following methods and properties:
* `cut.iter_data()` which iterates over (key, manifest) pairs of all data items attached to a given cut (e.g., `("recording", Recording(...)), ("custom_features", TemporalArray(...))`)
* `is_in_memory` property for all manifest types to indicate if it contains data that is held in memory
* `is_placeholder` for non-cut manifests to indicate if a manifest is just a placeholder (has some metadata, but can't be used to load data)
* `cut.drop_in_memory_data()` which converts manifests with in-memory data to placeholders (this is useful for manifests that live longer than just dataloading to avoid blowing up CPU memory and/or slowing down the program)