### PR TITLE
fix: add timeout to aistore client initialization

### DIFF
--- a/lhotse/serialization.py
+++ b/lhotse/serialization.py
@@ -81,7 +81,7 @@ def get_aistore_client():
 
     endpoint_url = os.environ["AIS_ENDPOINT"]
     version = parse_version(aistore.__version__)
-    return aistore.Client(endpoint_url), version
+    return aistore.Client(endpoint_url, timeout=(1, 20)), version
 
 
 def save_to_yaml(data: Any, path: Pathlike) -> None:


### PR DESCRIPTION
Currently, the AIStore Client waits indefinitely if the target URL is unreachable or unresponsive.
The connect timeout is 1s as we are in the same VCN. Read timeout is 20s, we might need to increase this later. 