### PR TITLE
add to_dict for CustomFieldMixin class

### DIFF
--- a/lhotse/custom.py
+++ b/lhotse/custom.py
@@ -1,11 +1,10 @@
-from dataclasses import asdict
 from functools import partial
 from typing import Any, Dict, Optional
 
 import numpy as np
 
 from lhotse import Recording
-from lhotse.utils import fastcopy, ifnone
+from lhotse.utils import asdict_nonull, fastcopy, ifnone
 
 
 class CustomFieldMixin:
@@ -83,7 +82,7 @@ class CustomFieldMixin:
         del self.custom[key]
 
     def to_dict(self) -> Dict[str, Any]:
-        return asdict(self)
+        return asdict_nonull(self)
 
     def with_custom(self, name: str, value: Any):
         """Return a copy of this object with an extra custom field assigned to it."""

--- a/lhotse/custom.py
+++ b/lhotse/custom.py
@@ -1,3 +1,4 @@
+from dataclasses import asdict
 from functools import partial
 from typing import Any, Dict, Optional
 
@@ -80,6 +81,9 @@ class CustomFieldMixin:
         if self.custom is None or key not in self.custom:
             raise AttributeError(f"No such member: '{key}'")
         del self.custom[key]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
 
     def with_custom(self, name: str, value: Any):
         """Return a copy of this object with an extra custom field assigned to it."""


### PR DESCRIPTION
Fix:

``` python
from lhotse.cut.text import TextExample

txts = [TextExample("a"), TextExample("b")]
CutSet(txts).to_jsonl("test.jsonl")
```

```
Traceback (most recent call last):
  File "/home/vscode/workspace/main.py", line 11, in <module>
    CutSet(txts).to_jsonl("test.jsonl")
  File "/home/vscode/miniforge3/envs/lhotse/lib/python3.10/site-packages/lhotse/serialization.py", line 356, in to_jsonl
    save_to_jsonl(self.to_dicts(), path)
  File "/home/vscode/miniforge3/envs/lhotse/lib/python3.10/site-packages/lhotse/serialization.py", line 181, in save_to_jsonl
    for item in data:
  File "/home/vscode/miniforge3/envs/lhotse/lib/python3.10/site-packages/lhotse/cut/set.py", line 686, in <genexpr>
    return (cut.to_dict() for cut in self)
  File "/home/vscode/miniforge3/envs/lhotse/lib/python3.10/site-packages/lhotse/custom.py", line 65, in __getattr__
    raise AttributeError(f"No such attribute: {name}")
AttributeError: No such attribute: to_dict
```