### PR TITLE
Allow up to half a second of duration mismatch between audio and manifest

### DIFF
--- a/lhotse/audio/utils.py
+++ b/lhotse/audio/utils.py
@@ -8,7 +8,7 @@ from typing import Callable, Optional
 
 from lhotse.utils import NonPositiveEnergyError, Seconds, fastcopy, suppress_and_warn
 
-_DEFAULT_LHOTSE_AUDIO_DURATION_MISMATCH_TOLERANCE: Seconds = 0.025
+_DEFAULT_LHOTSE_AUDIO_DURATION_MISMATCH_TOLERANCE: Seconds = 0.5
 _LHOTSE_AUDIO_DURATION_MISMATCH_TOLERANCE: Seconds = (
     _DEFAULT_LHOTSE_AUDIO_DURATION_MISMATCH_TOLERANCE
 )


### PR DESCRIPTION
People are running into MP3 issues too often and it's annoying.