### PR TITLE
Add `CutSet.mix(..., tag="noise")`, `MixTrack.{is_snr_reference,mute}` bools, and `MixedCut.unmix(tag=...)`

### DIFF
--- a/lhotse/cut/base.py
+++ b/lhotse/cut/base.py
@@ -263,6 +263,18 @@ class Cut:
         right = self.truncate(offset=timestamp)
         return left, right
 
+    def unmix(self, tag: Optional[str] = None) -> List["Cut"]:
+        """
+        Return this cut as a single-item list.
+
+        This is a compatibility no-op for cut types that are not :class:`~lhotse.cut.MixedCut`,
+        so callers can uniformly invoke ``cut.unmix()`` regardless of the concrete cut type.
+
+        :param tag: Ignored for non-mixed cuts.
+        :return: A single-item list containing ``self``.
+        """
+        return [self]
+
     def mix(
         self,
         other: "Cut",
@@ -270,6 +282,7 @@ class Cut:
         allow_padding: bool = False,
         snr: Optional[Decibels] = None,
         preserve_id: Optional[str] = None,
+        tag: Optional[str] = None,
     ) -> "Cut":
         """Refer to :function:`~lhotse.cut.mix` documentation."""
         from .set import mix
@@ -281,6 +294,7 @@ class Cut:
             allow_padding=allow_padding,
             snr=snr,
             preserve_id=preserve_id,
+            tag=tag,
         )
 
     def append(

--- a/lhotse/cut/mixed.py
+++ b/lhotse/cut/mixed.py
@@ -70,10 +70,13 @@ class MixTrack:
     how to mix it with other Cuts, relative to the first track in a mix.
     """
 
-    cut: Union[DataCut, PaddingCut]
+    cut: Cut
     type: str = None
     offset: Seconds = 0.0
     snr: Optional[Decibels] = None
+    tag: Optional[str] = None
+    is_snr_reference: bool = False
+    mute: bool = False
 
     def __post_init__(self):
         self.type = type(self.cut).__name__
@@ -95,6 +98,12 @@ class MixTrack:
         }
         if self.snr is not None:
             ans["snr"] = self.snr
+        if self.tag is not None:
+            ans["tag"] = self.tag
+        if self.is_snr_reference:
+            ans["is_snr_reference"] = self.is_snr_reference
+        if self.mute:
+            ans["mute"] = self.mute
         return ans
 
 
@@ -148,7 +157,7 @@ class MixedCut(Cut):
         """
         return [
             segment.with_offset(track.offset)
-            for track in self.tracks
+            for track in _get_audible_tracks(self)
             for segment in track.cut.supervisions
         ]
 
@@ -158,7 +167,9 @@ class MixedCut(Cut):
 
     @property
     def duration(self) -> Seconds:
-        track_durations = (track.offset + track.cut.duration for track in self.tracks)
+        track_durations = (
+            track.offset + track.cut.duration for track in _get_audible_tracks(self)
+        )
         return round(max(track_durations), ndigits=8)
 
     @property
@@ -180,7 +191,7 @@ class MixedCut(Cut):
 
     @property
     def is_in_memory(self) -> bool:
-        return any(track.cut.is_in_memory for track in self.tracks)
+        return any(track.cut.is_in_memory for track in _get_audible_tracks(self))
 
     def has(self, field: str) -> bool:
         return self._first_non_padding_cut.has(field)
@@ -197,11 +208,11 @@ class MixedCut(Cut):
 
     @property
     def frame_shift(self) -> Optional[Seconds]:
-        return self.tracks[0].cut.frame_shift
+        return self._first_non_padding_cut.frame_shift
 
     @property
     def sampling_rate(self) -> Optional[int]:
-        return self.tracks[0].cut.sampling_rate
+        return self._first_non_padding_cut.sampling_rate
 
     @property
     def num_samples(self) -> Optional[int]:
@@ -209,12 +220,12 @@ class MixedCut(Cut):
 
     @property
     def num_features(self) -> Optional[int]:
-        return self.tracks[0].cut.num_features
+        return self._first_non_padding_cut.num_features
 
     @property
     def num_channels(self) -> Optional[int]:
         # PaddingCut and MonoCut have 1 channel each, MultiCut has N. We don't support MixedCut with MixedCut tracks.
-        return max(track.cut.num_channels for track in self.tracks)
+        return max(track.cut.num_channels for track in _get_audible_tracks(self))
 
     @property
     def features_type(self) -> Optional[str]:
@@ -229,6 +240,37 @@ class MixedCut(Cut):
         if self.transforms:
             ans["transforms"] = [t.to_dict() for t in self.transforms]
         return ans
+
+    def unmix(self, tag: Optional[str] = None) -> List[Cut]:
+        """
+        Split this mixed cut into time-aligned constituent cuts.
+
+        When ``tag`` is ``None``, this returns one cut per non-padding audible track.
+        Each returned cut preserves the original offsets and overall duration, so the
+        loaded audio/features can be summed to reconstruct the original mix.
+
+        When ``tag`` is provided, this returns exactly two cuts in order:
+        ``[without_tag, with_tag]``. Tracks are grouped by whether their
+        :attr:`MixTrack.tag` matches ``tag``. For exact SNR preservation, the grouped
+        outputs may carry an internal muted SNR-reference track that is ignored by the
+        public track views but retained for mixing math.
+
+        :param tag: Optional track-group label to split on.
+        :return: A list of one cut per track, or two grouped cuts when ``tag`` is provided.
+        """
+        tracks = [
+            track
+            for track in _get_audible_tracks(self)
+            if not isinstance(track.cut, PaddingCut)
+        ]
+        if tag is None:
+            return [_to_unmixed_cut(self, [track]) for track in tracks]
+        without_tag = [track for track in tracks if track.tag != tag]
+        with_tag = [track for track in tracks if track.tag == tag]
+        return [
+            _to_unmixed_cut(self, without_tag),
+            _to_unmixed_cut(self, with_tag),
+        ]
 
     def iter_data(
         self,
@@ -297,7 +339,7 @@ class MixedCut(Cut):
         if name == "custom":
             # Merge custom dicts of underlying data.
             ans = {}
-            for t in self.tracks:
+            for t in _get_audible_tracks(self):
                 if cstm := t.cut.custom:
                     ans.update(cstm)
             return ans
@@ -462,6 +504,7 @@ class MixedCut(Cut):
             (idx, t.cut)
             for idx, t in enumerate(self.tracks)
             if isinstance(t.cut, DataCut)
+            and not t.mute
             and t.cut.custom is not None
             and attr_name in t.cut.custom
         ]
@@ -525,7 +568,7 @@ class MixedCut(Cut):
         return fastcopy(
             recording.to_cut(),
             supervisions=[fastcopy(s, channel=0) for s in self.supervisions],
-            custom=self.tracks[0].cut.custom,
+            custom=self._first_non_padding_track.cut.custom,
         )
 
     def truncate(
@@ -556,7 +599,6 @@ class MixedCut(Cut):
         assert (
             offset >= 0
         ), f"Offset for truncate must be non-negative (provided {offset})."
-        new_tracks = []
         old_duration = self.duration
         new_mix_end = (
             add_durations(old_duration, -offset, sampling_rate=self.sampling_rate)
@@ -564,7 +606,7 @@ class MixedCut(Cut):
             else add_durations(offset, duration, sampling_rate=self.sampling_rate)
         )
 
-        for track in sorted(self.tracks, key=lambda t: t.offset):
+        def truncate_track(track: MixTrack) -> Optional[MixTrack]:
             # First, determine how much of the beginning of the current track we're going to truncate:
             # when the track offset is larger than the truncation offset, we are not truncating the cut;
             # just decreasing the track offset.
@@ -587,7 +629,7 @@ class MixedCut(Cut):
 
             if track_end < offset:
                 # Omit a Cut that ends before the truncation offset.
-                continue
+                return None
 
             cut_duration_decrease = 0
             if track_end > new_mix_end:
@@ -609,22 +651,31 @@ class MixedCut(Cut):
             )
             if new_duration <= 0:
                 # Omit a Cut that is completely outside the time span of the new truncated MixedCut.
-                continue
+                return None
 
-            new_tracks.append(
-                MixTrack(
-                    cut=track.cut.truncate(
-                        offset=cut_offset,
-                        duration=new_duration,
-                        keep_excessive_supervisions=keep_excessive_supervisions,
-                        preserve_id=preserve_id,
-                        _supervisions_index=_supervisions_index,
-                    ),
-                    offset=track_offset,
-                    snr=track.snr,
-                )
+            return MixTrack(
+                cut=track.cut.truncate(
+                    offset=cut_offset,
+                    duration=new_duration,
+                    keep_excessive_supervisions=keep_excessive_supervisions,
+                    preserve_id=preserve_id,
+                    _supervisions_index=_supervisions_index,
+                ),
+                offset=track_offset,
+                snr=track.snr,
+                tag=track.tag,
+                is_snr_reference=track.is_snr_reference,
+                mute=track.mute,
             )
 
+        new_tracks = [
+            new_track
+            for new_track in (
+                truncate_track(track)
+                for track in sorted(self.tracks, key=lambda t: t.offset)
+            )
+            if new_track is not None
+        ]
         # Edge case: no tracks with data left after truncation. This can happen if we truncated an offset region.
         # In this case, return a PaddingCut of the requested duration
         if len([t for t in new_tracks if not isinstance(t.cut, PaddingCut)]) == 0:
@@ -641,7 +692,8 @@ class MixedCut(Cut):
             return new_tracks[0].cut
 
         new_cut = MixedCut(
-            id=self.id if preserve_id else str(uuid4()), tracks=new_tracks
+            id=self.id if preserve_id else str(uuid4()),
+            tracks=new_tracks,
         )
 
         # Final edge-case check. Scenario:
@@ -650,7 +702,7 @@ class MixedCut(Cut):
         # - we are left only with PaddingCuts and MonoCuts that have specified SNR
         # Solution:
         # - find first non padding cut and reset its SNR to None (make it the new reference)
-        if all(
+        if not any(track.is_snr_reference for track in new_cut.tracks) and all(
             t.snr is not None or isinstance(t.cut, PaddingCut) for t in new_cut.tracks
         ):
             first_non_padding_track_idx = [
@@ -659,7 +711,9 @@ class MixedCut(Cut):
                 if not isinstance(t.cut, PaddingCut)
             ][0]
             new_cut.tracks[first_non_padding_track_idx] = fastcopy(
-                new_cut.tracks[first_non_padding_track_idx], snr=None
+                new_cut.tracks[first_non_padding_track_idx],
+                snr=None,
+                is_snr_reference=True,
             )
 
         return new_cut
@@ -1051,8 +1105,9 @@ class MixedCut(Cut):
             c < rir_recording.num_channels for c in rir_channels
         ), "Invalid channel index in `rir_channels`."
 
+        audible_tracks = _get_audible_tracks(self)
         assert len(rir_channels) == 1 or len(rir_channels) == len(
-            self.tracks
+            audible_tracks
         ), "Invalid number of channels in `rir_channels`, must be either 1 or equal to the number of tracks."
 
         # There are 2 ways to apply RIRs:
@@ -1112,6 +1167,12 @@ class MixedCut(Cut):
 
         if len(rir_channels) == 1:
             rir_channels = rir_channels * len(self.tracks)
+        else:
+            audible_channels = iter(rir_channels)
+            rir_channels = [
+                next(audible_channels) if not track.mute else rir_channels[0]
+                for track in self.tracks
+            ]
 
         return MixedCut(
             id=f"{self.id}_rvb" if affix_id else self.id,
@@ -1150,15 +1211,22 @@ class MixedCut(Cut):
         """
         if not self.has_features:
             return None
-        first_cut = self.tracks[0].cut
+        tracks = _get_audible_tracks(self)
+        first_track = tracks[0]
+        first_cut = first_track.cut
 
         # First, check for a simple scenario: just a single cut with padding.
         # When that is the case, we don't have to instantiate a feature extractor,
         # because we are not performing any actual mixing.
         # That makes life simpler for the users who have a custom feature extractor,
         # but don't actually care about feature-domain mixing; just want to pad.
-        if mixed and all(isinstance(t.cut, PaddingCut) for t in self.tracks[1:]):
-            padding_val = self.tracks[1].cut.feat_value
+        if (
+            mixed
+            and first_track.snr is None
+            and tracks[1:]
+            and all(isinstance(t.cut, PaddingCut) for t in tracks[1:])
+        ):
+            padding_val = tracks[1].cut.feat_value
             first_cut_feats = first_cut.load_features()
             if first_cut_feats.ndim == 2:
                 # 2D features
@@ -1180,29 +1248,30 @@ class MixedCut(Cut):
         # They might not be if the first track is a padding track.
         reference_feats = None
         reference_energy = None
-        reference_pos, reference_cut = [
-            (idx, t.cut)
-            for idx, t in enumerate(self.tracks)
-            if not isinstance(t.cut, PaddingCut) and t.snr is None
-        ][0]
+        _, reference_track = _get_snr_reference_track(self)
         feature_extractor = create_default_feature_extractor(
-            reference_cut.features.type
+            reference_track.cut.features_type
         )
-        if first_cut.id != reference_cut.id:
-            reference_feats = reference_cut.load_features()
+        if reference_track is not first_track:
+            reference_feats = reference_track.cut.load_features()
             reference_energy = feature_extractor.compute_energy(reference_feats)
 
         # The mix itself.
+        first_cut_feats = first_cut.load_features()
+        first_cut_feats = _scale_features_for_snr(
+            first_cut_feats,
+            feature_extractor=feature_extractor,
+            snr=first_track.snr,
+            reference_energy=reference_energy,
+        )
         mixer = FeatureMixer(
-            feature_extractor=create_default_feature_extractor(
-                self._first_non_padding_cut.features.type
-            ),
-            base_feats=first_cut.load_features(),
+            feature_extractor=feature_extractor,
+            base_feats=first_cut_feats,
             frame_shift=first_cut.frame_shift,
             reference_energy=reference_energy,
         )
-        for pos, track in enumerate(self.tracks[1:], start=1):
-            if pos == reference_pos and reference_feats is not None:
+        for track in tracks[1:]:
+            if track is reference_track and reference_feats is not None:
                 feats = reference_feats  # manual caching to avoid duplicated I/O
             else:
                 feats = track.cut.load_features()
@@ -1261,30 +1330,33 @@ class MixedCut(Cut):
 
         if not self.has_recording:
             return None
-        first_cut = self.tracks[0].cut
+        tracks = _get_audible_tracks(self)
+        first_track = tracks[0]
+        first_cut = first_track.cut
 
         # First, we have to make sure that the reference energy levels are appropriate.
         # They might not be if the first track is a padding track.
         reference_audio = None
         reference_energy = None
-        reference_pos, reference_cut = [
-            (idx, t.cut)
-            for idx, t in enumerate(self.tracks)
-            if not isinstance(t.cut, PaddingCut) and t.snr is None
-        ][0]
-        if first_cut.id != reference_cut.id:
-            reference_audio = reference_cut.load_audio()
+        _, reference_track = _get_snr_reference_track(self)
+        if reference_track is not first_track:
+            reference_audio = reference_track.cut.load_audio()
             reference_energy = audio_energy(reference_audio)
 
-        mixer = AudioMixer(
-            self.tracks[0].cut.load_audio(),
-            sampling_rate=self.tracks[0].cut.sampling_rate,
+        first_cut_audio = _scale_audio_for_snr(
+            first_cut.load_audio(),
+            snr=first_track.snr,
             reference_energy=reference_energy,
-            base_offset=self.tracks[0].offset,
+        )
+        mixer = AudioMixer(
+            first_cut_audio,
+            sampling_rate=first_cut.sampling_rate,
+            reference_energy=reference_energy,
+            base_offset=first_track.offset,
         )
 
-        for pos, track in enumerate(self.tracks[1:], start=1):
-            if pos == reference_pos and reference_audio is not None:
+        for track in tracks[1:]:
+            if track is reference_track and reference_audio is not None:
                 audio = reference_audio  # manual caching to avoid duplicated I/O
             else:
                 audio = track.cut.load_audio()
@@ -1296,7 +1368,7 @@ class MixedCut(Cut):
 
         # Flattening a MixedCut without MultiCut tracks has no effect
         mono_downmix = mono_downmix and any(
-            track.type == "MultiCut" for track in self.tracks
+            track.type == "MultiCut" for track in tracks
         )
 
         # Flattening a MixedCut without mixed=True has no effect
@@ -1353,12 +1425,13 @@ class MixedCut(Cut):
         if not self.has_video:
             return None
 
+        tracks = _get_audible_tracks(self)
         mixer = VideoMixer(
-            self.tracks[0].cut.load_video(with_audio=False)[0],
+            tracks[0].cut.load_video(with_audio=False)[0],
             fps=self.video.fps,
-            base_offset=self.tracks[0].offset,
+            base_offset=tracks[0].offset,
         )
-        for pos, track in enumerate(self.tracks[1:], start=1):
+        for track in tracks[1:]:
             mixer.add_to_mix(
                 video=track.cut.load_video(with_audio=False)[0],
                 offset=track.offset,
@@ -1378,7 +1451,8 @@ class MixedCut(Cut):
         """
         import matplotlib.pyplot as plt
 
-        fig, axes = plt.subplots(len(self.tracks))
+        tracks = _get_audible_tracks(self)
+        fig, axes = plt.subplots(len(tracks))
         features = self.load_features(mixed=False)
         fmin, fmax = features.min(), features.max()
         for idx, ax in enumerate(axes):
@@ -1392,8 +1466,9 @@ class MixedCut(Cut):
         import matplotlib.pyplot as plt
 
         audio = self.load_audio(mixed=False)
-        fig, axes = plt.subplots(len(self.tracks), sharex=False, sharey=True)
-        for idx, (track, ax) in enumerate(zip(self.tracks, axes)):
+        tracks = _get_audible_tracks(self)
+        fig, axes = plt.subplots(len(tracks), sharex=False, sharey=True)
+        for idx, (track, ax) in enumerate(zip(tracks, axes)):
             samples = audio[idx].squeeze(0)
             ax.plot(np.linspace(0, self.duration, len(samples)), samples)
             for supervision in track.cut.supervisions:
@@ -1412,7 +1487,8 @@ class MixedCut(Cut):
             self.has_recording
         ), f"Cannot detach features from a MixedCut with no Recording (cut ID = {self.id})."
         return fastcopy(
-            self, tracks=[fastcopy(t, cut=t.cut.drop_features()) for t in self.tracks]
+            self,
+            tracks=[fastcopy(t, cut=t.cut.drop_features()) for t in self.tracks],
         )
 
     def drop_recording(self) -> "MixedCut":
@@ -1421,7 +1497,8 @@ class MixedCut(Cut):
             self.has_features
         ), f"Cannot detach recording from a MixedCut with no Features (cut ID = {self.id})."
         return fastcopy(
-            self, tracks=[fastcopy(t, cut=t.cut.drop_recording()) for t in self.tracks]
+            self,
+            tracks=[fastcopy(t, cut=t.cut.drop_recording()) for t in self.tracks],
         )
 
     def drop_supervisions(self) -> "MixedCut":
@@ -1502,10 +1579,16 @@ class MixedCut(Cut):
                     ),
                     offset=track.offset,
                     snr=track.snr,
+                    tag=track.tag,
+                    is_snr_reference=track.is_snr_reference,
+                    mute=track.mute,
                 )
                 for track in self.tracks
             ]
-            return MixedCut(id=self.id, tracks=new_tracks)
+            return MixedCut(
+                id=self.id,
+                tracks=new_tracks,
+            )
 
     def fill_supervision(
         self, add_empty: bool = True, shrink_ok: bool = False
@@ -1533,9 +1616,7 @@ class MixedCut(Cut):
         if n_sups == 0:
             if not add_empty:
                 return self
-            first_non_padding_idx = [
-                idx for idx, t in enumerate(self.tracks) if isinstance(t.cut, DataCut)
-            ][0]
+            first_non_padding_idx = self.tracks.index(self._first_non_padding_track)
             new_tracks = [
                 fastcopy(
                     t,
@@ -1562,6 +1643,9 @@ class MixedCut(Cut):
             ), f"Cannot expand more than one supervision (found {len(self.supervisions)}."
             new_tracks = []
             for t in self.tracks:
+                if t.mute:
+                    new_tracks.append(t)
+                    continue
                 if len(t.cut.supervisions) == 0:
                     new_tracks.append(t)
                 else:
@@ -1603,7 +1687,7 @@ class MixedCut(Cut):
         """
         new_mixed_cut = fastcopy(self)
         for track in new_mixed_cut.tracks:
-            if isinstance(track.cut, PaddingCut):
+            if isinstance(track.cut, PaddingCut) or track.mute:
                 continue
             track.cut.supervisions = [
                 segment.map(transform_fn) for segment in track.cut.supervisions
@@ -1750,9 +1834,18 @@ class MixedCut(Cut):
         transforms = None
         if "transforms" in data:
             transforms = [AudioTransform.from_dict(t) for t in data["transforms"]]
+        tracks = [MixTrack.from_dict(track) for track in data["tracks"]]
+        if "snr_reference" in data:
+            tracks.append(
+                fastcopy(
+                    MixTrack.from_dict(data["snr_reference"]),
+                    is_snr_reference=True,
+                    mute=True,
+                )
+            )
         return MixedCut(
             id=data["id"],
-            tracks=[MixTrack.from_dict(track) for track in data["tracks"]],
+            tracks=tracks,
             transforms=transforms,
         )
 
@@ -1784,7 +1877,7 @@ class MixedCut(Cut):
 
     @property
     def first_non_padding_track(self) -> MixTrack:
-        return [t for t in self.tracks if not isinstance(t.cut, PaddingCut)][0]
+        return _get_first_non_padding_track(self)
 
     # Note: the private properties below are kept for backward compatibility.
 
@@ -1795,3 +1888,101 @@ class MixedCut(Cut):
     @property
     def _first_non_padding_track(self) -> MixTrack:
         return self.first_non_padding_track
+
+
+def _get_audible_tracks(mixed_cut: "MixedCut") -> List[MixTrack]:
+    tracks = [track for track in mixed_cut.tracks if not track.mute]
+    return tracks if tracks else mixed_cut.tracks
+
+
+def _get_first_non_padding_track(mixed_cut: "MixedCut") -> MixTrack:
+    tracks = [
+        track
+        for track in _get_audible_tracks(mixed_cut)
+        if not isinstance(track.cut, PaddingCut)
+    ]
+    if tracks:
+        return tracks[0]
+    return _get_audible_tracks(mixed_cut)[0]
+
+
+def _get_snr_reference_track(mixed_cut: "MixedCut") -> Tuple[Optional[int], MixTrack]:
+    for idx, track in enumerate(mixed_cut.tracks):
+        if track.is_snr_reference:
+            return idx, track
+    for idx, track in enumerate(mixed_cut.tracks):
+        if not isinstance(track.cut, PaddingCut) and track.snr is None:
+            return idx, track
+    raise ValueError(
+        f"Cannot determine SNR reference track for MixedCut '{mixed_cut.id}'."
+    )
+
+
+def _ensure_explicit_snr_reference(tracks: List[MixTrack]) -> List[MixTrack]:
+    if any(track.is_snr_reference for track in tracks):
+        return tracks
+    for idx, track in enumerate(tracks):
+        if not isinstance(track.cut, PaddingCut) and track.snr is None:
+            tracks[idx] = fastcopy(track, is_snr_reference=True)
+            break
+    return tracks
+
+
+def _scale_audio_for_snr(
+    audio: np.ndarray,
+    snr: Optional[Decibels],
+    reference_energy: Optional[float],
+) -> np.ndarray:
+    if snr is None or reference_energy is None or reference_energy <= 0.0:
+        return audio
+    added_audio_energy = audio_energy(audio)
+    if added_audio_energy <= 0.0:
+        return audio
+    target_energy = reference_energy * (10.0 ** (-snr / 10))
+    return np.sqrt(target_energy / added_audio_energy) * audio
+
+
+def _scale_features_for_snr(
+    features: np.ndarray,
+    feature_extractor: FeatureExtractor,
+    snr: Optional[Decibels],
+    reference_energy: Optional[float],
+) -> np.ndarray:
+    if snr is None or reference_energy is None or reference_energy <= 0.0:
+        return features
+    added_features_energy = feature_extractor.compute_energy(features)
+    if added_features_energy <= 0.0:
+        return features
+    target_energy = reference_energy * (10.0 ** (-snr / 10))
+    return feature_extractor.scale(features, target_energy / added_features_energy)
+
+
+def _make_padding_cut(mixed_cut: "MixedCut") -> PaddingCut:
+    return PaddingCut(
+        id=str(uuid4()),
+        duration=mixed_cut.duration,
+        sampling_rate=mixed_cut.sampling_rate,
+        feat_value=LOG_EPSILON,
+        num_frames=mixed_cut.num_frames if mixed_cut.has_features else None,
+        num_features=mixed_cut.num_features if mixed_cut.has_features else None,
+        frame_shift=mixed_cut.frame_shift if mixed_cut.has_features else None,
+        num_samples=mixed_cut.num_samples if mixed_cut.has_recording else None,
+        video=mixed_cut.video if mixed_cut.has_video else None,
+    )
+
+
+def _to_unmixed_cut(mixed_cut: "MixedCut", tracks: List[MixTrack]) -> Cut:
+    if not tracks:
+        return _make_padding_cut(mixed_cut)
+    tracks = _ensure_explicit_snr_reference([fastcopy(track) for track in tracks])
+    needs_reference = all(track.snr is not None for track in tracks)
+    if needs_reference:
+        _, reference_track = _get_snr_reference_track(mixed_cut)
+        tracks.append(fastcopy(reference_track, is_snr_reference=True, mute=True))
+    cut = MixedCut(
+        id=str(uuid4()),
+        tracks=tracks,
+    )
+    if cut.duration < mixed_cut.duration:
+        cut = cut.pad(duration=mixed_cut.duration, preserve_id=True)
+    return cut

--- a/lhotse/cut/set.py
+++ b/lhotse/cut/set.py
@@ -35,7 +35,7 @@ from lhotse.audio import RecordingSet, null_result_on_audio_loading_error
 from lhotse.augmentation import AugmentFn
 from lhotse.cut.base import Cut
 from lhotse.cut.data import DataCut
-from lhotse.cut.mixed import MixedCut, MixTrack
+from lhotse.cut.mixed import MixedCut, MixTrack, _ensure_explicit_snr_reference
 from lhotse.cut.mono import MonoCut
 from lhotse.cut.multi import MultiCut
 from lhotse.cut.padding import PaddingCut
@@ -1723,6 +1723,7 @@ class CutSet(Serializable, AlgorithmMixin):
         mix_prob: float = 1.0,
         seed: Union[int, Literal["trng", "randomized"], random.Random] = 42,
         random_mix_offset: bool = False,
+        tag: Optional[str] = None,
     ) -> "CutSet":
         """
         Mix cuts in this ``CutSet`` with randomly sampled cuts from another ``CutSet``.
@@ -1754,6 +1755,7 @@ class CutSet(Serializable, AlgorithmMixin):
         :param random_mix_offset: an optional bool.
             When ``True`` and the duration of the to be mixed in cut in longer than the original cut,
              select a random sub-region from the to be mixed in cut.
+        :param tag: Optional label attached to the mixed-in tracks.
         :return: a new ``CutSet`` with mixed cuts.
         """
         return CutSet(
@@ -1767,6 +1769,7 @@ class CutSet(Serializable, AlgorithmMixin):
                 mix_prob=mix_prob,
                 seed=seed,
                 random_mix_offset=random_mix_offset,
+                tag=tag,
             )
         )
 
@@ -2801,6 +2804,7 @@ def mix(
     allow_padding: bool = False,
     snr: Optional[Decibels] = None,
     preserve_id: Optional[str] = None,
+    tag: Optional[str] = None,
 ) -> MixedCut:
     """
     Overlay, or mix, two cuts. Optionally the ``mixed_in_cut`` may be shifted by ``offset`` seconds
@@ -2815,6 +2819,7 @@ def mix(
     :param snr: Desired SNR of the ``right_cut`` w.r.t. the ``left_cut`` in the mix.
     :param preserve_id: optional string ("left", "right"). when specified, append will preserve the cut id
         of the left- or right-hand side argument. otherwise, a new random id is generated.
+    :param tag: Optional label attached to the mixed-in tracks.
     :return: A :class:`~MixedCut` instance.
     """
 
@@ -2889,10 +2894,16 @@ def mix(
     if (
         isinstance(reference_cut, MixedCut)
         and len(ifnone(reference_cut.transforms, [])) == 0
+        and not any(track.mute for track in reference_cut.tracks)
     ):
-        old_tracks = reference_cut.tracks
+        old_tracks = _ensure_explicit_snr_reference(reference_cut.tracks.copy())
     elif isinstance(reference_cut, (DataCut, PaddingCut, MixedCut)):
-        old_tracks = [MixTrack(cut=reference_cut)]
+        old_tracks = [
+            MixTrack(
+                cut=reference_cut,
+                is_snr_reference=not isinstance(reference_cut, PaddingCut),
+            )
+        ]
     else:
         raise ValueError(f"Unsupported type of cut in mix(): {type(reference_cut)}")
 
@@ -2901,8 +2912,10 @@ def mix(
     if isinstance(mixed_in_cut, MixedCut):
         # Similarly for mixed_in_cut, if it is a MixedCut and it does not have existing transforms,
         # take its existing tracks, otherwise create a new track.
-        if len(ifnone(mixed_in_cut.transforms, [])) > 0:
-            new_tracks = [MixTrack(cut=mixed_in_cut, offset=offset, snr=snr)]
+        if len(ifnone(mixed_in_cut.transforms, [])) > 0 or any(
+            track.mute for track in mixed_in_cut.tracks
+        ):
+            new_tracks = [MixTrack(cut=mixed_in_cut, offset=offset, snr=snr, tag=tag)]
         else:
             new_tracks = [
                 MixTrack(
@@ -2922,11 +2935,14 @@ def mix(
                         # When no SNR was specified whatsoever, use none.
                         else None
                     ),
+                    tag=track.tag if track.tag is not None else tag,
+                    is_snr_reference=False,
+                    mute=track.mute,
                 )
                 for track in mixed_in_cut.tracks
             ]
     elif isinstance(mixed_in_cut, (DataCut, PaddingCut)):
-        new_tracks = [MixTrack(cut=mixed_in_cut, offset=offset, snr=snr)]
+        new_tracks = [MixTrack(cut=mixed_in_cut, offset=offset, snr=snr, tag=tag)]
     else:
         raise ValueError(f"Unsupported type of cut in mix(): {type(mixed_in_cut)}")
 
@@ -3756,6 +3772,7 @@ class LazyCutMixer(Dillable):
         seed: Union[int, Literal["trng", "randomized"], random.Random] = 42,
         random_mix_offset: bool = False,
         stateful: bool = True,
+        tag: Optional[str] = None,
     ) -> None:
         self.source = cuts
         self.mix_in_cuts = mix_in_cuts
@@ -3767,6 +3784,7 @@ class LazyCutMixer(Dillable):
         self.seed = seed
         self.random_mix_offset = random_mix_offset
         self.stateful = stateful
+        self.tag = tag
         self.num_times_iterated = 0
 
         assert 0.0 <= self.mix_prob <= 1.0
@@ -3827,7 +3845,12 @@ class LazyCutMixer(Dillable):
             # Actual mixing
             to_mix = next(mix_in_cuts)
             to_mix = self._maybe_truncate_cut(to_mix, target_mixed_duration, rng)
-            mixed = cut.mix(other=to_mix, snr=cut_snr, preserve_id=self.preserve_id)
+            mixed = cut.mix(
+                other=to_mix,
+                snr=cut_snr,
+                preserve_id=self.preserve_id,
+                tag=self.tag,
+            )
             # Did the user specify a duration?
             # If yes, we will ensure that shorter cuts have more noise mixed in
             # to "pad" them with at the end.
@@ -3849,6 +3872,7 @@ class LazyCutMixer(Dillable):
                     offset_other_by=mixed_in_duration,
                     allow_padding=self.allow_padding,
                     preserve_id=self.preserve_id,
+                    tag=self.tag,
                 )
                 # Since we're adding floats, we can be off by an epsilon and trigger
                 # some assertions for exceeding duration; do precautionary rounding here.

--- a/lhotse/dataset/cut_transforms/mix.py
+++ b/lhotse/dataset/cut_transforms/mix.py
@@ -22,6 +22,7 @@ class CutMix:
         preserve_id: bool = False,
         seed: Union[int, Literal["trng", "randomized"], random.Random] = 42,
         random_mix_offset: bool = False,
+        tag: Optional[str] = None,
     ) -> None:
         """
         CutMix's constructor.
@@ -42,6 +43,7 @@ class CutMix:
         :param random_mix_offset: an optional bool.
             When ``True`` and the duration of the to be mixed in cut in longer than the original cut,
             select a random sub-region from the to be mixed in cut.
+        :param tag: Optional label attached to the mixed-in tracks.
         """
         self.cuts = cuts
         if len(self.cuts) == 0:
@@ -55,6 +57,7 @@ class CutMix:
         self.seed = seed
         self.rng = None
         self.random_mix_offset = random_mix_offset
+        self.tag = tag
 
     def __call__(self, cuts: CutSet) -> CutSet:
 
@@ -75,6 +78,7 @@ class CutMix:
             preserve_id="left" if self.preserve_id else None,
             seed=self.rng,
             random_mix_offset=self.random_mix_offset,
+            tag=self.tag,
         ).to_eager()
 
     def _lazy_rng_init(self):

--- a/lhotse/features/base.py
+++ b/lhotse/features/base.py
@@ -134,6 +134,21 @@ class FeatureExtractor(metaclass=ABCMeta):
             "after, rather than before mixing the cuts."
         )
 
+    @staticmethod
+    def scale(features: np.ndarray, energy_scaling_factor: float) -> np.ndarray:
+        """
+        Scale a single feature matrix by the provided energy factor.
+
+        :param features: A feature matrix.
+        :param energy_scaling_factor: The energy scaling factor to apply.
+        :return: A scaled feature matrix.
+        """
+        raise ValueError(
+            'The feature extractor\'s "scale" operation is undefined. '
+            "It does not support feature-domain mix, consider computing the features "
+            "after, rather than before mixing the cuts."
+        )
+
     def extract_batch(
         self,
         samples: Union[

--- a/lhotse/features/fbank.py
+++ b/lhotse/features/fbank.py
@@ -69,3 +69,7 @@ class TorchaudioFbank(TorchaudioFeatureExtractor):
     @staticmethod
     def compute_energy(features: np.ndarray) -> float:
         return float(np.sum(np.exp(features)))
+
+    @staticmethod
+    def scale(features: np.ndarray, energy_scaling_factor: float) -> np.ndarray:
+        return features + np.log(energy_scaling_factor)

--- a/lhotse/features/kaldi/extractors.py
+++ b/lhotse/features/kaldi/extractors.py
@@ -147,6 +147,10 @@ class Fbank(FeatureExtractor):
     def compute_energy(features: np.ndarray) -> float:
         return float(np.sum(np.exp(features)))
 
+    @staticmethod
+    def scale(features: np.ndarray, energy_scaling_factor: float) -> np.ndarray:
+        return features + np.log(energy_scaling_factor)
+
 
 @dataclass
 class MfccConfig:
@@ -363,6 +367,10 @@ class Spectrogram(FeatureExtractor):
     def compute_energy(features: np.ndarray) -> float:
         return float(np.sum(features))
 
+    @staticmethod
+    def scale(features: np.ndarray, energy_scaling_factor: float) -> np.ndarray:
+        return energy_scaling_factor * features
+
 
 @dataclass
 class LogSpectrogramConfig:
@@ -468,6 +476,10 @@ class LogSpectrogram(FeatureExtractor):
     @staticmethod
     def compute_energy(features: np.ndarray) -> float:
         return float(np.sum(features))
+
+    @staticmethod
+    def scale(features: np.ndarray, energy_scaling_factor: float) -> np.ndarray:
+        return energy_scaling_factor * features
 
 
 def _extract_batch(

--- a/lhotse/features/kaldifeat.py
+++ b/lhotse/features/kaldifeat.py
@@ -209,6 +209,10 @@ class KaldifeatFbank(KaldifeatExtractor):
     def compute_energy(features: np.ndarray) -> float:
         return float(np.sum(np.exp(features)))
 
+    @staticmethod
+    def scale(features: np.ndarray, energy_scaling_factor: float) -> np.ndarray:
+        return features + np.log(energy_scaling_factor)
+
 
 @dataclass
 class KaldifeatMfccConfig:

--- a/lhotse/features/librosa_fbank.py
+++ b/lhotse/features/librosa_fbank.py
@@ -172,3 +172,7 @@ class LibrosaFbank(FeatureExtractor):
     @staticmethod
     def compute_energy(features: np.ndarray) -> float:
         return float(np.sum(np.exp(features)))
+
+    @staticmethod
+    def scale(features: np.ndarray, energy_scaling_factor: float) -> np.ndarray:
+        return features + np.log(energy_scaling_factor)

--- a/lhotse/features/spectrogram.py
+++ b/lhotse/features/spectrogram.py
@@ -70,3 +70,7 @@ class TorchaudioSpectrogram(TorchaudioFeatureExtractor):
     def compute_energy(features: np.ndarray) -> float:
         # Torchaudio returns log-power spectrum, hence the need for exp before the sum
         return float(np.sum(np.exp(features)))
+
+    @staticmethod
+    def scale(features: np.ndarray, energy_scaling_factor: float) -> np.ndarray:
+        return features + np.log(energy_scaling_factor)

--- a/lhotse/features/whisper_fbank.py
+++ b/lhotse/features/whisper_fbank.py
@@ -179,3 +179,7 @@ class WhisperFbank(FeatureExtractor):
     @staticmethod
     def compute_energy(features: np.ndarray) -> float:
         return float(np.sum(np.exp(features)))
+
+    @staticmethod
+    def scale(features: np.ndarray, energy_scaling_factor: float) -> np.ndarray:
+        return features + np.log(energy_scaling_factor)

--- a/test/cut/test_cut_mixing.py
+++ b/test/cut/test_cut_mixing.py
@@ -5,8 +5,13 @@ import pytest
 
 from lhotse.audio import Recording
 from lhotse.cut import CutSet, MixedCut, MonoCut, MultiCut
+from lhotse.serialization import deserialize_item
 from lhotse.supervision import SupervisionSegment
-from lhotse.testing.dummies import DummyManifest, remove_spaces_from_segment_text
+from lhotse.testing.dummies import (
+    DummyManifest,
+    dummy_multi_cut,
+    remove_spaces_from_segment_text,
+)
 from lhotse.utils import nullcontext as does_not_raise
 
 # Note:
@@ -203,6 +208,154 @@ def test_mixed_cut_load_audio_unmixed(mixed_audio_cut):
     assert audio[1].shape == (1, 230400)
 
 
+def test_mixed_cut_unmix_preserves_audio_gain():
+    speech = DummyManifest(CutSet, begin_id=0, end_id=1, with_data=True)[0]
+    noise1 = DummyManifest(CutSet, begin_id=100, end_id=101, with_data=True)[0]
+    noise2 = DummyManifest(CutSet, begin_id=101, end_id=102, with_data=True)[0]
+
+    speech = speech.truncate(duration=1.0)
+    noise1 = noise1.truncate(duration=0.35)
+    noise2 = noise2.truncate(duration=0.4)
+
+    mixed = speech.mix(noise1, snr=10, tag="noise")
+    mixed = mixed.mix(noise2, offset_other_by=0.6, snr=10, tag="noise")
+
+    speech_only, noise_only = mixed.unmix(tag="noise")
+    constituents = mixed.unmix()
+
+    assert len(constituents) == 3
+    assert isinstance(noise_only, MixedCut)
+    assert any(track.is_snr_reference and track.mute for track in noise_only.tracks)
+    assert all(track.tag == "noise" for track in noise_only.tracks if not track.mute)
+
+    np.testing.assert_allclose(
+        mixed.load_audio(),
+        speech_only.load_audio() + noise_only.load_audio(),
+    )
+    np.testing.assert_allclose(
+        mixed.load_audio(),
+        sum(c.load_audio() for c in constituents),
+    )
+
+    noise_only_dict = noise_only.to_dict()
+    assert "snr_reference" not in noise_only_dict
+    hidden_track = next(
+        track for track in noise_only_dict["tracks"] if track.get("mute")
+    )
+    assert hidden_track["is_snr_reference"] is True
+
+    restored_noise = deserialize_item(noise_only_dict)
+    assert isinstance(restored_noise, MixedCut)
+    assert any(track.is_snr_reference and track.mute for track in restored_noise.tracks)
+    np.testing.assert_allclose(noise_only.load_audio(), restored_noise.load_audio())
+
+
+def test_mixed_cut_unmix_hides_muted_reference_from_public_views():
+    speech = DummyManifest(CutSet, begin_id=0, end_id=1, with_data=True)[0]
+    noise1 = DummyManifest(CutSet, begin_id=100, end_id=101, with_data=True)[0]
+    noise2 = DummyManifest(CutSet, begin_id=101, end_id=102, with_data=True)[0]
+
+    speech = speech.truncate(duration=1.0)
+    noise1 = noise1.truncate(duration=0.35)
+    noise2 = noise2.truncate(duration=0.4)
+
+    mixed = speech.mix(noise1, snr=10, tag="noise")
+    mixed = mixed.mix(noise2, offset_other_by=0.6, snr=10, tag="noise")
+
+    _, noise_only = mixed.unmix(tag="noise")
+
+    assert len(noise_only.unmix()) == 2
+    assert len(noise_only.load_audio(mixed=False)) == 2
+    assert noise_only.load_features(mixed=False).shape[0] == 2
+    assert {sup.recording_id for sup in noise_only.supervisions} == {
+        noise1.recording_id,
+        noise2.recording_id,
+    }
+    assert noise_only.first_non_padding_track.tag == "noise"
+    assert not noise_only.first_non_padding_track.mute
+
+
+def test_mixed_cut_backward_compat_deserializes_top_level_snr_reference():
+    speech = DummyManifest(CutSet, begin_id=0, end_id=1, with_data=True)[0]
+    noise1 = DummyManifest(CutSet, begin_id=100, end_id=101, with_data=True)[0]
+    noise2 = DummyManifest(CutSet, begin_id=101, end_id=102, with_data=True)[0]
+
+    speech = speech.truncate(duration=1.0)
+    noise1 = noise1.truncate(duration=0.35)
+    noise2 = noise2.truncate(duration=0.4)
+
+    mixed = speech.mix(noise1, snr=10, tag="noise")
+    mixed = mixed.mix(noise2, offset_other_by=0.6, snr=10, tag="noise")
+
+    _, noise_only = mixed.unmix(tag="noise")
+    new_dict = noise_only.to_dict()
+    old_hidden = next(track for track in new_dict["tracks"] if track.get("mute")).copy()
+    old_hidden.pop("mute")
+    old_hidden.pop("is_snr_reference")
+    old_style_dict = {
+        **new_dict,
+        "tracks": [track for track in new_dict["tracks"] if not track.get("mute")],
+        "snr_reference": old_hidden,
+    }
+
+    restored = deserialize_item(old_style_dict)
+
+    assert isinstance(restored, MixedCut)
+    assert any(track.is_snr_reference and track.mute for track in restored.tracks)
+    assert len(restored.load_audio(mixed=False)) == 2
+    assert "snr_reference" not in restored.to_dict()
+    np.testing.assert_allclose(restored.load_audio(), noise_only.load_audio())
+
+
+def test_unmix_is_noop_for_non_mixed_cuts():
+    mono_cut = DummyManifest(CutSet, begin_id=0, end_id=1, with_data=True)[0]
+    multi_cut = dummy_multi_cut(1, duration=1.0, with_data=True)
+
+    assert mono_cut.unmix() == [mono_cut]
+    assert mono_cut.unmix(tag="noise") == [mono_cut]
+    assert multi_cut.unmix() == [multi_cut]
+    assert multi_cut.unmix(tag="noise") == [multi_cut]
+
+
+def test_mixed_cut_hidden_reference_does_not_affect_num_channels():
+    speech = dummy_multi_cut(0, duration=1.0, with_data=True)
+    noise = DummyManifest(CutSet, begin_id=100, end_id=101, with_data=True)[0]
+    noise = noise.truncate(duration=0.5)
+
+    mixed = speech.mix(noise, snr=10, tag="noise")
+    _, noise_only = mixed.unmix(tag="noise")
+
+    assert noise_only.num_channels == 1
+    assert noise_only.channel == 0
+    assert noise_only.load_audio().shape[0] == 1
+
+
+def test_mix_does_not_flatten_mixed_cut_with_hidden_reference():
+    speech = DummyManifest(CutSet, begin_id=0, end_id=1, with_data=True)[0]
+    noise1 = DummyManifest(CutSet, begin_id=100, end_id=101, with_data=True)[0]
+    noise2 = DummyManifest(CutSet, begin_id=101, end_id=102, with_data=True)[0]
+    extra_noise = DummyManifest(CutSet, begin_id=102, end_id=103, with_data=True)[0]
+
+    speech = speech.truncate(duration=1.0)
+    noise1 = noise1.truncate(duration=0.35)
+    noise2 = noise2.truncate(duration=0.4)
+    extra_noise = extra_noise.truncate(duration=0.25)
+
+    mixed = speech.mix(noise1, snr=10, tag="noise")
+    mixed = mixed.mix(noise2, offset_other_by=0.6, snr=10, tag="noise")
+    _, noise_only = mixed.unmix(tag="noise")
+
+    mixed_left = noise_only.mix(extra_noise, snr=5, tag="noise")
+    assert len(mixed_left.tracks) == 2
+    assert mixed_left.tracks[0].is_snr_reference
+    assert isinstance(mixed_left.tracks[0].cut, MixedCut)
+
+    mixed_right = speech.mix(noise_only, snr=5, tag="noise")
+    assert len(mixed_right.tracks) == 2
+    assert isinstance(mixed_right.tracks[1].cut, MixedCut)
+    assert not mixed_right.tracks[1].is_snr_reference
+
+
 def test_mixed_cut_load_offseted_mixed(offseted_mixed_audio_cut):
     audio = offseted_mixed_audio_cut.load_audio()
     assert audio.shape == (1, 266560)
@@ -355,6 +508,10 @@ def test_mix_cut_snr_truncate_snr_reference(libri_cut):
 
     assert len(mixed.tracks) == 2
     assert len(mixed_snr.tracks) == 2
+    assert sum(track.is_snr_reference for track in mixed_snr.tracks) == 1
+    assert [track for track in mixed_snr.tracks if track.is_snr_reference][
+        0
+    ].snr is None
 
     audio = mixed.load_audio()
     audio_snr = mixed_snr.load_audio()

--- a/test/cut/test_cut_set_mix.py
+++ b/test/cut/test_cut_set_mix.py
@@ -76,3 +76,19 @@ def test_cut_set_mixing_less_noise_cuts_than_speech_cuts_lazy_noise_cutset():
     mixed_cuts = speech_cuts.mix(noise_cuts)
     for c in mixed_cuts:
         assert isinstance(c, MixedCut)
+
+
+def test_cut_set_mixing_with_tag():
+    speech_cuts = DummyManifest(CutSet, begin_id=0, end_id=2)
+    noise_cuts = DummyManifest(CutSet, begin_id=100, end_id=102)
+    for cut in speech_cuts:
+        cut.duration = 10.0
+    for cut in noise_cuts:
+        cut.duration = 1.5
+
+    mixed_cuts = speech_cuts.mix(noise_cuts, tag="noise")
+    for cut in mixed_cuts:
+        assert isinstance(cut, MixedCut)
+        assert len(cut.tracks) > 2
+        assert cut.tracks[0].tag is None
+        assert all(track.tag == "noise" for track in cut.tracks[1:])

--- a/test/cut/test_padding_cut.py
+++ b/test/cut/test_padding_cut.py
@@ -554,6 +554,11 @@ def test_pad_both_padding_cut(padding_cut):
     assert all(isinstance(t.cut, PaddingCut) for t in cut.tracks)
 
 
+def test_unmix_is_noop_for_padding_cut(padding_cut):
+    assert padding_cut.unmix() == [padding_cut]
+    assert padding_cut.unmix(tag="noise") == [padding_cut]
+
+
 def test_pad_both_mixed_cut(mixed_libri_cut, libri_cut):
     cut = mixed_libri_cut.pad(30, direction="both")
 

--- a/test/dataset/test_cut_transforms.py
+++ b/test/dataset/test_cut_transforms.py
@@ -177,6 +177,23 @@ def test_cutmix_random_mix_offset():
         assert not np.array_equal(a.load_audio(), b.load_audio())
 
 
+def test_cutmix_tag():
+    speech_cuts = DummyManifest(CutSet, begin_id=0, end_id=2)
+    noise_cuts = DummyManifest(CutSet, begin_id=100, end_id=102)
+    for cut in speech_cuts:
+        cut.duration = 10.0
+    for cut in noise_cuts:
+        cut.duration = 1.5
+
+    tfnm = CutMix(noise_cuts, snr=None, p=1.0, tag="noise")
+    tfnm_cuts = tfnm(speech_cuts)
+
+    for cut in tfnm_cuts:
+        assert isinstance(cut, MixedCut)
+        assert cut.tracks[0].tag is None
+        assert all(track.tag == "noise" for track in cut.tracks[1:])
+
+
 @pytest.mark.parametrize("randomized", [False, True])
 @pytest.mark.parametrize("preserve_id", [False, True])
 def test_extra_padding_frames(randomized: bool, preserve_id: bool):


### PR DESCRIPTION
```python
    def unmix(self, tag: Optional[str] = None) -> List[Cut]:
        """
        Split this mixed cut into time-aligned constituent cuts.
        When ``tag`` is ``None``, this returns one cut per non-padding audible track.
        Each returned cut preserves the original offsets and overall duration, so the
        loaded audio/features can be summed to reconstruct the original mix.
        When ``tag`` is provided, this returns exactly two cuts in order:
        ``[without_tag, with_tag]``. Tracks are grouped by whether their
        :attr:`MixTrack.tag` matches ``tag``. For exact SNR preservation, the grouped
        outputs may carry an internal muted SNR-reference track that is ignored by the
        public track views but retained for mixing math.
        :param tag: Optional track-group label to split on.
        :return: A list of one cut per track, or two grouped cuts when ``tag`` is provided.
        """
```