### PR TITLE
Refactor bucket selection for customization

### DIFF
--- a/lhotse/dataset/sampling/base.py
+++ b/lhotse/dataset/sampling/base.py
@@ -2,6 +2,7 @@ import copy
 import os
 import warnings
 from abc import ABCMeta, abstractmethod
+from bisect import bisect_right
 from copy import deepcopy
 from dataclasses import asdict, dataclass
 from math import isclose
@@ -406,6 +407,17 @@ class SamplingConstraint(metaclass=ABCMeta):
         (e.g., for audio it may be duration; for text it may be number of tokens; etc.).
         """
         pass
+
+    def select_bucket(self, buckets: Any, example: Any) -> int:
+        """
+        Given a list of buckets and an example, assign the example to the correct bucket.
+        This is leveraged by bucketing samplers.
+
+        Default implementation assumes that buckets are expressed in the same units as
+        the output of :meth:`SamplingConstraint.measure_length` and returns the index
+        of the first bucket that has a larger length than the example.
+        """
+        return bisect_right(buckets, self.measure_length(example))
 
     def copy(self) -> "SamplingConstraint":
         """Return a shallow copy of this constraint."""

--- a/lhotse/dataset/sampling/dynamic_bucketing.py
+++ b/lhotse/dataset/sampling/dynamic_bucketing.py
@@ -2,7 +2,6 @@ import random
 import threading
 import time
 import warnings
-from bisect import bisect_right
 from dataclasses import asdict, dataclass
 from itertools import islice
 from queue import Queue

--- a/lhotse/dataset/sampling/dynamic_bucketing.py
+++ b/lhotse/dataset/sampling/dynamic_bucketing.py
@@ -742,10 +742,10 @@ class DynamicBucketer:
                         time.sleep(0.1)
                         continue
                     cuts = next(self.cuts_iter)
-                    duration = self.constraint.measure_length(
-                        cuts[0] if isinstance(cuts, tuple) else cuts
+                    bucket_idx = self.constraint.select_bucket(
+                        buckets=self.duration_bins,
+                        example=cuts[0] if isinstance(cuts, tuple) else cuts,
                     )
-                    bucket_idx = bisect_right(self.duration_bins, duration)
                     self.buckets[bucket_idx].put(cuts)
             except StopIteration:
                 self._source_exhausted = True
@@ -766,10 +766,10 @@ class DynamicBucketer:
         try:
             for _ in range(n_cuts):
                 cuts = next(self.cuts_iter)
-                duration = self.constraint.measure_length(
-                    cuts[0] if isinstance(cuts, tuple) else cuts
+                bucket_idx = self.constraint.select_bucket(
+                    buckets=self.duration_bins,
+                    example=cuts[0] if isinstance(cuts, tuple) else cuts,
                 )
-                bucket_idx = bisect_right(self.duration_bins, duration)
                 self.buckets[bucket_idx].put(cuts)
         except StopIteration:
             pass

--- a/lhotse/dataset/sampling/dynamic_bucketing.py
+++ b/lhotse/dataset/sampling/dynamic_bucketing.py
@@ -3,7 +3,6 @@ import threading
 import time
 import warnings
 from bisect import bisect_right
-from collections import deque
 from dataclasses import asdict, dataclass
 from itertools import islice
 from queue import Queue
@@ -350,7 +349,9 @@ class FixedBucketBatchSizeConstraint(SamplingConstraint):
         selecting the right property from the input ``cut`` object.
         """
         seqlen = self.measure_length(example)
-        bucket_idx = bisect_right(self.max_seq_len_buckets, seqlen)
+        bucket_idx = self.select_bucket(
+            buckets=self.max_seq_len_buckets, example_len=seqlen
+        )
         assert bucket_idx < len(self.max_seq_len_buckets), (
             f"Received example with sequence length {seqlen} that exceeds "
             f"the highest allowed length {self.max_seq_len_buckets[-1]}."


### PR DESCRIPTION
Sampling constraints can now specify their own policy for bucket selection. This is leveraged in NeMo for implementing a 2D bucketing strategy:

https://github.com/NVIDIA/NeMo/blob/ade45ea1cd6e3ed8bdb4178092582caf2d7bcf2b/nemo/collections/common/data/lhotse/dataloader.py#L481-L514