### PR TITLE
fix not enough data on the first training iteration

### DIFF
--- a/lhotse/dataset/sampling/dynamic_bucketing.py
+++ b/lhotse/dataset/sampling/dynamic_bucketing.py
@@ -760,6 +760,14 @@ class DynamicBucketer:
         self._producer_thread = threading.Thread(target=producer)
         self._producer_thread.start()
 
+        # wait until at least one bucket in buffer is ready to form a complete batch
+        # or all datasource is exhausted!
+        while True:
+            time.sleep(1.0)
+            for b in self.buckets:
+                if self._source_exhausted or self._is_ready(b):
+                    return
+
     def _maybe_wait_for_producer(self):
         """Triggers wait for producer if the bucket buffers are less than 10% utilized."""
         while (


### PR DESCRIPTION
As I mentioned in [#1459](https://github.com/lhotse-speech/lhotse/issues/1459#issuecomment-2975066997), when using drop_last with concurrent_bucketing, the data iterator sometimes starts **_without any of the buckets having enough data_** and the StopIteration() is raised outside the producer thread.

The PR #1487 fixes the `TypeError: 'NoneType' object is not an iterator`; however, it does not solve the ___not enough data problem on the first iteration___ (which is the root of the problem), and the iteration will be forced to stop, forcing a new epoch to start immediately, and this may repeat many times.

To solve this problem, this PR waits until there is at least one bucket ready for a complete batch or all sources are exhausted after creating a data producer thread. This will allow us to start training without the need for a large buffer size.