### PR TITLE
Extract prompts from alignments option

### DIFF
--- a/lhotse/bin/modes/cut.py
+++ b/lhotse/bin/modes/cut.py
@@ -173,6 +173,12 @@ def trim_to_supervisions(
     help="""If ``True``, the output cut will have the same channels as the input cut. By default,
             the trimmed cut will have the same channels as the supervision.""",
 )
+@click.option(
+    "--get-all-segments",
+    type=bool,
+    default=True,
+    help="If ``True``, all segments will be returned. If ``False``, only the first segment will be returned.",
+)
 def trim_to_alignments(
     cuts: Pathlike,
     output_cuts: Pathlike,
@@ -180,6 +186,7 @@ def trim_to_alignments(
     max_pause: float,
     delimiter: str,
     keep_all_channels: bool,
+    get_all_segments: bool,
 ):
     """
     Return a new CutSet with Cuts that have identical spans as the alignments of
@@ -199,6 +206,7 @@ def trim_to_alignments(
             max_pause=max_pause,
             delimiter=delimiter,
             keep_all_channels=keep_all_channels,
+            get_all_segments=get_all_segments,
         ):
             writer.write(cut)
 

--- a/lhotse/custom.py
+++ b/lhotse/custom.py
@@ -115,11 +115,15 @@ class CustomFieldMixin:
             # TemporalArray supports slicing.
             return value.load(start=self.start, duration=self.duration)
         elif isinstance(value, Recording):
-            # Recording supports slicing.
-            # Note: cut.channels referes to cut.recording and not the custom field.
+            # Note: cut.channels refers to cut.recording and not the custom field.
             # We have to use a special channel selector field instead; e.g.:
             # if this is "target_recording", we'll look for "target_recording_channel_selector"
             channels = self.custom.get(f"{name}_channel_selector")
+            # By default, the custom Recording is assumed to be in alignment with cut.recording,
+            # i.e. has the same duration. That means slicing cut.recording should also slice the custom Recording.
+            # If this is not desired, set cut.custom[f"{name}_unaligned]" = True to always load the entire thing.
+            if self.custom.get(f"{name}_unaligned", False):
+                return value.load_audio(channels=channels)
             return value.load_audio(
                 channels=channels, offset=self.start, duration=self.duration
             )

--- a/lhotse/cut/base.py
+++ b/lhotse/cut/base.py
@@ -578,6 +578,7 @@ class Cut:
         :param keep_all_channels: If ``True``, the output cut will have the same channels as the input cut. By default,
             the trimmed cut will have the same channels as the supervision.
         :param num_jobs: Number of parallel workers to process the cuts.
+        :param get_all_segments: If ``True``, all segments will be returned. If ``False``, only the segment with the longest duration will be returned.
         :return: a CutSet object.
         """
         from lhotse.supervision import AlignmentItem
@@ -630,6 +631,7 @@ class Cut:
                 else:
                     merged_alignments.append((item, [i + 1]))
             if not get_all_segments:
+                merged_alignments.sort(key=lambda x: x[0].duration, reverse=True)
                 merged_alignments = [merged_alignments[0]]
 
             # Create new supervisions for the merged alignments.

--- a/lhotse/cut/mixed.py
+++ b/lhotse/cut/mixed.py
@@ -337,7 +337,7 @@ class MixedCut(Cut):
             non_padding_idx,
             mono_cut,
         ) = self._assert_one_data_cut_with_attr_and_return_it_with_track_index(name)
-
+        
         # Use getattr to propagate AttributeError if "name" is not defined.
         manifest = getattr(mono_cut, name)
 

--- a/lhotse/cut/set.py
+++ b/lhotse/cut/set.py
@@ -1100,6 +1100,7 @@ class CutSet(Serializable, AlgorithmMixin):
         delimiter: str = " ",
         keep_all_channels: bool = False,
         num_jobs: int = 1,
+        get_all_segments: bool = True,
     ) -> "CutSet":
         """
         Return a new CutSet with Cuts that have identical spans as the alignments of
@@ -1117,9 +1118,9 @@ class CutSet(Serializable, AlgorithmMixin):
         :param keep_all_channels: If ``True``, the output cut will have the same channels as the input cut. By default,
             the trimmed cut will have the same channels as the supervision.
         :param num_jobs: Number of parallel workers to process the cuts.
+        :param get_all_segments: If ``True``, all segments will be returned. If ``False``, only the first segment will be returned.
         :return: a ``CutSet``.
         """
-
         if num_jobs == 1:
             return CutSet(
                 LazyFlattener(
@@ -1132,6 +1133,7 @@ class CutSet(Serializable, AlgorithmMixin):
                             max_segment_duration=max_segment_duration,
                             delimiter=delimiter,
                             keep_all_channels=keep_all_channels,
+                            get_all_segments=get_all_segments,
                         ),
                     )
                 )
@@ -1148,6 +1150,7 @@ class CutSet(Serializable, AlgorithmMixin):
             max_segment_duration=max_segment_duration,
             delimiter=delimiter,
             keep_all_channels=keep_all_channels,
+            get_all_segments=get_all_segments,
         )
         return result
 
@@ -3449,13 +3452,16 @@ def _trim_to_alignments_single(
     max_segment_duration,
     delimiter,
     keep_all_channels,
+    get_all_segments,
 ) -> CutSet:
+    
     return cuts.trim_to_alignments(
         type=type,
         max_pause=max_pause,
         max_segment_duration=max_segment_duration,
         delimiter=delimiter,
         keep_all_channels=keep_all_channels,
+        get_all_segments=get_all_segments,
     ).to_eager()
 
 

--- a/lhotse/dataset/collation.py
+++ b/lhotse/dataset/collation.py
@@ -185,12 +185,17 @@ def collate_audio(
             num_samples = cut.num_samples
         else:
             num_samples = compute_num_samples(
-                cut.duration, sampling_rate=getattr(cut, recording_field).sampling_rate
+                getattr(cut, recording_field).duration, sampling_rate=getattr(cut, recording_field).sampling_rate
             )
         sample_counts.append(num_samples)
 
+    if recording_field is None:
+        pad_dur = max(cut.duration for cut in cuts)
+    else:
+        pad_dur = max(getattr(cut, recording_field).duration for cut in cuts)
+
     cuts = cuts.pad(
-        duration=max(cut.duration for cut in cuts),
+        duration=pad_dur,
         direction=pad_direction,
         preserve_id=True,
     )

--- a/lhotse/shar/writers/shar.py
+++ b/lhotse/shar/writers/shar.py
@@ -172,6 +172,7 @@ class SharWriter:
         for key in self.fields:
 
             # Skip fields already taken care of.
+            # Amir: added target_recording
             if key in ["recording", "features"]:
                 continue
 
@@ -184,6 +185,7 @@ class SharWriter:
                     ), f"Expected writer type 'jsonl' (got '{self.fields[key]}') for non-data field '{key}'."
                     self.writers[key].write({"cut_id": cut.id, key: val})
                 else:
+                    
                     data = cut.load_custom(key)
                     placeholder_obj = to_shar_placeholder(val, cut)
                     channel_selector_key = f"{key}_channel_selector"


### PR DESCRIPTION
This branch adds option to get single  segment from `trim_to_alignment`:

```
    # Trim cuts to alignments and get the first segment
    cuts_prompt = cuts.trim_to_alignments(type="word",
                                        max_pause=max_pause,
                                        max_segment_duration=max_segment_duration,
                                        get_all_segments=False)
```