### PR TITLE
Option to save audio in the original format when exporting to shar

### DIFF
--- a/lhotse/audio/recording.py
+++ b/lhotse/audio/recording.py
@@ -168,6 +168,23 @@ class Recording:
     def num_channels(self) -> int:
         return len(self.channel_ids)
 
+    @property
+    def source_format(self) -> str:
+        """Infer format of the audio sources.
+        If all sources have the same format, return it.
+        If sources have different formats, raise an error.
+        """
+        source_formats = list(set([s.format for s in self.sources]))
+
+        if len(source_formats) == 1:
+            # if all sources have the same format, return it
+            return source_formats[0]
+        else:
+            # at the moment, we don't resolve different formats
+            raise NotImplementedError(
+                "Sources have different formats. Resolving to a single format not implemented."
+            )
+
     @staticmethod
     def from_file(
         path: Pathlike,

--- a/lhotse/bin/modes/shar.py
+++ b/lhotse/bin/modes/shar.py
@@ -27,8 +27,8 @@ def shar():
     "-a",
     "--audio",
     default="none",
-    type=click.Choice(["none", "wav", "flac", "mp3", "opus"]),
-    help="Format in which to export audio (disabled by default, enabling will make a copy of the data)",
+    type=click.Choice(["none", "wav", "flac", "mp3", "opus", "original"]),
+    help="Format in which to export audio. Original will save in the same format as the original audio (disabled by default, enabling will make a copy of the data)",
 )
 @click.option(
     "-f",

--- a/lhotse/shar/writers/shar.py
+++ b/lhotse/shar/writers/shar.py
@@ -135,7 +135,11 @@ class SharWriter:
                     recording.sources[0].channels = cut_channels
                     recording.channel_ids = cut_channels
                 self.writers["recording"].write(
-                    cut.id, data, cut.sampling_rate, manifest=recording
+                    cut.id,
+                    data,
+                    cut.sampling_rate,
+                    manifest=recording,
+                    original_format=cut.recording.source_format,
                 )
                 cut = fastcopy(cut, recording=recording)
             else:
@@ -224,6 +228,7 @@ def resolve_writer(name: str) -> Tuple[FieldWriter, str]:
         "flac": (partial(AudioTarWriter, format="flac"), ".tar"),
         "mp3": (partial(AudioTarWriter, format="mp3"), ".tar"),
         "opus": (partial(AudioTarWriter, format="opus"), ".tar"),
+        "original": (partial(AudioTarWriter, format="original"), ".tar"),
         "lilcom": (partial(ArrayTarWriter, compression="lilcom"), ".tar"),
         "numpy": (partial(ArrayTarWriter, compression="numpy"), ".tar"),
         "jsonl": (JsonlShardWriter, ".jsonl.gz"),

--- a/lhotse/testing/dummies.py
+++ b/lhotse/testing/dummies.py
@@ -102,7 +102,7 @@ def dummy_audio_source(
         f_sine = 1000
         assert (
             f_sine < sampling_rate / 2
-        ), "Sine wave frequency exceeds Nyquist frequency"
+        ), f"Sine wave frequency {f_sine} exceeds Nyquist frequency {sampling_rate/2} for sampling rate {sampling_rate}"
         data = torch.sin(2 * np.pi * f_sine / sampling_rate * torch.arange(num_samples))
 
         # prepare multichannel data

--- a/lhotse/testing/dummies.py
+++ b/lhotse/testing/dummies.py
@@ -63,6 +63,7 @@ def dummy_recording(
     duration: float = 1.0,
     sampling_rate: int = 16000,
     with_data: bool = False,
+    source_format: str = "wav",
 ) -> Recording:
     num_samples = compute_num_samples(duration, sampling_rate)
     return Recording(
@@ -72,6 +73,7 @@ def dummy_recording(
                 sampling_rate=sampling_rate,
                 num_samples=num_samples,
                 with_data=with_data,
+                format=source_format,
             )
         ],
         sampling_rate=sampling_rate,
@@ -85,6 +87,7 @@ def dummy_audio_source(
     sampling_rate: int = 16000,
     channels: Optional[List[int]] = None,
     with_data: bool = False,
+    format: str = "wav",
 ) -> AudioSource:
     if channels is None:
         channels = [0]
@@ -95,21 +98,40 @@ def dummy_audio_source(
     else:
         import soundfile
 
-        # 1kHz sine wave
-        data = torch.sin(2 * np.pi * 1000 * torch.arange(num_samples))
+        # generate 1kHz sine wave
+        f_sine = 1000
+        assert (
+            f_sine < sampling_rate / 2
+        ), "Sine wave frequency exceeds Nyquist frequency"
+        data = torch.sin(2 * np.pi * f_sine / sampling_rate * torch.arange(num_samples))
+
+        # prepare multichannel data
         if len(channels) > 1:
             data = data.unsqueeze(0).expand(len(channels), -1).transpose(0, 1)
             # ensure each channel has different data for channel selection testing
             mults = torch.tensor([1 / idx for idx in range(1, len(channels) + 1)])
             data = data * mults
+
+        # prepare source with the selected format
         binary_data = BytesIO()
-        soundfile.write(
-            binary_data,
-            data.numpy(),
-            sampling_rate,
-            format="wav",
-            closefd=False,
-        )
+        if format == "opus":
+            # workaround for OPUS: soundfile supports OPUS as a subtype of OGG format
+            soundfile.write(
+                binary_data,
+                data.numpy(),
+                sampling_rate,
+                format="OGG",
+                subtype="OPUS",
+                closefd=False,
+            )
+        else:
+            soundfile.write(
+                binary_data,
+                data.numpy(),
+                sampling_rate,
+                format=format,
+                closefd=False,
+            )
         binary_data.seek(0)
         return AudioSource(
             type="memory", channels=channels, source=binary_data.getvalue()

--- a/test/shar/test_write.py
+++ b/test/shar/test_write.py
@@ -67,56 +67,6 @@ def test_tar_writer_pipe(tmp_path: Path):
 
 
 @pytest.mark.parametrize(
-    "format",
-    [
-        "wav",
-        pytest.param(
-            "flac",
-            marks=pytest.mark.skipif(
-                not check_torchaudio_version_gt("0.12.1"),
-                reason="Torchaudio v0.12.1 or greater is required.",
-            ),
-        ),
-        # "mp3",  # apparently doesn't work in CI, mp3 encoder is missing
-        pytest.param(
-            "opus",
-            marks=pytest.mark.skipif(
-                not check_torchaudio_version_gt("2.1.0"),
-                reason="Torchaudio v2.1.0 or greater is required.",
-            ),
-        ),
-    ],
-)
-# TODO: check if this should be removed?
-def test_audio_tar_writer(tmp_path: Path, format: str):
-    from lhotse.testing.dummies import dummy_recording
-
-    recording = dummy_recording(0, with_data=True)
-    audio = recording.load_audio()
-
-    with AudioTarWriter(
-        str(tmp_path / "test.tar"), shard_size=None, format=format
-    ) as writer:
-        writer.write(
-            key="my-recording",
-            value=audio,
-            sampling_rate=recording.sampling_rate,
-            manifest=recording,
-        )
-
-    (path,) = writer.output_paths
-
-    ((deserialized_recording, inner_path),) = list(TarIterator(path))
-
-    deserialized_audio = deserialized_recording.resample(
-        recording.sampling_rate
-    ).load_audio()
-
-    rmse = np.sqrt(np.mean((audio - deserialized_audio) ** 2))
-    assert rmse < 0.5
-
-
-@pytest.mark.parametrize(
     ["format", "backend"],
     [
         ("flac", "default"),


### PR DESCRIPTION
Added an option to use the original audio format when exporting to shar.

### Example

Use `--audio original` when calling `lhotse shar export`.
For example:

```
lhotse shar export --num-jobs 1 --verbose --shard-size 2 --audio original --no-shuffle ${INPUT_MANIFEST} ${OUTPUT_DIR}
```