### PR TITLE
feat: add multi-storage-client backend for file open

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -57,7 +57,7 @@ jobs:
         # the torchaudio env var does nothing when torchaudio is installed, but doesn't require it's presence when it's not
         pip install lilcom '.[tests]'
         # Enable some optional tests
-        pip install h5py dill smart_open[http] kaldi_native_io webdataset==0.2.5 s3prl scipy nara_wpe pyloudnorm ${{ matrix.extra_deps }}
+        pip install h5py dill smart_open[http] kaldi_native_io webdataset==0.2.5 s3prl scipy nara_wpe pyloudnorm ${{ matrix.extra_deps }} multi-storage-client==0.16.0
     - name: Install sph2pipe
       run: |
         lhotse install-sph2pipe  # Handle sphere files.

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -21,16 +21,16 @@ jobs:
             extra_deps: ""
           - python-version: "3.9"
             torch-install-cmd: "pip install torch==2.3 torchaudio==2.3 --extra-index-url https://download.pytorch.org/whl/cpu"
-            extra_deps: ""
+            extra_deps: "multi-storage-client==0.16.0"
           - python-version: "3.10"  # note: no torchaudio
             torch-install-cmd: "pip install torch==2.4 --extra-index-url https://download.pytorch.org/whl/cpu"
-            extra_deps: ""
+            extra_deps: "multi-storage-client==0.16.0"
           - python-version: "3.11"  # note: no torchaudio
             torch-install-cmd: "pip install torch==2.5 --extra-index-url https://download.pytorch.org/whl/cpu"
-            extra_deps: ""
+            extra_deps: "multi-storage-client==0.16.0"
           - python-version: "3.12"  # note: no torchaudio
             torch-install-cmd: "pip install torch==2.5 --extra-index-url https://download.pytorch.org/whl/cpu"
-            extra_deps: ""  # kaldifeat
+            extra_deps: "multi-storage-client==0.16.0"  # kaldifeat
 
       fail-fast: false
 
@@ -57,7 +57,7 @@ jobs:
         # the torchaudio env var does nothing when torchaudio is installed, but doesn't require it's presence when it's not
         pip install lilcom '.[tests]'
         # Enable some optional tests
-        pip install h5py dill smart_open[http] kaldi_native_io webdataset==0.2.5 s3prl scipy nara_wpe pyloudnorm ${{ matrix.extra_deps }} multi-storage-client==0.16.0
+        pip install h5py dill smart_open[http] kaldi_native_io webdataset==0.2.5 s3prl scipy nara_wpe pyloudnorm ${{ matrix.extra_deps }}
     - name: Install sph2pipe
       run: |
         lhotse install-sph2pipe  # Handle sphere files.

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ Lhotse uses several environment variables to customize it's behavior. They are a
 - `AIS_ENDPOINT` is read by AIStore client to determine AIStore endpoint URL. Required for AIStore dataloading.
 - `RANK`, `WORLD_SIZE`, `WORKER`, and `NUM_WORKERS` are internally used to inform Lhotse Shar dataloading subprocesses.
 - `READTHEDOCS` is internally used for documentation builds.
+- `LHOTSE_MSC_OVERRIDE_PROTOCOLS` - when set, it will override your input protocols before feeding to MSCIOBackend.  Useful when you don't want to change your existing url format but want to use MSCIOBackend.  For example, if you have `s3://s3-bucket/path/to/my/object` and `gs://gs-bucket/path/to/my/object`, you can set `LHOTSE_MSC_OVERRIDE_PROTOCOLS=s3,gs` to override the urls to `msc://s3-bucket/path/to/my/object` and `msc://gs-bucket/path/to/my/object`.
+- `LHOTSE_MSC_PROFILE` - when set, it will override the your bucket name before feeding to MSCIOBackend.  Useful when your msc profile is not the same as your bucket name.  For example, if you have `s3://s3-bucket/path/to/my/object`, you can set `LHOTSE_MSC_OVERRIDE_PROTOCOLS=s3` and `LHOTSE_MSC_PROFILE=msc-s3-profile` to override the url to `msc://msc-s3-profile/path/to/my/object`.
 
 ### Optional dependencies
 
@@ -126,6 +128,7 @@ Lhotse uses several environment variables to customize it's behavior. They are a
 - `pip install aistore` to read manifests, tar fles, and other data from AIStore using AIStore-supported URLs (set `AIS_ENDPOINT` environment variable to activate it). See [AIStore documentation](https://aiatscale.org) for more details.
 - `pip install smart_open` to read and write manifests and data in any location supported by `smart_open` (e.g. cloud, http).
 - `pip install opensmile` for feature extraction using the OpenSmile toolkit's Python wrapper.
+- `pip install multi-storage-client` for read and write manifests and data in different storage backends. See [multi-storage-client](https://github.com/NVIDIA/multi-storage-client) for more details.
 
 **sph2pipe.** For reading older LDC SPHERE (.sph) audio files that are compressed with codecs unsupported by ffmpeg and sox, please run:
 

--- a/lhotse/serialization.py
+++ b/lhotse/serialization.py
@@ -850,7 +850,7 @@ class MSCIOBackend(IOBackend):
         if bucket name is not provided, then we expect the msc profile name to match with bucket name
         """
         if not is_module_available("multistorageclient"):
-            raise RuntimeError("Please run 'pip install multistorageclient' in order to use MSCIOBackend.")
+            raise RuntimeError("Please run 'pip install multi-storage-client' in order to use MSCIOBackend.")
 
         import multistorageclient as msc
 

--- a/lhotse/serialization.py
+++ b/lhotse/serialization.py
@@ -815,27 +815,28 @@ class AIStoreIOBackend(IOBackend):
     def is_applicable(self, identifier: Pathlike) -> bool:
         return is_valid_url(identifier)
 
-    
-@lru_cache(1)
+
 def get_lhotse_msc_override_protocols() -> Any:
     return os.getenv("LHOTSE_MSC_OVERRIDE_PROTOCOLS", None)
 
 
-@lru_cache(1)
 def get_lhotse_msc_profile() -> Any:
     return os.getenv("LHOTSE_MSC_PROFILE", None)
-
-
-@lru_cache(1)
-def get_lhotse_io_backend() -> Any:
-    return os.getenv("LHOTSE_IO_BACKEND", None)
 
 
 MSC_PREFIX = "msc"
 
 class MSCIOBackend(IOBackend):
     """
-    Uses multi-storage client to download data from object store
+    Uses Multi-Storage Client to download data from object store.
+
+    Multi-Storage Client (MSC) is a Python library aims at providing a unified interface to object and file
+    storage backends, including S3, GCS, AIStore, and more.  With no code change, user can seamlessly switch
+    between different storage backends with corresponding MSC urls.  To use MSCIOBackend, user will need a
+    MSC config file that specifies the storage backend information.  Please refer to the MSC documentation
+    for more details: https://nvidia.github.io/multi-storage-client/user_guide/quickstart.html#configuration
+
+    To learn more about MSC, please check out the GitHub repo: https://github.com/NVIDIA/multi-storage-client
     """
 
     def open(self, identifier: str, mode: str):
@@ -848,6 +849,8 @@ class MSCIOBackend(IOBackend):
         2. override the profile/bucket name by env LHOTSE_MSC_PROFILE if provided: msc://profile/path/to/my/object2,
         if bucket name is not provided, then we expect the msc profile name to match with bucket name
         """
+        if not is_module_available("multistorageclient"):
+            raise RuntimeError("Please run 'pip install multistorageclient' in order to use MSCIOBackend.")
 
         import multistorageclient as msc
 

--- a/lhotse/serialization.py
+++ b/lhotse/serialization.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, Generator, Iterable, List, Optional, Type, Union
 import yaml
 from packaging.version import parse as parse_version
 
-from lhotse.utils import Pathlike, Pipe, SmartOpen, is_module_available, is_valid_url
+from lhotse.utils import Pathlike, Pipe, SmartOpen, is_module_available, is_valid_url, replace_bucket_with_profile_name
 from lhotse.workarounds import gzip_open_robust
 
 # TODO: figure out how to use some sort of typing stubs
@@ -815,6 +815,82 @@ class AIStoreIOBackend(IOBackend):
     def is_applicable(self, identifier: Pathlike) -> bool:
         return is_valid_url(identifier)
 
+    
+@lru_cache(1)
+def get_lhotse_msc_override_protocols() -> Any:
+    return os.getenv("LHOTSE_MSC_OVERRIDE_PROTOCOLS", None)
+
+
+@lru_cache(1)
+def get_lhotse_msc_profile() -> Any:
+    return os.getenv("LHOTSE_MSC_PROFILE", None)
+
+
+@lru_cache(1)
+def get_lhotse_io_backend() -> Any:
+    return os.getenv("LHOTSE_IO_BACKEND", None)
+
+
+MSC_PREFIX = "msc"
+
+class MSCIOBackend(IOBackend):
+    """
+    Uses multi-storage client to download data from object store
+    """
+
+    def open(self, identifier: str, mode: str):
+        """
+        Convert identifier if is not prefixed with msc, and use msc.open to access the file
+        For paths that are prefixed with msc, e.g. msc://profile/path/to/my/object1
+
+        For paths are yet to migrate to msc-compatible url, e.g. protocol://bucket/path/to/my/object2
+        1. override protocols provided by env LHOTSE_MSC_OVERRIDE_PROTOCOLS to msc: msc://bucket/path/to/my/object2
+        2. override the profile/bucket name by env LHOTSE_MSC_PROFILE if provided: msc://profile/path/to/my/object2,
+        if bucket name is not provided, then we expect the msc profile name to match with bucket name
+        """
+
+        import multistorageclient as msc
+
+        # if url prefixed with msc, then return early
+        if identifier.startswith(f"{MSC_PREFIX}://"):
+            return msc.open(identifier, mode)
+
+        # override protocol if provided
+        lhotse_msc_override_protocols = get_lhotse_msc_override_protocols()
+        if lhotse_msc_override_protocols:
+            if "," in lhotse_msc_override_protocols:
+                override_protocol_list = lhotse_msc_override_protocols.split(",")
+            else:
+                override_protocol_list = [lhotse_msc_override_protocols]
+            for override_protocol in override_protocol_list:
+                if identifier.startswith(override_protocol):
+                    identifier = identifier.replace(override_protocol, MSC_PREFIX)
+                    break
+
+        # override bucket if provided
+        lhotse_msc_profile = get_lhotse_msc_profile()
+        if lhotse_msc_profile:
+            identifier = replace_bucket_with_profile_name(identifier, lhotse_msc_profile)
+
+        try:
+            file = msc.open(identifier, mode)
+        except Exception as e:
+            print(f"exception: {e}, identifier: {identifier}")
+            raise e
+
+        return file
+
+
+    @classmethod
+    def is_available(cls) -> bool:
+        return is_module_available("multistorageclient")
+
+    def handles_special_case(self, identifier: Pathlike) -> bool:
+        return str(identifier).startswith(f"{MSC_PREFIX}://")
+
+    def is_applicable(self, identifier: Pathlike) -> bool:
+        return is_valid_url(identifier)
+
 
 class CompositeIOBackend(IOBackend):
     """
@@ -938,6 +1014,8 @@ def get_default_io_backend() -> "IOBackend":
         RedirectIOBackend(),
         PipeIOBackend(),
     ]
+    if MSCIOBackend.is_available():
+        backends.append(MSCIOBackend())
     if AIStoreIOBackend.is_available():
         # Try AIStore before other generalist backends,
         # but only if it's installed and enabled via AIS_ENDPOINT env var.

--- a/lhotse/serialization.py
+++ b/lhotse/serialization.py
@@ -13,7 +13,14 @@ from typing import Any, Dict, Generator, Iterable, List, Optional, Type, Union
 import yaml
 from packaging.version import parse as parse_version
 
-from lhotse.utils import Pathlike, Pipe, SmartOpen, is_module_available, is_valid_url, replace_bucket_with_profile_name
+from lhotse.utils import (
+    Pathlike,
+    Pipe,
+    SmartOpen,
+    is_module_available,
+    is_valid_url,
+    replace_bucket_with_profile_name,
+)
 from lhotse.workarounds import gzip_open_robust
 
 # TODO: figure out how to use some sort of typing stubs
@@ -826,6 +833,7 @@ def get_lhotse_msc_profile() -> Any:
 
 MSC_PREFIX = "msc"
 
+
 class MSCIOBackend(IOBackend):
     """
     Uses Multi-Storage Client to download data from object store.
@@ -850,7 +858,9 @@ class MSCIOBackend(IOBackend):
         if bucket name is not provided, then we expect the msc profile name to match with bucket name
         """
         if not is_module_available("multistorageclient"):
-            raise RuntimeError("Please run 'pip install multi-storage-client' in order to use MSCIOBackend.")
+            raise RuntimeError(
+                "Please run 'pip install multistorageclient' in order to use MSCIOBackend."
+            )
 
         import multistorageclient as msc
 
@@ -873,7 +883,9 @@ class MSCIOBackend(IOBackend):
         # override bucket if provided
         lhotse_msc_profile = get_lhotse_msc_profile()
         if lhotse_msc_profile:
-            identifier = replace_bucket_with_profile_name(identifier, lhotse_msc_profile)
+            identifier = replace_bucket_with_profile_name(
+                identifier, lhotse_msc_profile
+            )
 
         try:
             file = msc.open(identifier, mode)
@@ -882,7 +894,6 @@ class MSCIOBackend(IOBackend):
             raise e
 
         return file
-
 
     @classmethod
     def is_available(cls) -> bool:

--- a/lhotse/utils.py
+++ b/lhotse/utils.py
@@ -32,7 +32,7 @@ from typing import (
     TypeVar,
     Union,
 )
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
 
 import click
 import numpy as np
@@ -1119,3 +1119,9 @@ _LHOTSE_DILL_ENABLED = False
 
 def is_dill_enabled() -> bool:
     return _LHOTSE_DILL_ENABLED or os.environ["LHOTSE_DILL_ENABLED"]
+
+
+def replace_bucket_with_profile_name(identifier, profile_name):
+    parsed_identifier = urlparse(identifier)
+    updated_identifier = parsed_identifier._replace(netloc=profile_name)
+    return urlunparse(updated_identifier)

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -1,7 +1,7 @@
 import os
-from tempfile import NamedTemporaryFile
 import sys
 import types
+from tempfile import NamedTemporaryFile
 
 import pytest
 
@@ -528,17 +528,31 @@ def test_open_pipe_iter(tmp_path):
 @pytest.mark.parametrize(
     "identifier,expected_output,lhotse_msc_profile",
     [
-        ("msc://profile/path/to/object", "msc://profile/path/to/object", "profile"),  # No change for msc:// prefix
-        ("s3://bucket/path/to/object", "msc://bucket/path/to/object", ""),  # Override only protocol
-        ("s3://bucket/path", "msc://profile/path", "profile"),  # Override protocol and bucket
+        (
+            "msc://profile/path/to/object",
+            "msc://profile/path/to/object",
+            "profile",
+        ),  # No change for msc:// prefix
+        (
+            "s3://bucket/path/to/object",
+            "msc://bucket/path/to/object",
+            "",
+        ),  # Override only protocol
+        (
+            "s3://bucket/path",
+            "msc://profile/path",
+            "profile",
+        ),  # Override protocol and bucket
     ],
 )
-def test_msc_io_backend_url_conversion(monkeypatch, identifier, expected_output, lhotse_msc_profile):
+def test_msc_io_backend_url_conversion(
+    monkeypatch, identifier, expected_output, lhotse_msc_profile
+):
     # Mock environment variables
     monkeypatch.setenv("LHOTSE_MSC_OVERRIDE_PROTOCOLS", "s3")
     if lhotse_msc_profile:
         monkeypatch.setenv("LHOTSE_MSC_PROFILE", lhotse_msc_profile)
-    
+
     # Mock multistorageclient.open to capture the transformed URL
     class MockMSC:
         def open(self, url, mode):
@@ -549,7 +563,7 @@ def test_msc_io_backend_url_conversion(monkeypatch, identifier, expected_output,
     mock_module = MockMSC()
     mock_module.__spec__ = types.SimpleNamespace(name="multistorageclient")
     sys.modules["multistorageclient"] = mock_module
-    
+
     # Create backend and test URL transformation
     backend = MSCIOBackend()
     backend.open(identifier, mode="r")
@@ -563,10 +577,10 @@ def test_msc_io_backend_url_conversion(monkeypatch, identifier, expected_output,
     ],
 )
 def test_msc_io_backend_multiple_protocols(monkeypatch, protocols):
-    
+
     # Mock environment variables
     monkeypatch.setenv("LHOTSE_MSC_OVERRIDE_PROTOCOLS", protocols)
-    
+
     # Mock multistorageclient.open to capture the transformed URL
     class MockMSC:
         def open(self, url, mode):
@@ -577,13 +591,13 @@ def test_msc_io_backend_multiple_protocols(monkeypatch, protocols):
     mock_module = MockMSC()
     mock_module.__spec__ = types.SimpleNamespace(name="multistorageclient")
     sys.modules["multistorageclient"] = mock_module
-    
+
     # Create backend and test URL transformation
     backend = MSCIOBackend()
-    
+
     # Test with first protocol
     backend.open("s3://bucket/path", mode="r")
-    
+
     if "," in protocols:
         # Test with second protocol if multiple
         backend.open("gs://bucket/path", mode="r")
@@ -591,14 +605,15 @@ def test_msc_io_backend_multiple_protocols(monkeypatch, protocols):
 
 def test_msc_io_backend_availability(monkeypatch):
     from lhotse.serialization import MSCIOBackend
-    
+
     # Test when multistorageclient is not available
     monkeypatch.setitem(sys.modules, "multistorageclient", None)
     assert not MSCIOBackend.is_available()
-    
+
     # Test when multistorageclient is available
     class MockMSC:
         pass
+
     mock_module = MockMSC()
     mock_module.__spec__ = types.SimpleNamespace(name="multistorageclient")
     monkeypatch.setitem(sys.modules, "multistorageclient", mock_module)

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -20,7 +20,12 @@ from lhotse import (
     store_manifest,
 )
 from lhotse.lazy import LazyJsonlIterator
-from lhotse.serialization import SequentialJsonlWriter, load_manifest_lazy, open_best
+from lhotse.serialization import (
+    MSCIOBackend,
+    SequentialJsonlWriter,
+    load_manifest_lazy,
+    open_best,
+)
 from lhotse.supervision import AlignmentItem
 from lhotse.testing.dummies import DummyManifest
 from lhotse.utils import fastcopy
@@ -537,10 +542,6 @@ def clear_msc_env_caches():
     ],
 )
 def test_msc_io_backend_url_conversion(monkeypatch, clear_msc_env_caches, identifier, expected_output, lhotse_msc_profile):
-    pytest.importorskip("multistorageclient")
-    
-    from lhotse.serialization import MSCIOBackend
-    
     # Mock environment variables
     monkeypatch.setenv("LHOTSE_MSC_OVERRIDE_PROTOCOLS", "s3")
     if lhotse_msc_profile:
@@ -552,7 +553,6 @@ def test_msc_io_backend_url_conversion(monkeypatch, clear_msc_env_caches, identi
             assert url == expected_output
             return None
             
-    import sys
     sys.modules["multistorageclient"] = MockMSC()
     sys.modules["multistorageclient"].__spec__ = None
     
@@ -569,9 +569,6 @@ def test_msc_io_backend_url_conversion(monkeypatch, clear_msc_env_caches, identi
     ],
 )
 def test_msc_io_backend_multiple_protocols(monkeypatch, clear_msc_env_caches, protocols):
-    pytest.importorskip("multistorageclient")
-    
-    from lhotse.serialization import MSCIOBackend
     
     # Mock environment variables
     monkeypatch.setenv("LHOTSE_MSC_OVERRIDE_PROTOCOLS", protocols)
@@ -582,7 +579,6 @@ def test_msc_io_backend_multiple_protocols(monkeypatch, clear_msc_env_caches, pr
             assert url.startswith("msc://")
             return None
             
-    import sys
     sys.modules["multistorageclient"] = MockMSC()
     sys.modules["multistorageclient"].__spec__ = None
     


### PR DESCRIPTION
This PR adds support for the Multi-Storage Client (MSC) backend to handle object storage access in Lhotse. The changes include:

## Features
- New `MSCIOBackend` for handling MSC protocol URLs
- URL transformation from existing protocols (e.g., s3://) to MSC format via 
  - `LHOTSE_MSC_OVERRIDE_PROTOCOLS` env for supported protocols, e.g. `s3://` -> `msc://`
  - `LHOTSE_MSC_PROFILE` env for profile/bucket name overrides, e.g. `msc://my-bucket` -> `msc://my-profile`


## Implementation Details
- Added URL transformation utilities for bucket/profile name handling
- Integrated MSC backend into the default IO backend chain
- Added unit tests for MSC functionality

## Configuration
MSC behavior can be configured through environment variables:
- `LHOTSE_MSC_OVERRIDE_PROTOCOLS`: Comma-separated list of protocols to override (e.g., "s3,gs")
- `LHOTSE_MSC_PROFILE`: Profile name to use for bucket override

## Dependencies
- Requires `multistorageclient` package to be installed