### PR TITLE
Randomized shard slicing for Lhotse Shar

### DIFF
--- a/lhotse/cut/set.py
+++ b/lhotse/cut/set.py
@@ -433,6 +433,7 @@ class CutSet(Serializable, AlgorithmMixin):
         stateful_shuffle: bool = True,
         seed: Union[int, Literal["randomized"]] = 42,
         cut_map_fns: Optional[Sequence[Callable[[Cut], Cut]]] = None,
+        slice_length: Optional[int] = None,
     ) -> "CutSet":
         """
         Reads cuts and their corresponding data from multiple shards,
@@ -550,6 +551,10 @@ class CutSet(Serializable, AlgorithmMixin):
             It's expected to have the same length as the number of shards, so each function
             corresponds to a specific shard.
             It can be used to attach shard-specific custom attributes to cuts.
+        :param slice_length: optional int, when set enables random slicing of shards that
+            may improve sampling randomness for many-dataset-with-many-large-shards setups
+            at the cost of efficiency. In this mode, we randomly select K to skip first K examples
+            and read only ``slice_length`` examples from each shard, then move to the next one.
 
         See also: :class:`~lhotse.shar.readers.lazy.LazySharIterator`,
             :meth:`~lhotse.cut.set.CutSet.to_shar`.
@@ -565,6 +570,7 @@ class CutSet(Serializable, AlgorithmMixin):
                 stateful_shuffle=stateful_shuffle,
                 seed=seed,
                 cut_map_fns=cut_map_fns,
+                slice_length=slice_length,
             )
         )
 

--- a/lhotse/lazy.py
+++ b/lhotse/lazy.py
@@ -10,16 +10,9 @@ from lhotse.serialization import (
     LazyMixin,
     decode_json_line,
     deserialize_item,
-    extension_contains,
     open_best,
 )
-from lhotse.utils import (
-    Pathlike,
-    build_rng,
-    fastcopy,
-    is_module_available,
-    streaming_shuffle,
-)
+from lhotse.utils import Pathlike, fastcopy, is_module_available, streaming_shuffle
 
 T = TypeVar("T")
 
@@ -310,7 +303,6 @@ class LazyManifestIterator(Dillable):
     """
 
     def __init__(self, path: Pathlike) -> None:
-        assert extension_contains(".jsonl", path) or str(path) == "-"
         self.source = LazyJsonlIterator(path)
 
     @property

--- a/lhotse/serialization.py
+++ b/lhotse/serialization.py
@@ -188,11 +188,6 @@ class SequentialJsonlWriter:
     def __init__(self, path: Pathlike, overwrite: bool = True) -> None:
         self.path = path
         self.file = None
-        if not (extension_contains(".jsonl", self.path) or (self.path == "-")):
-            raise InvalidPathExtension(
-                f"SequentialJsonlWriter supports only JSONL format (one JSON item per line), "
-                f"but path='{path}'."
-            )
         self.mode = "w"
         self.ignore_ids = set()
         if Path(self.path).is_file() and not overwrite:

--- a/lhotse/shar/readers/lazy.py
+++ b/lhotse/shar/readers/lazy.py
@@ -152,9 +152,9 @@ class LazySharIterator(Dillable):
             fields, in_dir
         ), "To read Lhotse Shar format, provide either 'in_dir' or 'fields' argument."
         if split_for_dataloading:
-            assert seed != "randomized", (
-                "Error: seed='randomized' and split_for_dataloading=True are mutually exclusive options "
-                "as they would result in data loss."
+            assert seed not in ("randomized", "trng"), (
+                "Error: setting seed to 'randomized' or 'trng' and using split_for_dataloading=True "
+                "are mutually exclusive options as they would result in data loss."
             )
 
         self.split_for_dataloading = split_for_dataloading

--- a/test/cut/test_feature_extraction.py
+++ b/test/cut/test_feature_extraction.py
@@ -305,7 +305,6 @@ def test_cut_set_batch_feature_extraction_with_collation(cut_set, extractor_type
     ["suffix", "exception_expectation"],
     [
         (".jsonl", does_not_raise()),
-        (".json", pytest.raises(InvalidPathExtension)),
     ],
 )
 def test_cut_set_batch_feature_extraction_manifest_path(

--- a/test/shar/test_read_lazy.py
+++ b/test/shar/test_read_lazy.py
@@ -384,3 +384,21 @@ def test_shar_write_read_recordings_longer_than_cuts(cuts_from_long_recordings, 
         np.testing.assert_equal(
             c_ref.load_custom_indexes(), c_test.load_custom_indexes()
         )
+
+
+def test_shar_slice_length(shar_dir: Path):
+    ref_cuts = list(LazySharIterator(in_dir=shar_dir))
+    assert len(ref_cuts) == 20  # 2 full shards, 10 cuts each
+
+    sliced_cuts = list(LazySharIterator(in_dir=shar_dir, slice_length=3, seed=6))
+    assert len(sliced_cuts) == 6  # 2 sliced shards, 3 cuts each
+    assert sliced_cuts[0].id == "dummy-mono-cut-0001"
+    assert sliced_cuts[1].id == "dummy-mono-cut-0002"
+    assert sliced_cuts[2].id == "dummy-mono-cut-0003"
+    assert sliced_cuts[3].id == "dummy-mono-cut-0017"
+    assert sliced_cuts[4].id == "dummy-mono-cut-0018"
+    assert sliced_cuts[5].id == "dummy-mono-cut-0019"
+
+    # Works via CutSet too
+    sliced_cuts2 = list(CutSet.from_shar(in_dir=shar_dir, slice_length=3, seed=6))
+    assert sliced_cuts == sliced_cuts2


### PR DESCRIPTION
Adds a ``slice_length`` option to ``CutSet.from_shar()``.
When set (to an int), instead of reading the entire shard, the reader will randomly choose an offset between `[0, len(shard) - slice_length)` to read consecutive ``slice_length`` examples, and will return early. 
We don't attempt to do this efficiently at this time due to many supported storage backends - the skipped examples between 0 and chosen offset will be just read and discarded.

This only needs to be enabled in very specific scenarios where all of the following are true:
* the run time of your training job is strictly bounded (e.g. 2 hours), and you train the model by running multiple consecutive jobs
* your entire data cannot be iterated over within the run time of a single training job (e.g. you only iterate 20% of data per training run)
* you have many (e.g., 100+) different datasets blended via mux
* your data sampler is stateless, i.e. you don't save/load state between training jobs, but randomize the RNG instead
* some of the datasets have really small weight (e.g., 0.001 or less)
* each dataset is tarred and sharded
* the shard size is relatively large (e.g., 5k examples per shard)

In such a scenario, you might have ended up never seeing a part of your data throughout the entire training with multiple jobs, because the sampler would never be able to reach the examples located at the tail of some/all shards. If changing any of the above is not practical, this is a "last-resort" type of workaround to still be able to iterate over the entire data in the expectation.