### PR TITLE
avoid bug appearing with OnTheFlyFeatures and PerturbVolume cut_transform

### DIFF
--- a/lhotse/dataset/cut_transforms/perturb_volume.py
+++ b/lhotse/dataset/cut_transforms/perturb_volume.py
@@ -28,13 +28,16 @@ class PerturbVolume:
 
     def __call__(self, cuts: CutSet) -> CutSet:
         if self.random is None:
-            self.random = random
+            self.random = random.Random()
         return CutSet.from_cuts(
             cut.perturb_volume(
-                factor=self.random.uniform(self.scale_low, self.scale_high),
+                factor=self._uniform(self.scale_low, self.scale_high),
                 affix_id=not self.preserve_id,
             )
             if self.random.random() <= self.p
             else cut
             for cut in cuts
         )
+
+    def _uniform(self, low: float, high: float) -> float:
+        return low + self.random.random() * (high - low)


### PR DESCRIPTION
the error appeared when training on 4 GPUs with 6 workers per GPU

```
File "/mnt/matylda5/iveselyk/ASR_TOOLKITS/K2_SHERPA_PYTORCH24_CUDA121/K2_CONDA_ENVIRONMENT/lib/python3.11/multiprocessing/reduction.py", line 60, in dump
ForkingPickler(file, protocol).dump(obj)
TypeError: cannot pickle 'module' object
```

the `PerturbVolume.random` should not have the module `random` assigned: https://github.com/lhotse-speech/lhotse/blob/a509b4ad9e3c997c08b6f0d41086a14109d0ac81/lhotse/dataset/cut_transforms/perturb_volume.py#L31

assigning the object `random.Random()` was fine, the error disappeared.

the custom `_uniform()` method was implemented.