### PR TITLE
Grid recipe fix

### DIFF
--- a/lhotse/recipes/grid.py
+++ b/lhotse/recipes/grid.py
@@ -23,8 +23,11 @@ from lhotse import (
 )
 from lhotse.supervision import AlignmentItem, SupervisionSegment
 from lhotse.utils import Pathlike, is_module_available
+import os
+import shutil
 
 GRID_ZENODO_ID = "10.5281/zenodo.3625687"
+
 
 
 def download_grid(
@@ -48,8 +51,8 @@ def download_grid(
         raise RuntimeError(
             "To download Grid Audio-Visual Speech Corpus please 'pip install zenodo_get'."
         )
-    target_dir = Path(target_dir)
-    corpus_dir = target_dir / "grid-corpus"
+        
+    corpus_dir = Path(target_dir)
     corpus_dir.mkdir(parents=True, exist_ok=True)
 
     download_marker = corpus_dir / ".downloaded"
@@ -62,7 +65,43 @@ def download_grid(
     for p in tqdm(corpus_dir.glob("*.zip"), desc="Unzipping files"):
         with zipfile.ZipFile(p) as f:
             f.extractall(corpus_dir)
+        
+    # Speaker mapping to fix mis-assigned alignment data
+    speaker_fix_map = {
+        's1': 's1', 's2': 's2', 's3': 's3', 's4': 's4',
+        's5': 's6', 's6': 's5', 's7': 's7', 's8': 's8',
+        's9': 's9', 's10': 's13', 's11': 's10', 's12': 's11',
+        's13': 's12', 's14': 's15', 's15': 's14', 's16': 's16',
+        's17': 's17', 's18': 's19', 's19': 's18', 's20': 's21',
+        's22': 's23', 's23': 's22', 's24': 's24', 's25': 's25',
+        's26': 's27', 's27': 's26', 's28': 's29', 's29': 's28',
+        's30': 's30', 's31': 's31', 's32': 's33', 's33': 's32',
+        's34': 's34',        
+    }
+    
+    #Downloaded alignment folder 
+    input_dir = corpus_dir / "alignments"
+    #temporary folder to contain the corrected alignments
+    temp_dir = corpus_dir / "tmp_alignments"
 
+    os.makedirs(temp_dir, exist_ok=True)
+
+    for source_folder, target_speaker in speaker_fix_map.items():
+        src_path = os.path.join(input_dir, source_folder)
+        tgt_path = os.path.join(temp_dir, target_speaker)
+        
+        if not os.path.exists(src_path):
+            print(f"Source folder does not exist: {src_path}")
+            continue
+        
+        if os.path.exists(tgt_path):
+            shutil.rmtree(tgt_path)
+        
+        shutil.copytree(src_path, tgt_path)
+        print(f"Copied entire folder from {source_folder} to {target_speaker}")
+    shutil.rmtree(input_dir)
+    os.rename(temp_dir, input_dir)
+ 
     return corpus_dir
 
 


### PR DESCRIPTION
- I noticed that the Grid corpus alignment folders downloaded from Zenodo were disorganized. To address this, I used a mapping to assign each alignment folder to the correct speaker.

- For audio processing, I recommend extracting audio directly from the video files, as the separately provided audio tracks are shorter than  the video duration. To avoid errors during processing, the audio is also converted to mono.