### PR TITLE
fix_random_seed: seed only the CPU torch RNG, not every CUDA device

### DIFF
--- a/lhotse/utils.py
+++ b/lhotse/utils.py
@@ -141,12 +141,21 @@ def is_valid_url(value: str) -> bool:
 def fix_random_seed(random_seed: int):
     """
     Set the same random seed for the libraries and modules that Lhotse interacts with.
-    Includes the ``random`` module, numpy, torch, and ``uuid4()`` function defined in this file.
+    Includes the ``random`` module, numpy, torch (CPU generator only), and ``uuid4()``
+    function defined in this file.
+
+    .. note:: This function deliberately does not touch CUDA RNG state.
+        ``torch.manual_seed`` would seed the RNG of every visible CUDA device,
+        which is surprising when this function runs inside DataLoader worker
+        processes (e.g. via :func:`~lhotse.dataset.dataloading.worker_init_fn`)
+        and can interfere with the GPU RNG state managed by the training loop.
+        Seed CUDA explicitly in your training script if you need it, e.g. with
+        ``torch.cuda.manual_seed_all(seed)``. See issue #1564 for details.
     """
     global _lhotse_uuid
     random.seed(random_seed)
     np.random.seed(random_seed)
-    torch.random.manual_seed(random_seed)
+    torch.default_generator.manual_seed(random_seed)
     # Ensure deterministic ID creation
     rd = random.Random()
     rd.seed(random_seed)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -325,3 +325,28 @@ def test_cli_list_storage_backends_marks_missing_optional_dependencies(monkeypat
     assert (
         "lilcom_hdf5 (unavailable, requires: pip install h5py lilcom)" in result.output
     )
+
+
+def test_fix_random_seed_is_deterministic_on_cpu():
+    import torch
+
+    from lhotse.utils import fix_random_seed
+
+    fix_random_seed(42)
+    a = torch.randn(3)
+    fix_random_seed(42)
+    b = torch.randn(3)
+    assert torch.equal(a, b)
+
+
+@pytest.mark.skipif(not __import__("torch").cuda.is_available(), reason="Requires CUDA")
+def test_fix_random_seed_does_not_touch_cuda_rng():
+    import torch
+
+    from lhotse.utils import fix_random_seed
+
+    states_before = torch.cuda.get_rng_state_all()
+    fix_random_seed(42)
+    states_after = torch.cuda.get_rng_state_all()
+    for before, after in zip(states_before, states_after):
+        assert torch.equal(before, after)


### PR DESCRIPTION
Fixes #1564.

Implements what was agreed in the issue: `fix_random_seed()` no longer touches CUDA RNG state and seeds only the CPU torch generator (`torch.default_generator.manual_seed`), plus `random`, numpy and lhotse's `uuid4()` as before. (Following up on the thread since the PR mentioned there didn't land yet — happy to adjust if you had a different shape in mind.)

Why: `torch.random.manual_seed()` also seeds the RNG of **every visible CUDA device** in the process. `fix_random_seed()` runs inside DataLoader workers (`worker_init_fn` in `lhotse/dataset/dataloading.py`) and at arbitrary points in user scripts, where silently rewriting GPU RNG state interferes with the training loop's own seeding policy. CUDA seeding is now explicitly the training script's responsibility, and the docstring says so.

Evidence (2x H100 NVL, torch 2.8.0):

```python
import torch, lhotse
torch.cuda.manual_seed_all(1234)          # training script's own CUDA seeding
before = torch.cuda.get_rng_state_all()
lhotse.fix_random_seed(42)                # e.g. from a worker_init_fn
after = torch.cuda.get_rng_state_all()
# master:      CUDA RNG state changed on GPUs [0, 1]
# this branch: CUDA RNG state unchanged
```

Added two tests: CPU determinism is preserved (`fix_random_seed` → identical `torch.randn` draws), and a CUDA-marked test asserting `torch.cuda.get_rng_state_all()` is unchanged by `fix_random_seed` (passes on the 2-GPU machine, skipped without CUDA).
