### PR TITLE
Add optional params to specify target split sizes in number of hours in ReazonSpeech recipe.

### DIFF
--- a/lhotse/bin/modes/recipes/reazonspeech.py
+++ b/lhotse/bin/modes/recipes/reazonspeech.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List
+from typing import List, Optional
 
 import click
 
@@ -24,14 +24,46 @@ __all__ = ["reazonspeech"]
     default=1,
     help="How many threads to use (can give good speed-ups with slow disks).",
 )
+@click.option(
+    "--train-hours",
+    type=float,
+    default=None,
+    help="Optional: Target number of hours for the training set. If specified, "
+         "the dataset will be split by duration instead of fixed counts. "
+         "Requires --dev-hours and/or --test-hours to also be specified for splitting.",
+)
+@click.option(
+    "--dev-hours",
+    type=float,
+    default=None,
+    help="Optional: Target number of hours for the development set. If specified, "
+         "the dataset will be split by duration instead of fixed counts.",
+)
+@click.option(
+    "--test-hours",
+    type=float,
+    default=None,
+    help="Optional: Target number of hours for the test set. If specified, "
+         "the dataset will be split by duration instead of fixed counts.",
+)
 def reazonspeech(
     corpus_dir: Pathlike,
     output_dir: Pathlike,
     num_jobs: int,
+    train_hours: Optional[float],
+    dev_hours: Optional[float],
+    test_hours: Optional[float],
 ):
     """ReazonSpeech ASR data preparation."""
     logging.basicConfig(level=logging.INFO)
-    prepare_reazonspeech(corpus_dir, output_dir=output_dir, num_jobs=num_jobs)
+    prepare_reazonspeech(
+        corpus_dir,
+        output_dir=output_dir,
+        num_jobs=num_jobs,
+        train_hours=train_hours,
+        dev_hours=dev_hours,
+        test_hours=test_hours,
+    )
 
 
 @download.command(context_settings=dict(show_default=True))

--- a/lhotse/recipes/reazonspeech.py
+++ b/lhotse/recipes/reazonspeech.py
@@ -14,6 +14,7 @@ import re
 from collections import defaultdict
 from pathlib import Path
 from typing import Any, Dict, Optional, Sequence, Tuple, Union
+import random
 
 from tqdm.auto import tqdm
 
@@ -140,6 +141,9 @@ def prepare_reazonspeech(
     corpus_dir: Pathlike,
     output_dir: Optional[Pathlike],
     num_jobs: int = 1,
+    train_hours: Optional[float] = None,
+    dev_hours: Optional[float] = None,
+    test_hours: Optional[float] = None,
 ) -> Dict[str, Dict[str, Union[RecordingSet, SupervisionSet]]]:
     """
     Returns the manifests which consist of the Recordings and Supervisions.
@@ -147,21 +151,70 @@ def prepare_reazonspeech(
     :param corpus_dir: Pathlike, the path of the data dir.
     :param output_dir: Pathlike, the path where to write the manifests.
     :param num_jobs: int, number of parallel threads used for 'parse_utterance' calls.
+    :param train_hours: Optional[float], target number of hours for the training set.
+    :param dev_hours: Optional[float], target number of hours for the development set.
+    :param test_hours: Optional[float], target number of hours for the test set.
     :return: a Dict whose key is the dataset part, and the value is Dicts with the keys 'audio' and 'supervisions'.
     """
     corpus_dir = Path(corpus_dir)
     assert corpus_dir.is_dir(), f"No such directory: {corpus_dir}"
 
-    # Split the dataset into train, dev, and test
     with open(corpus_dir / "dataset.json", "r", encoding="utf-8") as file:
-        full = json.load(file)
-        dev = full[:1000]
-        test = full[1000:1100]
-        train = full[1100:]
+        full_dataset = json.load(file)
 
-        write_to_json(train, corpus_dir / "train.json")
-        write_to_json(dev, corpus_dir / "dev.json")
-        write_to_json(test, corpus_dir / "test.json")
+    train = []
+    dev = []
+    test = []
+
+    # Determine if hour-based splitting is requested
+    if train_hours is not None or dev_hours is not None or test_hours is not None:
+        logging.info(f"Splitting dataset by duration: Train target {train_hours or 'inf'}h, Dev target {dev_hours or 'inf'}h, Test target {test_hours or 'inf'}h")
+        random.seed(42) # For reproducibility
+        random.shuffle(full_dataset)
+
+        current_train_duration = 0.0
+        current_dev_duration = 0.0
+        current_test_duration = 0.0
+
+        # Convert hours to seconds. Use float('inf') if None.
+        train_target_seconds = train_hours * 3600 if train_hours is not None else float('inf')
+        dev_target_seconds = dev_hours * 3600 if dev_hours is not None else float('inf')
+        test_target_seconds = test_hours * 3600 if test_hours is not None else float('inf')
+
+        for item in full_dataset:
+            duration = item.get("duration", 0.0)
+            if duration == 0.0:
+                logging.warning(f"Skipping item with zero duration: {item.get('id', 'N/A')}")
+                continue
+
+            # Prioritize dev and test to ensure they get their target sizes
+            if current_dev_duration < dev_target_seconds:
+                dev.append(item)
+                current_dev_duration += duration
+            elif current_test_duration < test_target_seconds:
+                test.append(item)
+                current_test_duration += duration
+            elif current_train_duration < train_target_seconds:
+                train.append(item)
+                current_train_duration += duration
+            else:
+                # If all finite targets are met, remaining data is not used for any split.
+                pass
+
+        logging.info(f"Actual train duration: {current_train_duration / 3600:.2f}h ({len(train)} samples)")
+        logging.info(f"Actual dev duration: {current_dev_duration / 3600:.2f}h ({len(dev)} samples)")
+        logging.info(f"Actual test duration: {current_test_duration / 3600:.2f}h ({len(test)} samples)")
+
+    else:
+        logging.info("No specific hours provided for splitting. Using default fixed-count split.")
+        # Original fixed-count splitting logic
+        dev = full_dataset[:1000]
+        test = full_dataset[1000:1100]
+        train = full_dataset[1100:]
+
+    write_to_json(train, corpus_dir / "train.json")
+    write_to_json(dev, corpus_dir / "dev.json")
+    write_to_json(test, corpus_dir / "test.json")
 
     parts = ("train", "dev", "test")
 
@@ -182,49 +235,90 @@ def prepare_reazonspeech(
             part=part, output_dir=output_dir, prefix="reazonspeech", suffix="jsonl.gz"
         ):
             logging.info(f"ReazonSpeech subset: {part} already prepared - skipping.")
+            # Ensure manifests dict is populated even if skipped
+            manifests[part] = {
+                "recordings": RecordingSet.from_jsonl_lazy(output_dir / f"reazonspeech_recordings_{part}.jsonl.gz"),
+                "supervisions": SupervisionSet.from_jsonl_lazy(output_dir / f"reazonspeech_supervisions_{part}.jsonl.gz"),
+                "cuts": CutSet.from_jsonl_lazy(output_dir / f"reazonspeech_cuts_{part}.jsonl.gz"),
+            }
             continue
 
         filename = corpus_dir / f"{part}.json"
+        if not filename.is_file() or Path(filename).stat().st_size == 0:
+            logging.warning(f"Split file {filename} is missing or empty. Skipping manifest generation for {part}.")
+            manifests[part] = {
+                "recordings": RecordingSet.from_recordings([]),
+                "supervisions": SupervisionSet.from_segments([]),
+                "cuts": CutSet.from_cuts([]),
+            }
+            continue
+
         with open(filename, "r", encoding="utf-8") as file:
             items = json.load(file)
 
-        with RecordingSet.open_writer(
-            output_dir / f"reazonspeech_recordings_{part}.jsonl.gz"
-        ) as rec_writer, SupervisionSet.open_writer(
-            output_dir / f"reazonspeech_supervisions_{part}.jsonl.gz"
-        ) as sup_writer, CutSet.open_writer(
-            output_dir / f"reazonspeech_cuts_{part}.jsonl.gz"
-        ) as cut_writer:
-            for recording, segment in tqdm(
-                parallel_map(
-                    parse_utterance,
-                    items,
-                    num_jobs=num_jobs,
-                ),
-                desc="Processing reazonspeech JSON entries",
-            ):
-                # Fix and validate the recording + supervisions
-                recordings, segments = fix_manifests(
-                    recordings=RecordingSet.from_recordings([recording]),
-                    supervisions=SupervisionSet.from_segments([segment]),
-                )
-                validate_recordings_and_supervisions(
-                    recordings=recordings, supervisions=segments
-                )
-                # Create the cut since most users will need it anyway.
-                # There will be exactly one cut since there's exactly one recording.
-                cuts = CutSet.from_manifests(
-                    recordings=recordings, supervisions=segments
-                )
-                # Write the manifests
-                rec_writer.write(recordings[0])
-                sup_writer.write(segments[0])
-                cut_writer.write(cuts[0])
+        if not items:
+            logging.info(f"No items in {filename}. Skipping manifest generation for {part}.")
+            manifests[part] = {
+                "recordings": RecordingSet.from_recordings([]),
+                "supervisions": SupervisionSet.from_segments([]),
+                "cuts": CutSet.from_cuts([]),
+            }
+            continue
+
+        # Collect all results first from parallel_map
+        all_recordings = []
+        all_supervisions = []
+        all_cuts = []
+
+        for result in tqdm(
+            parallel_map(
+                parse_utterance,
+                items,
+                num_jobs=num_jobs,
+            ),
+            desc=f"Processing reazonspeech JSON entries for {part}",
+            total=len(items)
+        ):
+            if result is None:
+                continue
+            recording, segment = result
+
+            # Fix and validate the recording + supervisions
+            recordings, segments = fix_manifests(
+                recordings=RecordingSet.from_recordings([recording]),
+                supervisions=SupervisionSet.from_segments([segment]),
+            )
+            validate_recordings_and_supervisions(
+                recordings=recordings, supervisions=segments
+            )
+            cuts = CutSet.from_manifests(
+                recordings=recordings, supervisions=segments
+            )
+            all_recordings.append(recordings[0])
+            all_supervisions.append(segments[0])
+            all_cuts.append(cuts[0])
+
+        rec_writer_path = output_dir / f"reazonspeech_recordings_{part}.jsonl.gz"
+        sup_writer_path = output_dir / f"reazonspeech_supervisions_{part}.jsonl.gz"
+        cut_writer_path = output_dir / f"reazonspeech_cuts_{part}.jsonl.gz"
+
+        # Write all collected manifests at once
+        if all_recordings: # Check if there's anything to write
+            RecordingSet.from_recordings(all_recordings).to_jsonl(rec_writer_path)
+            SupervisionSet.from_segments(all_supervisions).to_jsonl(sup_writer_path)
+            CutSet.from_cuts(all_cuts).to_jsonl(cut_writer_path)
+            logging.info(f"Successfully processed and wrote {len(all_recordings)} samples for {part}.")
+        else:
+            # If no recordings, ensure empty files are created or handled
+            logging.warning(f"No valid items processed for {part}. Creating empty manifests.")
+            RecordingSet.from_recordings([]).to_jsonl(rec_writer_path)
+            SupervisionSet.from_segments([]).to_jsonl(sup_writer_path)
+            CutSet.from_cuts([]).to_jsonl(cut_writer_path)
 
         manifests[part] = {
-            "recordings": RecordingSet.from_jsonl_lazy(rec_writer.path),
-            "supervisions": SupervisionSet.from_jsonl_lazy(sup_writer.path),
-            "cuts": CutSet.from_jsonl_lazy(cut_writer.path),
+            "recordings": RecordingSet.from_jsonl_lazy(rec_writer_path),
+            "supervisions": SupervisionSet.from_jsonl_lazy(sup_writer_path),
+            "cuts": CutSet.from_jsonl_lazy(cut_writer_path),
         }
 
     return dict(manifests)
@@ -236,7 +330,13 @@ def parse_utterance(item: Any) -> Optional[Tuple[Recording, SupervisionSegment]]
     :param item: The utterance to process.
     :return: A tuple containing the Recording and SupervisionSegment.
     """
-    recording = Recording.from_file(item["audio_filepath"], recording_id=item["id"])
+    # Ensure audio_filepath exists and is valid
+    audio_path = Path(item["audio_filepath"])
+    if not audio_path.is_file():
+        logging.warning(f"Audio file not found: {audio_path}. Skipping utterance {item.get('id', 'N/A')}")
+        return None
+
+    recording = Recording.from_file(str(audio_path), recording_id=item["id"])
     segments = SupervisionSegment(
         id=item["id"],
         recording_id=item["id"],


### PR DESCRIPTION
Adds optional parameters to specify target split sizes by number of hours in the ReazonSpeech prepare recipe.

The user can now optionally specify target hours by command line, like so:

```
lhotse prepare reazonspeech \
  -j $nj \
  --train-hours 100 \
  --dev-hours 2 \
  --test-hours 2 \
  $dl_dir/ReazonSpeech data/manifests
```