### PR TITLE
downgrading sphinx version from 7.2.6 to 7.1.2

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.18.1
 sphinx_rtd_theme==2.0.0
-sphinx==7.2.6
+sphinx==7.1.2
 sphinx-click==5.1.0
 sphinx-autodoc-typehints==2.0.0


### PR DESCRIPTION
Python 3.8 wasn't working with sphinx 7.2.6 so downgraded sphinx.
[https://github.com/lhotse-speech/lhotse/issues/1405](url)