### PR TITLE
fix: Add Image support to Cut.iter_data() method

### DIFF
--- a/lhotse/cut/data.py
+++ b/lhotse/cut/data.py
@@ -29,6 +29,7 @@ from lhotse.custom import CustomFieldMixin
 from lhotse.cut.base import Cut
 from lhotse.features import FeatureExtractor, Features
 from lhotse.features.io import FeaturesWriter
+from lhotse.image import Image
 from lhotse.supervision import SupervisionSegment
 from lhotse.utils import (
     LOG_EPSILON,
@@ -99,14 +100,14 @@ class DataCut(Cut, CustomFieldMixin, metaclass=ABCMeta):
     def iter_data(
         self,
     ) -> Generator[
-        Tuple[str, Union[Recording, Features, Array, TemporalArray]], None, None
+        Tuple[str, Union[Recording, Features, Array, TemporalArray, Image]], None, None
     ]:
         """
         Iterate over each data piece attached to this cut.
         Returns a generator yielding tuples of ``(key, manifest)``, where
         ``key`` is the name of the attribute under which ``manifest`` is found.
         ``manifest`` is of type :class:`~lhotse.Recording`, :class:`~lhotse.Features`,
-        :class:`~lhotse.TemporalArray`, or :class:`~lhotse.Array`.
+        :class:`~lhotse.TemporalArray`, :class:`~lhotse.Array`, or :class:`~lhotse.Image`.
 
         For example, if ``key`` is ``recording``, then ``manifest`` is ``self.recording``.
         """
@@ -115,7 +116,7 @@ class DataCut(Cut, CustomFieldMixin, metaclass=ABCMeta):
         if self.has_features:
             yield "features", self.features
         for k, v in (self.custom or {}).items():
-            if isinstance(v, (Recording, Features, Array, TemporalArray)):
+            if isinstance(v, (Recording, Features, Array, TemporalArray, Image)):
                 yield k, v
 
     @property

--- a/lhotse/cut/mixed.py
+++ b/lhotse/cut/mixed.py
@@ -42,6 +42,7 @@ from lhotse.features import (
 )
 from lhotse.features.base import Features
 from lhotse.features.io import FeaturesWriter
+from lhotse.image import Image
 from lhotse.supervision import SupervisionSegment
 from lhotse.utils import (
     DEFAULT_PADDING_VALUE,
@@ -232,14 +233,14 @@ class MixedCut(Cut):
     def iter_data(
         self,
     ) -> Generator[
-        Tuple[str, Union[Recording, Features, Array, TemporalArray]], None, None
+        Tuple[str, Union[Recording, Features, Array, TemporalArray, Image]], None, None
     ]:
         """
         Iterate over each data piece attached to this cut.
         Returns a generator yielding tuples of ``(key, manifest)``, where
         ``key`` is the name of the attribute under which ``manifest`` is found.
         ``manifest`` is of type :class:`~lhotse.Recording`, :class:`~lhotse.Features`,
-        :class:`~lhotse.TemporalArray`, or :class:`~lhotse.Array`.
+        :class:`~lhotse.TemporalArray`, :class:`~lhotse.Array`, or :class:`~lhotse.Image`.
 
         For example, if ``key`` is ``recording``, then ``manifest`` is ``self.recording``.
         """


### PR DESCRIPTION
The iter_data() method was not yielding Image objects from cut.custom, only Recording, Features, Array, and TemporalArray. This prevented batch loaders and other utilities from discovering and processing Image manifests attached to cuts.

- Add Image to isinstance() check in DataCut.iter_data()
- Update type annotations to include Image in return type
- Add Image import to data.py and mixed.py