### PR TITLE
fix: add LHOTSE_MSC_BACKEND_FORCED flag to only enfore MSCIOBackend for non-MSC URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Lhotse uses several environment variables to customize it's behavior. They are a
 - `READTHEDOCS` is internally used for documentation builds.
 - `LHOTSE_MSC_OVERRIDE_PROTOCOLS` - when set, it will override your input protocols before feeding to MSCIOBackend.  Useful when you don't want to change your existing url format but want to use MSCIOBackend.  For example, if you have `s3://s3-bucket/path/to/my/object` and `gs://gs-bucket/path/to/my/object`, you can set `LHOTSE_MSC_OVERRIDE_PROTOCOLS=s3,gs` to override the urls to `msc://s3-bucket/path/to/my/object` and `msc://gs-bucket/path/to/my/object`.
 - `LHOTSE_MSC_PROFILE` - when set, it will override the your bucket name before feeding to MSCIOBackend.  Useful when your msc profile is not the same as your bucket name.  For example, if you have `s3://s3-bucket/path/to/my/object`, you can set `LHOTSE_MSC_OVERRIDE_PROTOCOLS=s3` and `LHOTSE_MSC_PROFILE=msc-s3-profile` to override the url to `msc://msc-s3-profile/path/to/my/object`.
+- `LHOTSE_MSC_BACKEND_FORCED` - when set to `True`, forces Lhotse to use MSCIOBackend for all URLs. Use with caution as functionality may break if MSC does not support the provided URL format.
 
 ### Optional dependencies
 

--- a/lhotse/serialization.py
+++ b/lhotse/serialization.py
@@ -826,8 +826,10 @@ class AIStoreIOBackend(IOBackend):
 def get_lhotse_msc_override_protocols() -> Any:
     return os.getenv("LHOTSE_MSC_OVERRIDE_PROTOCOLS", None)
 
+
 def get_lhotse_msc_profile() -> Any:
     return os.getenv("LHOTSE_MSC_PROFILE", None)
+
 
 def get_lhotse_msc_backend_forced() -> Any:
     """
@@ -835,6 +837,7 @@ def get_lhotse_msc_backend_forced() -> Any:
     """
     val = os.getenv("LHOTSE_MSC_BACKEND_FORCED", "False")
     return val.lower() == "true"
+
 
 MSC_PREFIX = "msc"
 
@@ -845,15 +848,15 @@ class MSCIOBackend(IOBackend):
 
     Multi-Storage Client (MSC) is a Python library aims at providing a unified interface to object and file
     storage backends, including S3, GCS, AIStore, and more.  With no code change, user can seamlessly switch
-    between different storage backends with corresponding MSC urls.  
-    
+    between different storage backends with corresponding MSC urls.
+
     To use MSCIOBackend, user will need
-    
-    1) 
-    MSC config file that specifies the storage backend information. Please refer to the MSC documentation 
+
+    1)
+    MSC config file that specifies the storage backend information. Please refer to the MSC documentation
     for more details: https://nvidia.github.io/multi-storage-client/user_guide/quickstart.html#configuration
 
-    2) 
+    2)
     Provide MSC URLs, OR
     Set env `LHOTSE_MSC_BACKEND_FORCED` to True to force the use of MSC backend for regular URLs.
 
@@ -918,13 +921,13 @@ class MSCIOBackend(IOBackend):
     def is_applicable(self, identifier: Pathlike) -> bool:
         return is_module_available("multistorageclient") and (
             MSCIOBackend.is_msc_url(identifier)
-            or 
-            (get_lhotse_msc_backend_forced() and is_valid_url(identifier))
+            or (get_lhotse_msc_backend_forced() and is_valid_url(identifier))
         )
 
     @staticmethod
     def is_msc_url(identifier: Any) -> bool:
         return str(identifier).startswith(f"{MSC_PREFIX}://")
+
 
 class CompositeIOBackend(IOBackend):
     """

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -629,24 +629,24 @@ def test_msc_io_backend_is_applicable(monkeypatch):
 
     mock_module = MockMSC()
     mock_module.__spec__ = types.SimpleNamespace(name="multistorageclient")
-    
+
     # Test 1: When multistorageclient is not available
     monkeypatch.setitem(sys.modules, "multistorageclient", None)
     backend = MSCIOBackend()
     assert not backend.is_applicable("msc://profile/path/to/object")
     assert not backend.is_applicable("s3://bucket/path")
-    
+
     # Test 2: When multistorageclient is available
     monkeypatch.setitem(sys.modules, "multistorageclient", mock_module)
     backend = MSCIOBackend()
-    
+
     # Test 2.1: MSC URL is always applicable
     assert backend.is_applicable("msc://profile/path/to/object")
-    
+
     # Test 2.2: Non-MSC URL with forced backend
     monkeypatch.setenv("LHOTSE_MSC_BACKEND_FORCED", "true")
     assert backend.is_applicable("s3://bucket/path")
-    
+
     # Test 2.3: Non-MSC URL without forced backend
     monkeypatch.setenv("LHOTSE_MSC_BACKEND_FORCED", "")
     assert not backend.is_applicable("s3://bucket/path")


### PR DESCRIPTION
- Added `LHOTSE_MSC_BACKEND_FORCED `environment variable to force MSC for all URLs only when requested
- Modified is_applicable() to be more constrainted