### PR TITLE
Concurrent dynamic bucketing

### DIFF
--- a/lhotse/dataset/sampling/dynamic_bucketing.py
+++ b/lhotse/dataset/sampling/dynamic_bucketing.py
@@ -137,7 +137,8 @@ class DynamicBucketingSampler(CutSampler):
             duration buckets as possible to minimize the tail worker effect.
         :param concurrent: Enabling concurrency eliminates most of the waiting to pre-populate the
             bucketing buffers before the sampler starts yielding examples. For tarred/Lhotse Shar data
-            this can speed up the start of the training. This feature is experimental.
+            this can speed up the start of the training. Note that enabling concurrency will cause the
+            sampling results to be non-deterministic. This feature is experimental.
         :param world_size: Total number of distributed nodes. We will try to infer it by default.
         :param rank: Index of distributed node. We will try to infer it by default.
         :param seed: Random seed used to consistently shuffle the dataset across different processes.

--- a/lhotse/dataset/sampling/dynamic_bucketing.py
+++ b/lhotse/dataset/sampling/dynamic_bucketing.py
@@ -98,7 +98,7 @@ class DynamicBucketingSampler(CutSampler):
         rank: Optional[int] = None,
         seed: Union[int, Literal["randomized", "trng"]] = 0,
         sync_buckets: bool = True,
-        concurrent: bool = True,
+        concurrent: bool = False,
         strict=None,
         shuffle_buffer_size=None,
     ) -> None:

--- a/lhotse/dataset/sampling/dynamic_bucketing.py
+++ b/lhotse/dataset/sampling/dynamic_bucketing.py
@@ -160,6 +160,7 @@ class DynamicBucketingSampler(CutSampler):
         self.buffer_size = buffer_size
         self.quadratic_duration = quadratic_duration
         self.sync_buckets = sync_buckets
+        self.concurrent = concurrent
         self.rng = None
         check_constraint(constraint, max_duration, max_cuts)
 
@@ -288,6 +289,7 @@ class DynamicBucketingSampler(CutSampler):
             shuffle=self.shuffle,
             rng=self.rng,
             bucket_rng=bucket_rng,
+            concurrent=self.concurrent,
             diagnostics=self.diagnostics,
         )
         self.cuts_iter = iter(cuts_iter)

--- a/test/dataset/sampling/test_dynamic_bucketing.py
+++ b/test/dataset/sampling/test_dynamic_bucketing.py
@@ -115,7 +115,8 @@ def test_dynamic_bucketing_drop_last_true():
     assert sum(c.duration for c in batches[2]) == 5
 
 
-def test_dynamic_bucketing_sampler():
+@pytest.mark.parametrize("concurrent", [False, True])
+def test_dynamic_bucketing_sampler(concurrent):
     cuts = DummyManifest(CutSet, begin_id=0, end_id=10)
     for i, c in enumerate(cuts):
         if i < 5:
@@ -123,7 +124,9 @@ def test_dynamic_bucketing_sampler():
         else:
             c.duration = 2
 
-    sampler = DynamicBucketingSampler(cuts, max_duration=5, num_buckets=2, seed=0)
+    sampler = DynamicBucketingSampler(
+        cuts, max_duration=5, num_buckets=2, seed=0, concurrent=concurrent
+    )
     batches = [b for b in sampler]
     sampled_cuts = [c for b in batches for c in b]
 


### PR DESCRIPTION
Experimental feature. It should remove most of the waiting for the training to start when using `DynamicBucketingSampler` together with webdataset/lhotse shar data. I don't want to enable it as a default yet, until it's more battle tested, because with concurrency it's easy to run into unforeseen edge cases.