### PR TITLE
Fix backend to None while ffmpeg is unavailable.

### DIFF
--- a/lhotse/audio/backend.py
+++ b/lhotse/audio/backend.py
@@ -808,7 +808,8 @@ def torchaudio_info(
 
     if torchaudio_ffmpeg_backend_available():
         # Torchaudio 2.1 with official "ffmpeg" backend should solve all the special cases below.
-        info = torchaudio.info(path_or_fileobj, backend="ffmpeg")
+        backend = "ffmpeg" if "ffmpeg" in torchaudio.list_audio_backends() else None
+        info = torchaudio.info(path_or_fileobj, backend=backend)
         return LibsndfileCompatibleAudioInfo(
             channels=info.num_channels,
             frames=info.num_frames,


### PR DESCRIPTION
Before:

<img width="1251" alt="Screenshot 2024-09-14 at 18 34 15" src="https://github.com/user-attachments/assets/7e92a06a-2c80-4f61-8d78-2d9dfefb2805">

After:

<img width="2171" alt="Screenshot 2024-09-14 at 18 35 08" src="https://github.com/user-attachments/assets/96808047-14ef-4d3b-9b24-1669a63884ab">
