### PR TITLE
fix: resolve AttributeError in DynamicBucketer

### DIFF
--- a/lhotse/dataset/sampling/dynamic_bucketing.py
+++ b/lhotse/dataset/sampling/dynamic_bucketing.py
@@ -576,12 +576,14 @@ class DynamicBucketer:
         self.buckets: List[Queue] = [Queue() for _ in range(len(duration_bins) + 1)]
 
         self._producer_thread = None
+        self._source_exhausted = False
 
     def __iter__(self) -> Generator[CutSet, None, None]:
         # Init: sample `buffer_size` cuts and assign them to the right buckets.
         self.cuts_iter = iter(self.cuts)
 
         if self.concurrent:
+            self._source_exhausted = False
             self._start_data_producer_thread()
             self._maybe_wait_for_producer()
         else:
@@ -743,7 +745,6 @@ class DynamicBucketer:
 
         def producer():
             try:
-                self._source_exhausted = False
                 while not self._source_exhausted:
                     if sum(b.qsize() for b in self.buckets) == self.buffer_size:
                         time.sleep(0.1)


### PR DESCRIPTION
Fixes #1522

- Add `_source_exhausted` initialization in `__init__()`
- Reset flag in `__iter__()` for sampler reuse
- Remove redundant initialization from producer thread

Prevents AttributeError when main thread accesses the attribute before producer thread initializes it in multi-process DataLoader environments.