### PR TITLE
Include a copyright NOTICE listing major copyright holders

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,19 @@
+Lhotse
+Copyright 2020-2024 Piotr Żelasko
+Copyright 2020-2021 Johns Hopkins University
+Copyright 2022-2023 Meaning.Team Inc.
+Copyright 2023-2024 NVIDIA Corporation
+
+This repository includes software developed by:
+- Johns Hopkins University
+- Xiaomi Corporation
+- Meaning.Team Inc.
+- NVIDIA Corporation
+- other organizations and individuals.
+
+This project includes contributions from various organizations and individuals.
+Only major copyright holders are listed here.
+For a complete list of contributors, please refer to the project's version control history.
+
+Licensed under the Apache License, Version 2.0 (the "License").
+See the LICENSE file for the full contents of the license.

--- a/NOTICE
+++ b/NOTICE
@@ -1,6 +1,7 @@
 Lhotse
 Copyright 2020-2024 Piotr Żelasko
-Copyright 2020-2021 Johns Hopkins University
+Copyright 2020-2024 Johns Hopkins University
+Copyright 2020-2024 Xiaomi Corporation
 Copyright 2022-2023 Meaning.Team Inc.
 Copyright 2023-2024 NVIDIA Corporation
 


### PR DESCRIPTION
I created a short copyright notice listing the major (mostly institutional) copyright owners. If I omitted anybody (or their institution) please reach out to me so we can fix that. Also feel free to add this information with a follow up PR at any time.

CC @danpovey @csukuangfj as major contributors, could you confirm it looks right for you?

