### PR TITLE
Remove hardcoded timeout from AIStore client

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ Lhotse uses several environment variables to customize it's behavior. They are a
 - `LHOTSE_PREPARING_RELEASE` - used internally by developers when releasing a new version of Lhotse.
 - `TORCHAUDIO_USE_BACKEND_DISPATCHER` - when set to `1` and torchaudio version is below 2.1, we'll enable the experimental ffmpeg backend of torchaudio.
 - `AIS_ENDPOINT` is read by AIStore client to determine AIStore endpoint URL. Required for AIStore dataloading.
+- `AIS_CONNECT_TIMEOUT` - used by AIStore SDK to set the connection timeout (in seconds) for AIStore client requests. Set to `0` to disable (no timeout). If not set, the SDK default is used (3s).
+- `AIS_READ_TIMEOUT` - used by AIStore SDK to set the read timeout (in seconds) for AIStore client requests. Set to `0` to disable (no timeout). If not set, the SDK default is used (20s).
 - `RANK`, `WORLD_SIZE`, `WORKER`, and `NUM_WORKERS` are internally used to inform Lhotse Shar dataloading subprocesses.
 - `READTHEDOCS` is internally used for documentation builds.
 - `LHOTSE_MSC_OVERRIDE_PROTOCOLS` - when set, it will override your input protocols before feeding to MSCIOBackend.  Useful when you don't want to change your existing url format but want to use MSCIOBackend.  For example, if you have `s3://s3-bucket/path/to/my/object` and `gs://gs-bucket/path/to/my/object`, you can set `LHOTSE_MSC_OVERRIDE_PROTOCOLS=s3,gs` to override the urls to `msc://s3-bucket/path/to/my/object` and `msc://gs-bucket/path/to/my/object`.

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -143,6 +143,10 @@ Lhotse uses several environment variables to customize it's behavior. They are a
 
 * ``AIS_ENDPOINT`` is read by AIStore client to determine AIStore endpoint URL. Required for AIStore dataloading.
 
+* ``AIS_CONNECT_TIMEOUT`` - used by AIStore SDK to set the connection timeout (in seconds) for AIStore client requests. Set to ``0`` to disable (no timeout). If not set, the SDK default is used (3s).
+
+* ``AIS_READ_TIMEOUT`` - used by AIStore SDK to set the read timeout (in seconds) for AIStore client requests. Set to ``0`` to disable (no timeout). If not set, the SDK default is used (20s).
+
 * ``RANK``, ``WORLD_SIZE``, ``WORKER``, and ``NUM_WORKERS`` are internally used to inform Lhotse Shar dataloading subprocesses.
 
 * ``READTHEDOCS`` is internally used for documentation builds.

--- a/lhotse/serialization.py
+++ b/lhotse/serialization.py
@@ -81,7 +81,12 @@ def get_aistore_client():
 
     endpoint_url = os.environ["AIS_ENDPOINT"]
     version = parse_version(aistore.__version__)
-    return aistore.Client(endpoint_url, timeout=(5, 30), max_pool_size=50), version
+    # NOTE: No explicit timeout is passed here so that the AIStore SDK picks up
+    # the 'AIS_CONNECT_TIMEOUT' and 'AIS_READ_TIMEOUT' environment variables
+    # when they are set. Users should configure these env vars to control
+    # request timeouts.
+    # See https://github.com/NVIDIA/aistore/tree/main/python/aistore/sdk#environment-variables
+    return aistore.Client(endpoint_url, max_pool_size=50), version
 
 
 def save_to_yaml(data: Any, path: Pathlike) -> None:


### PR DESCRIPTION
- Rely on AIS_CONNECT_TIMEOUT and AIS_READ_TIMEOUT env vars for timeout config
- Add link to AIStore SDK environment variables docs