### PR TITLE
Fix .m4a support in some setups (possibly for other formats not supported by libsndfile)

### DIFF
--- a/lhotse/audio/backend.py
+++ b/lhotse/audio/backend.py
@@ -516,6 +516,10 @@ class LibsndfileBackend(AudioBackend):
         return False
 
     def is_applicable(self, path_or_fd: Union[Pathlike, FileObject]) -> bool:
+        if isinstance(path_or_fd, (Path, str)) and any(
+            str(path_or_fd).endswith(ext) for ext in [".mp4", ".m4a", ".m4b"]
+        ):
+            return False
         return True
 
     def supports_save(self) -> bool:

--- a/lhotse/audio/backend.py
+++ b/lhotse/audio/backend.py
@@ -574,6 +574,9 @@ class AudioreadBackend(AudioBackend):
             offset=offset,
             duration=duration,
         )
+        
+    def supports_info(self):
+        return True
 
     def info(
         self,

--- a/lhotse/audio/backend.py
+++ b/lhotse/audio/backend.py
@@ -574,7 +574,7 @@ class AudioreadBackend(AudioBackend):
             offset=offset,
             duration=duration,
         )
-        
+
     def supports_info(self):
         return True
 

--- a/lhotse/cut/set.py
+++ b/lhotse/cut/set.py
@@ -3570,7 +3570,7 @@ def _export_to_shar_single(
             except Exception as e:
                 if fault_tolerant:
                     logging.warning(
-                        "Skipping: failed to load cut '{cut.id}'. Error message: {e}."
+                        f"Skipping: failed to load cut '{cut.id}'. Error message: {e}."
                     )
                 else:
                     raise


### PR DESCRIPTION
Requesting to merge following changes

* Explicitly set m4a as unsupported in `lhotse.audio.backend.LibsndfileBackend` because it does not support m4a and will not support it in observable future. This is mostly a cosmetic change to eliminate a confusing exception when working with m4a files.  
  * https://github.com/bastibe/python-soundfile/issues/431#issuecomment-2068550691

* Set `AudioreadBackend.supports_info` to `True` because it has an `info` method just a line below. This is a bugfix making fallback to this backend actually work.

Real world impact: fixing `Recording.from_file` for m4a files in environments where `torchaudio` is not installed.
An example of such environment would be the `nvcr.io/nvidia/nemo:24.07` container.