### PR TITLE
fix numpy broadcast dtype issue in loudness normalization

### DIFF
--- a/lhotse/augmentation/loudness.py
+++ b/lhotse/augmentation/loudness.py
@@ -56,6 +56,7 @@ def normalize_loudness(
 
     assert audio.ndim == 2, f"Expected 2D audio shape, got: {audio.shape}"
 
+    dtype = audio.dtype
     duration = audio.shape[1] / sampling_rate
 
     # measure the loudness first
@@ -70,4 +71,4 @@ def normalize_loudness(
         warnings.simplefilter("ignore")
         loudness_normalized_audio = pyln.normalize.loudness(audio.T, loudness, target)
 
-    return loudness_normalized_audio.T
+    return loudness_normalized_audio.astype(dtype).T


### PR DESCRIPTION
**Issue**
With numpy >= 2.0, seems like when multiplying a np.float32 with a np.float64, it returns a np.float64. For numpy < 2, it returns np.float32. For example:

```
>>> import numpy as np
>>> np.__version__
'2.4.3'
>>> a = np.arange(10, dtype=np.float32)
>>> b = np.ones((), dtype=np.float64)
>>> (a * b).dtype
dtype('float64')
```
and:  
```
>>> import numpy as np
>>> np.__version__
'1.26.4'
>>> a = np.arange(10, dtype=np.float32)
>>> b = np.ones((), dtype=np.float64)
>>> (a * b).dtype
dtype('float32')
```

If we do the following transformations: cut → loudness normalization → resample, and our setting is **numpy >= 2 + torchaudio**:  

- loudness level is calculated as np.float64 here https://github.com/lhotse-speech/lhotse/blob/master/lhotse/augmentation/loudness.py#L65
- then the gain calculated from the loudness level is float64 and after multiplying with audio ndarray here https://github.com/csteinmetz1/pyloudnorm/blob/master/pyloudnorm/normalize.py#L58, it returns a np.float64 here https://github.com/lhotse-speech/lhotse/blob/master/lhotse/augmentation/loudness.py#L73
- and if we're using torchaudio backend, in Resample here https://github.com/lhotse-speech/lhotse/blob/master/lhotse/augmentation/torchaudio.py#L127 it'll throw an error because dtype mismatch between Double and Float  


To replicate:

```
conda create -n lhotse python=3.12
conda activate lhotse
# I think just `pip install lhotse` is fine too
git clone git@github.com:lhotse-speech/lhotse.git
cd lhotse
pip install -e '.[dev]'
pip install torchaudio pyloudnorm
```  

Then run:
```python
from lhotse import Recording
# wget https://github.com/voxserv/audio_quality_testing_samples/raw/refs/heads/master/mono_44100/127389__acclivity__thetimehascome.wav
rec = Recording.from_file("./127389__acclivity__thetimehascome.wav")
audio = rec.load_audio()
print("Original audio dtype: ", audio.dtype)

rec = rec.normalize_loudness(target=-20)
audio = rec.load_audio()
print("After audio dtype: ", audio.dtype)

rec = rec.resample(16000)
audio = rec.load_audio()
print("Loaded resampled audio")
```  

Traceback:  

```
(lhotse) ➜  test_lhotse git:(fix-numpy-broadcast-bug) ✗ python3 test.py
Original audio dtype:  float32
After audio dtype:  float64
Traceback (most recent call last):
  File "/Users/username/code/lhotse_error/lhotse/utils.py", line 854, in wrapper
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/Users/username/code/lhotse_error/lhotse/audio/recording.py", line 471, in load_audio
    audio = tfn(audio, self.sampling_rate)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/username/code/lhotse_error/lhotse/augmentation/torchaudio.py", line 127, in __call__
    augmented = self.resampler(samples)
                ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/username/miniconda3/envs/lhotse/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1779, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/username/miniconda3/envs/lhotse/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1790, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/username/code/lhotse_error/lhotse/augmentation/resample.py", line 121, in forward
    return _apply_sinc_resample_kernel(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/username/code/lhotse_error/lhotse/augmentation/resample.py", line 308, in _apply_sinc_resample_kernel
    resampled = torch.nn.functional.conv1d(waveform[:, None], kernel, stride=orig_freq)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: expected scalar type Double but found Float

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/username/code/lhotse/test_lhotse/test.py", line 12, in <module>
    audio = rec.load_audio()
            ^^^^^^^^^^^^^^^^
  File "/Users/username/code/lhotse_error/lhotse/utils.py", line 856, in wrapper
    raise type(e)(
RuntimeError: expected scalar type Double but found Float
[extra info] When calling: Recording.load_audio(args=(Recording(id='127389__acclivity__thetimehascome', sources=[AudioSource(type='file', channels=[0], source='127389__acclivity__thetimehascome.wav')], sampling_rate=16000, num_samples=447882, duration=27.992625, channel_ids=[0], transforms=[LoudnessNormalization(target=-20), Resample(source_sampling_rate=44100, target_sampling_rate=16000)]),) kwargs={})
```  

This PR adds a simple fix to revert to original dtype after loudness normalization.  

PS: this is my first time creating a public PR, apologize in advance if I miss anything.