### PR TITLE
[codex] Add indexed JSONL decode guard

### DIFF
--- a/lhotse/indexing.py
+++ b/lhotse/indexing.py
@@ -36,6 +36,7 @@ import struct
 import tarfile
 import tempfile
 import time
+from json import JSONDecodeError
 from pathlib import Path
 from typing import TYPE_CHECKING, Iterator, Optional, Tuple, Union
 
@@ -710,6 +711,7 @@ class IndexedJsonlReader:
             if self.index_path is not None
             else index_file_path(self.path)
         )
+        self._resolved_index_path = idx_path
         if not index_exists(self.path, index_path=idx_path):
             if auto_create_index:
                 create_jsonl_index(self.path, output_path=idx_path)
@@ -764,7 +766,18 @@ class IndexedJsonlReader:
         end = int(self._offsets[idx + 1])
         self._fh.seek(start)
         line = self._fh.read(end - start)
-        return decode_json_line(line.decode("utf-8"))
+        decoded_line = line.decode("utf-8")
+        try:
+            return decode_json_line(decoded_line)
+        except JSONDecodeError as ex:
+            preview = decoded_line[:120].replace("\n", "\\n").replace("\r", "\\r")
+            msg = (
+                f"{ex.msg} while decoding indexed JSONL record "
+                f"path={self.path!r} index_path={self._resolved_index_path!r} "
+                f"idx={idx} byte_range=[{start}, {end}) bytes_read={len(line)} "
+                f"preview={preview!r}"
+            )
+            raise JSONDecodeError(msg, ex.doc, ex.pos) from ex
 
     def __iter__(self):
         for i in range(len(self)):

--- a/lhotse/lazy.py
+++ b/lhotse/lazy.py
@@ -5,6 +5,7 @@ import warnings
 from collections import deque
 from contextlib import contextmanager
 from functools import partial
+from json import JSONDecodeError
 from typing import Any, Callable, Iterable, List, Literal, Optional, TypeVar, Union
 
 from lhotse.serialization import (
@@ -573,6 +574,10 @@ class LazyIndexedManifestIterator(IteratorNode):
         seed: int = 0,
         index_path: Optional[Pathlike] = None,
         decode: Optional[Callable[[dict], Any]] = None,
+        skip_decode_errors: bool = False,
+        decode_error_callback: Optional[
+            Callable[[BaseException, int, Pathlike], None]
+        ] = None,
     ) -> None:
         from lhotse.dataset.dataloading import PartitionedIndexedIterator
         from lhotse.indexing import IndexedJsonlReader
@@ -581,6 +586,8 @@ class LazyIndexedManifestIterator(IteratorNode):
         self.shuffle = shuffle
         self.seed = seed
         self.index_path = index_path
+        self.skip_decode_errors = skip_decode_errors
+        self.decode_error_callback = decode_error_callback
         self._decode = decode if decode is not None else deserialize_item
         self._reader = IndexedJsonlReader(path, index_path=index_path)
         self._iter_state = PartitionedIndexedIterator(shuffle=shuffle, seed=seed)
@@ -595,11 +602,25 @@ class LazyIndexedManifestIterator(IteratorNode):
 
     def __getitem__(self, idx: int) -> Any:
         """O(1) random access: decodes the *idx*-th item."""
+        return self._decode_index(idx)
+
+    def _decode_index(self, idx: int) -> Any:
         return attach_graph_origin(self._decode(self._reader[idx]), idx)
 
     def __iter__(self):
         for phys_idx in self._iter_state.iterate(len(self._reader)):
-            yield attach_graph_origin(self._decode(self._reader[phys_idx]), phys_idx)
+            try:
+                yield self._decode_index(phys_idx)
+            except (JSONDecodeError, UnicodeDecodeError) as ex:
+                if not self.skip_decode_errors:
+                    raise
+                if self.decode_error_callback is not None:
+                    self.decode_error_callback(ex, phys_idx, self.path)
+                else:
+                    warnings.warn(
+                        f"Skipping malformed indexed JSONL record path={self.path!r} "
+                        f"idx={phys_idx}: {type(ex).__name__}: {ex}"
+                    )
 
     def __len__(self) -> int:
         return len(self._reader)


### PR DESCRIPTION
## Summary

- Add path/index/offset context to IndexedJsonlReader JSON decode failures.
- Add optional skip_decode_errors support to LazyIndexedManifestIterator so indexed lazy iteration can skip malformed JSONL records without terminating the generator.
- Add an optional callback hook for callers that want structured warning/logging when a record is skipped.

## Why

Indexed JSONL sidecars are built from byte offsets, so index creation can succeed even when a record is empty, malformed, or read through a stale/mismatched index. The old error surfaced as a bare JSONDecodeError, which made it hard to tell whether the issue was a malformed manifest row, stale offsets, or a range-read problem.

This keeps the default behavior fail-fast, but makes failures actionable and gives downstream dataloaders a controlled opt-in skip path.

## Validation

- python -m py_compile lhotse/indexing.py lhotse/lazy.py
- Focused smoke test with a temporary indexed JSONL containing an empty record: verified contextual JSONDecodeError includes index_path, idx, and byte_range; verified LazyIndexedManifestIterator(..., skip_decode_errors=True) skips the malformed record and continues.