### PR TITLE
`CutSet`.prefetch() for background cuts loading during iteration

### DIFF
--- a/lhotse/cut/set.py
+++ b/lhotse/cut/set.py
@@ -45,7 +45,6 @@ from lhotse.features.io import FeaturesWriter, LilcomChunkyWriter
 from lhotse.lazy import (
     AlgorithmMixin,
     Dillable,
-    LazyFilter,
     LazyFlattener,
     LazyIteratorChain,
     LazyManifestIterator,
@@ -63,7 +62,6 @@ from lhotse.utils import (
     Seconds,
     compute_num_frames,
     compute_num_samples,
-    deprecated,
     exactly_one_not_null,
     fastcopy,
     ifnone,
@@ -2033,7 +2031,6 @@ class CutSet(Serializable, AlgorithmMixin):
         """
         from concurrent.futures import ThreadPoolExecutor
 
-        import torch
         from torch.utils.data import DataLoader
 
         from lhotse.dataset import SimpleCutSampler, UnsupervisedWaveformDataset
@@ -2523,6 +2520,36 @@ class CutSet(Serializable, AlgorithmMixin):
             partial(_transform_text, transform_fn=transform_fn)
         )
 
+    def prefetch(self, buffer_size: int = 10) -> "CutSet":
+        """
+        Pre-fetches the CutSet elements in a background process.
+        Useful for enabling concurrent reading/processing/writing in ETL-style tasks.
+
+        .. caution:: This method internally uses a PyTorch DataLoader with a single worker.
+            It is not suitable for use in typical PyTorch training scripts.
+
+        .. caution:: If you run into pickling issues when using this method, you're also likely
+            using .filter/.map methods with a lambda function.
+            Please set ``lhotse.set_dill_enabled(True)`` to resolve these issues, or convert lambdas
+            to regular functions + ``functools.partial``
+
+        """
+        from torch.utils.data import DataLoader
+
+        from lhotse.dataset import DynamicCutSampler, IterableDatasetWrapper
+
+        return CutSet(
+            DataLoader(
+                dataset=IterableDatasetWrapper(
+                    _BackgroundCutFetcher(),
+                    DynamicCutSampler(self, max_cuts=1, rank=0, world_size=1),
+                ),
+                batch_size=None,
+                num_workers=1,
+                prefetch_factor=buffer_size,
+            )
+        )
+
     def __repr__(self) -> str:
         try:
             len_val = len(self)
@@ -2552,6 +2579,12 @@ class CutSet(Serializable, AlgorithmMixin):
 
     def __iter__(self) -> Iterable[Cut]:
         yield from self.cuts
+
+
+class _BackgroundCutFetcher(torch.utils.data.Dataset):
+    def __getitem__(self, cuts: CutSet):
+        assert len(cuts) == 1
+        return cuts[0]
 
 
 def mix(

--- a/test/cut/test_cut_set.py
+++ b/test/cut/test_cut_set.py
@@ -81,6 +81,12 @@ def test_cut_set_iteration(cut_set_with_mixed_cut):
     assert len(cuts) == 3
 
 
+def test_cut_set_prefetch_iteration(cut_set_with_mixed_cut):
+    cuts = list(cut_set_with_mixed_cut.prefetch())
+    assert len(cut_set_with_mixed_cut) == 3
+    assert len(cuts) == 3
+
+
 def test_cut_set_holds_both_simple_and_mixed_cuts(cut_set_with_mixed_cut):
     simple_cuts = cut_set_with_mixed_cut.simple_cuts
     assert all(isinstance(c, MonoCut) for c in simple_cuts)


### PR DESCRIPTION
Can speed up ETL-style jobs by making data reading concurrent to processing (especially for tarred / lhotse shar data).