### PR TITLE
Add the Emilia corpus

### DIFF
--- a/docs/corpus.rst
+++ b/docs/corpus.rst
@@ -209,6 +209,8 @@ a CLI tool that create the manifests given a corpus directory.
     - :func:`lhotse.recipes.prepare_wenetspeech4tts`
   * - YesNo
     - :func:`lhotse.recipes.prepare_yesno`
+  * - Emilia
+    - :func:`lhotse.recipes.prepare_emilia`
   * - Eval2000
     - :func:`lhotse.recipes.prepare_eval2000`
   * - MGB2

--- a/lhotse/bin/modes/recipes/__init__.py
+++ b/lhotse/bin/modes/recipes/__init__.py
@@ -31,6 +31,7 @@ from .earnings21 import *
 from .earnings22 import *
 from .ears import *
 from .edacc import *
+from .emilia import *
 from .eval2000 import *
 from .fisher_english import *
 from .fisher_spanish import *

--- a/lhotse/bin/modes/recipes/emilia.py
+++ b/lhotse/bin/modes/recipes/emilia.py
@@ -1,0 +1,36 @@
+import click
+
+from lhotse.bin.modes import prepare
+from lhotse.recipes.emilia import prepare_emilia
+from lhotse.utils import Pathlike
+
+
+@prepare.command(context_settings=dict(show_default=True))
+@click.argument("corpus_dir", type=click.Path(exists=True, dir_okay=True))
+@click.argument("output_dir", type=click.Path())
+@click.option(
+    "-l",
+    "--lang",
+    type=str,
+    help="The language to process. Valid values: zh, en, ja, ko, de, fr",
+)
+@click.option(
+    "-j",
+    "--num-jobs",
+    type=int,
+    default=1,
+    help="How many threads to use (can give good speed-ups with slow disks).",
+)
+def emilia(
+    corpus_dir: Pathlike,
+    output_dir: Pathlike,
+    lang: str,
+    num_jobs: int = 1,
+):
+    """Prepare the Emilia corpus manifests."""
+    prepare_emilia(
+        corpus_dir=corpus_dir,
+        output_dir=output_dir,
+        lang=lang,
+        num_jobs=num_jobs,
+    )

--- a/lhotse/recipes/emilia.py
+++ b/lhotse/recipes/emilia.py
@@ -1,0 +1,176 @@
+"""
+The Emilia dataset is constructed from a vast collection of speech data sourced
+from diverse video platforms and podcasts on the Internet, covering various
+content genres such as talk shows, interviews, debates, sports commentary, and
+audiobooks. This variety ensures the dataset captures a wide array of real
+human speaking styles. The initial version of the Emilia dataset includes a
+total of 101,654 hours of multilingual speech data in six different languages:
+English, French, German, Chinese, Japanese, and Korean.
+
+See also
+https://emilia-dataset.github.io/Emilia-Demo-Page/
+
+Please note that Emilia does not own the copyright to the audio files; the
+copyright remains with the original owners of the videos or audio. Users are
+permitted to use this dataset only for non-commercial purposes under the
+CC BY-NC-4.0 license.
+
+Please refer to
+https://huggingface.co/datasets/amphion/Emilia-Dataset
+or
+https://openxlab.org.cn/datasets/Amphion/Emilia
+to download the dataset.
+
+Note that you need to apply for downloading.
+
+"""
+
+from concurrent.futures.thread import ThreadPoolExecutor
+from pathlib import Path
+from typing import Dict, Optional, Tuple, Union
+
+from tqdm.auto import tqdm
+
+from lhotse.audio import Recording, RecordingSet
+from lhotse.qa import fix_manifests, validate_recordings_and_supervisions
+from lhotse.serialization import load_jsonl
+from lhotse.supervision import SupervisionSegment, SupervisionSet
+from lhotse.utils import Pathlike
+
+
+def _parse_utterance(
+    data_dir: Path,
+    line: dict,
+) -> Optional[Tuple[Recording, SupervisionSegment]]:
+    """
+    :param data_dir: Path to the data directory
+    :param line: dict, it looks like below::
+
+        {
+          "id": "DE_B00000_S00000_W000029",
+          "wav": "DE_B00000/DE_B00000_S00000/mp3/DE_B00000_S00000_W000029.mp3",
+          "text": " Und es gibt auch einen Stadtplan von Tegun zu sehen.",
+          "duration": 3.228,
+          "speaker": "DE_B00000_S00000",
+          "language": "de",
+          "dnsmos": 3.3697
+        }
+
+    :return: a tuple of "recording" and "supervision"
+    """
+    full_path = data_dir / line["wav"]
+
+    if not full_path.is_file():
+        return None
+
+    recording = Recording.from_file(
+        path=full_path,
+        recording_id=full_path.stem,
+    )
+    segment = SupervisionSegment(
+        id=recording.id,
+        recording_id=recording.id,
+        start=0.0,
+        duration=recording.duration,
+        channel=0,
+        text=line["text"],
+        language=line["language"],
+        speaker=line["speaker"],
+        custom={"dnsmos": line["dnsmos"]},
+    )
+
+    return recording, segment
+
+
+def prepare_emilia(
+    corpus_dir: Pathlike,
+    lang: str,
+    num_jobs: int,
+    output_dir: Optional[Pathlike] = None,
+) -> Dict[str, Union[RecordingSet, SupervisionSet]]:
+    """
+    Returns the manifests which consist of the Recordings and Supervisions
+
+    :param corpus_dir: Pathlike, the path of the data dir.
+                       We assume the directory has the following structure:
+                       corpus_dir/raw/openemilia_all.tar.gz,
+                       corpus_dir/raw/DE,
+                       corpus_dir/raw/DE/DE_B00000.jsonl,
+                       corpus_dir/raw/DE/DE_B00000/DE_B00000_S00000/mp3/DE_B00000_S00000_W000000.mp3,
+                       corpus_dir/raw/EN, etc.
+    :param lang: str, one of en, zh, de, ko, ja, fr
+    :param num_jobs: int, number of threads for processing jsonl files
+    :param output_dir: Pathlike, the path where to write the manifests.
+    :return: The RecordingSet and SupervisionSet with the keys 'recordings' and
+             'supervisions'.
+    """
+    if lang is None:
+        raise ValueError("Please provide --lang")
+
+    lang_uppercase = lang.upper()
+    if lang_uppercase not in ("DE", "EN", "FR", "JA", "KO", "ZH"):
+        raise ValueError(
+            "Please provide a valid language. "
+            f"Choose from de, en, fr, ja, ko, zh. Given: {lang}"
+        )
+
+    corpus_dir = Path(corpus_dir)
+    assert corpus_dir.is_dir(), f"No such directory: {corpus_dir}"
+    data_dir = corpus_dir / "raw" / lang_uppercase
+    assert data_dir.is_dir(), f"No such directory: {data_dir}"
+
+    jsonl_files = data_dir.glob("*.jsonl")
+
+    recordings = []
+    supervisions = []
+    futures = []
+
+    with ThreadPoolExecutor(num_jobs) as ex:
+        for jsonl_file in jsonl_files:
+            for item in tqdm(
+                # Note: People's Speech manifest.json is really a JSONL.
+                load_jsonl(jsonl_file),
+                desc=f"Processing {jsonl_file} with {num_jobs} jobs",
+            ):
+                futures.append(
+                    ex.submit(
+                        _parse_utterance,
+                        data_dir,
+                        item,
+                    )
+                )
+
+        for future in tqdm(futures, desc="Collecting futures"):
+            result = future.result()
+            if result is None:
+                continue
+
+            recording, segment = result
+
+            recordings.append(recording)
+            supervisions.append(segment)
+
+    recording_set = RecordingSet.from_recordings(recordings)
+    supervision_set = SupervisionSet.from_segments(supervisions)
+
+    recording_set, supervision_set = fix_manifests(recording_set, supervision_set)
+    validate_recordings_and_supervisions(
+        recordings=recording_set, supervisions=supervision_set
+    )
+
+    if output_dir is not None:
+        output_dir = Path(output_dir)
+        supervision_set.to_file(
+            output_dir / f"emilia_supervisions_{lang_uppercase}.jsonl.gz"
+        )
+        recording_set.to_file(
+            output_dir / f"emilia_recordings_{lang_uppercase}.jsonl.gz"
+        )
+
+    manifests = dict()
+    manifests[lang_uppercase] = {
+        "recordings": recording_set,
+        "supervisions": supervision_set,
+    }
+
+    return manifests

--- a/lhotse/recipes/emilia.py
+++ b/lhotse/recipes/emilia.py
@@ -31,11 +31,11 @@ from typing import Optional, Tuple
 
 from tqdm.auto import tqdm
 
+from lhotse import CutSet, MonoCut
 from lhotse.audio import Recording
 from lhotse.serialization import load_jsonl
 from lhotse.supervision import SupervisionSegment
 from lhotse.utils import Pathlike
-from lhotse import MonoCut, CutSet
 
 
 def _parse_utterance(


### PR DESCRIPTION
The corpus can be downloaded from
https://huggingface.co/datasets/amphion/Emilia-Dataset

---

### Usage example
```
(py38) kuangfangjun:recipes$ mkdir ~/t5
(py38) kuangfangjun:recipes$ time lhotse prepare emilia --num-jobs 30 --lang de /star-fj/fangjun/data/tts/emilia/download/Amphion___Emilia /star-fj/fa
ngjun/t5/
Processing /star-fj/fangjun/data/tts/emilia/download/Amphion___Emilia/raw/DE/DE_B00000.jsonl with 30 jobs: 166901it [00:41, 4024.66it/s]
Processing /star-fj/fangjun/data/tts/emilia/download/Amphion___Emilia/raw/DE/DE_B00001.jsonl with 30 jobs: 152274it [00:33, 4592.59it/s]
Processing /star-fj/fangjun/data/tts/emilia/download/Amphion___Emilia/raw/DE/DE_B00002.jsonl with 30 jobs: 167050it [00:49, 3391.75it/s]
Processing /star-fj/fangjun/data/tts/emilia/download/Amphion___Emilia/raw/DE/DE_B00003.jsonl with 30 jobs: 45364it [00:09, 4747.71it/s]
Processing /star-fj/fangjun/data/tts/emilia/download/Amphion___Emilia/raw/DE/DE_B00004.jsonl with 30 jobs: 48257it [00:35, 1378.46it/s]
Processing /star-fj/fangjun/data/tts/emilia/download/Amphion___Emilia/raw/DE/DE_B00005.jsonl with 30 jobs: 32706it [00:02, 13124.74it/s]
Processing /star-fj/fangjun/data/tts/emilia/download/Amphion___Emilia/raw/DE/DE_B00006.jsonl with 30 jobs: 22127it [00:05, 4183.53it/s]
Processing /star-fj/fangjun/data/tts/emilia/download/Amphion___Emilia/raw/DE/DE_B00007.jsonl with 30 jobs: 14712it [00:01, 13699.85it/s]
Processing /star-fj/fangjun/data/tts/emilia/download/Amphion___Emilia/raw/DE/DE_B00008.jsonl with 30 jobs: 3718it [00:00, 13919.69it/s]
Collecting futures: 100%|_________________________________________________________________________________| 653109/653109 [00:04<00:00, 144918.00it/s]

real    4m15.395s
user    4m30.221s
sys     0m57.310s
```

(Note: Only audio files of `DE_B00000.jsonl` and `DE_B00001.jsonl`  in the above example are extracted to the corpus directory).

Generated files are
```
(py38) kuangfangjun:recipes$ cd ~/t5
(py38) kuangfangjun:t5$ ls -lh
total 30M
-rw-r--r-- 1 kuangfangjun root 30M Oct 21 15:57 emilia_cuts_DE.jsonl.gz
```

```
(py38) kuangfangjun:t5$ lhotse cut describe ./emilia_cuts_DE.jsonl.gz
```

prints

```
Cut statistics:
_________________________________________
_ Cuts count:               _ 319175    _
_________________________________________
_ Total duration (hh:mm:ss) _ 766:12:03 _
_________________________________________
_ mean                      _ 8.6       _
_________________________________________
_ std                       _ 5.0       _
_________________________________________
_ min                       _ 3.0       _
_________________________________________
_ 25%                       _ 4.7       _
_________________________________________
_ 50%                       _ 7.2       _
_________________________________________
_ 75%                       _ 11.3      _
_________________________________________
_ 99%                       _ 24.2      _
_________________________________________
_ 99.5%                     _ 28.0      _
_________________________________________
_ 99.9%                     _ 29.6      _
_________________________________________
_ max                       _ 30.0      _
_________________________________________
_ Recordings available:     _ 319175    _
_________________________________________
_ Features available:       _ 0         _
_________________________________________
_ Supervisions available:   _ 319175    _
_________________________________________
SUPERVISION custom fields:
- dnsmos (in 319175 cuts)
Speech duration statistics:
___________________________________________________________________
_ Total speech duration        _ 766:12:03 _ 100.00% of recording _
___________________________________________________________________
_ Total speaking time duration _ 766:12:04 _ 100.00% of recording _
___________________________________________________________________
_ Total silence duration       _ 00:00:01  _ 0.00% of recording   _
___________________________________________________________________
```