### PR TITLE
Update CI to install torchaudio and kaldifeat

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -9,6 +9,8 @@ on:
   pull_request:
     branches: [ master ]
 
+  workflow_dispatch:
+
 jobs:
   black:
     runs-on: ubuntu-latest

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -9,6 +9,8 @@ on:
   pull_request:
     branches: [ master ]
 
+  workflow_dispatch:
+
 jobs:
   flake8:
 

--- a/.github/workflows/isort.yml
+++ b/.github/workflows/isort.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [ master ]
 
+  workflow_dispatch:
+
 jobs:
   isort:
 

--- a/.github/workflows/missing_torchaudio.yml
+++ b/.github/workflows/missing_torchaudio.yml
@@ -9,6 +9,8 @@ on:
   pull_request:
     branches: [ master ]
 
+  workflow_dispatch:
+
 jobs:
   missing_torchaudio:
 

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -5,9 +5,11 @@ name: unit_tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, fix-ci ]
   pull_request:
     branches: [ master ]
+
+  workflow_dispatch:
 
 jobs:
   unit_tests:
@@ -16,21 +18,24 @@ jobs:
     strategy:
       matrix:
         include:
-          - python-version: "3.8"  # note: no torchaudio
-            torch-install-cmd: "pip install torch==1.12.1 --extra-index-url https://download.pytorch.org/whl/cpu"
-            extra_deps: ""
+          - python-version: "3.8"
+            torch-install-cmd: "pip install torch==1.12.1+cpu torchaudio==0.12.1+cpu -f https://download.pytorch.org/whl/torch -f https://download.pytorch.org/whl/torchaudio"
+            extra_deps: "kaldifeat==1.25.5.dev20241029+cpu.torch1.12.1 -f https://csukuangfj.github.io/kaldifeat/cpu.html"
           - python-version: "3.9"
-            torch-install-cmd: "pip install torch==2.3 torchaudio==2.3 --extra-index-url https://download.pytorch.org/whl/cpu"
-            extra_deps: ""
-          - python-version: "3.10"  # note: no torchaudio
-            torch-install-cmd: "pip install torch==2.4 --extra-index-url https://download.pytorch.org/whl/cpu"
-            extra_deps: ""
-          - python-version: "3.11"  # note: no torchaudio
-            torch-install-cmd: "pip install torch==2.5 --extra-index-url https://download.pytorch.org/whl/cpu"
-            extra_deps: ""
-          - python-version: "3.12"  # note: no torchaudio
-            torch-install-cmd: "pip install torch==2.5 --extra-index-url https://download.pytorch.org/whl/cpu"
-            extra_deps: ""  # kaldifeat
+            torch-install-cmd: "pip install torch==2.3.0+cpu torchaudio==2.3.0+cpu -f https://download.pytorch.org/whl/torch -f https://download.pytorch.org/whl/torchaudio"
+            extra_deps: "kaldifeat==1.25.5.dev20241029+cpu.torch2.3.0 -f https://csukuangfj.github.io/kaldifeat/cpu.html"
+          - python-version: "3.10"
+            torch-install-cmd: "pip install torch==2.4.0+cpu torchaudio==2.4.0+cpu -f https://download.pytorch.org/whl/torch -f https://download.pytorch.org/whl/torchaudio"
+            extra_deps: "kaldifeat==1.25.5.dev20241029+cpu.torch2.4.0 -f https://csukuangfj.github.io/kaldifeat/cpu.html"
+          - python-version: "3.11"
+            torch-install-cmd: "pip install torch==2.5.0+cpu torchaudio==2.5.0+cpu -f https://download.pytorch.org/whl/torch -f https://download.pytorch.org/whl/torchaudio"
+            extra_deps: "kaldifeat==1.25.5.dev20241030+cpu.torch2.5.0 -f https://csukuangfj.github.io/kaldifeat/cpu.html"
+          - python-version: "3.12"
+            torch-install-cmd: "pip install torch==2.5.0+cpu torchaudio==2.5.0+cpu -f https://download.pytorch.org/whl/torch -f https://download.pytorch.org/whl/torchaudio"
+            extra_deps: "kaldifeat==1.25.5.dev20241030+cpu.torch2.5.0 -f https://csukuangfj.github.io/kaldifeat/cpu.html"
+          - python-version: "3.13"
+            torch-install-cmd: "pip install torch==2.6.0+cpu torchaudio==2.6.0+cpu -f https://download.pytorch.org/whl/torch -f https://download.pytorch.org/whl/torchaudio"
+            extra_deps: "kaldifeat==1.25.5.dev20250130+cpu.torch2.6.0 -f https://csukuangfj.github.io/kaldifeat/cpu.html"
 
       fail-fast: false
 


### PR DESCRIPTION
Fixes https://github.com/csukuangfj/kaldifeat/issues/113


Note: The remaining test errors are not related to kaldifeat.


---


# Error for python 3.13
https://github.com/csukuangfj/lhotse/actions/runs/13276855268/job/37067912546#step:7:100
```
==================================== ERRORS ====================================
______________ ERROR collecting test/audio/test_recording_set.py _______________
ImportError while importing test module '/home/runner/work/lhotse/lhotse/test/audio/test_recording_set.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/hostedtoolcache/Python/3.13.1/x64/lib/python3.13/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
test/audio/test_recording_set.py:538: in <module>
    for backend in audioread.available_backends()
/opt/hostedtoolcache/Python/3.13.1/x64/lib/python3.13/site-packages/audioread/__init__.py:80: in available_backends
    from . import rawread
/opt/hostedtoolcache/Python/3.13.1/x64/lib/python3.13/site-packages/audioread/rawread.py:16: in <module>
    import aifc
E   ModuleNotFoundError: No module named 'aifc'
```


