### PR TITLE
Add packed mmap indexes for sharded datasets

### DIFF
--- a/docs/indexed-manifests.rst
+++ b/docs/indexed-manifests.rst
@@ -62,6 +62,66 @@ index creation:
    supported remote/object-store URIs can be indexed as long as the storage
    backend supports indexed reads.
 
+Packing many sidecars into one ``.idxpack``
+-------------------------------------------
+
+A very large sharded dataset may have hundreds of thousands of ``.idx``
+sidecars. Opening one reader per shard can then spend significant time on
+filesystem metadata operations and create one Python or NumPy object per index.
+An ``.idxpack`` is an optional storage optimization for this case: it combines
+the existing sidecar payloads, ordered shard catalog, and collection metadata
+into one immutable, memory-mapped file. Opening the pack maps one file and the
+operating system faults in offset pages only when records are requested.
+
+An index pack does not replace the source data or change checkpoint semantics.
+It stores byte offsets into the original uncompressed sources, and it is built
+from sidecars that already exist. The pack itself must be a local seekable file.
+Lhotse deliberately leaves dataset discovery to the caller, so a pack can hold
+one or more application-defined logical collections (for example, a manifest
+collection and a payload collection).
+
+The following example packs two ordered CutSet JSONL shards and reads them as
+one lazy virtual collection:
+
+.. code-block:: python
+
+   from lhotse import CutSet
+   from lhotse.index_pack import (
+       IndexPackCollectionSpec,
+       write_index_pack,
+   )
+   from lhotse.packed_lazy import LazyPackedManifestIterator
+
+   paths = (
+       "/data/cuts.000000.jsonl",
+       "/data/cuts.000001.jsonl",
+   )
+   # Each path must already have a corresponding .idx sidecar.
+   spec = IndexPackCollectionSpec(
+       role="cuts",
+       kind="jsonl",
+       source_spec="/data/cuts.{000000..000001}.jsonl",
+       paths=paths,
+   )
+   write_index_pack("/data/cuts.idxpack", [spec])
+
+   source = LazyPackedManifestIterator("/data/cuts.idxpack", spec.key)
+   cuts = CutSet(source)
+   print(len(cuts), cuts[0].id)
+
+``role``, ``kind``, and ``source_spec`` define the stable collection key; their
+meaning is application-defined. ``paths`` is the exact expanded shard order
+used at runtime. Repeated physical sources are stored once inside the pack, so
+several logical collections may refer to them without duplicating offset
+payloads.
+
+Use one pack per independently configured dataset rather than one global pack
+for an entire training mixture. This keeps rebuilds, validation, and deployment
+scoped to the dataset whose source declaration changed. For direct catalog and
+byte-range lookup, use :class:`lhotse.index_pack.IndexPack`; for sharded JSONL
+manifest iteration with deterministic shuffle and checkpoint support, use
+:class:`lhotse.packed_lazy.LazyPackedManifestIterator`.
+
 Reading indexed data
 --------------------
 

--- a/examples/07-resumable-indexed-dataloading.ipynb
+++ b/examples/07-resumable-indexed-dataloading.ipynb
@@ -13,6 +13,7 @@
     "\n",
     "Key concepts covered:\n",
     "- Uncompressed `.jsonl` files with binary `.idx` indexes for O(1) access\n",
+    "- `.idxpack` files that combine many shard indexes into one memory-mapped catalog\n",
     "- `CutSet.from_file(path, indexed=True)` — the recommended way to load indexed CutSets\n",
     "- `CutSet.from_file(path, shuffle=True, seed=42)` — seed-based shuffled iteration\n",
     "- `CutSet.state_dict()` / `load_state_dict()` — checkpoint/restore mid-epoch\n",
@@ -196,6 +197,71 @@
     "print(f\"\\ncuts[0]:   {cuts[0].id}\")\n",
     "print(f\"cuts[42]:  {cuts[42].id}\")\n",
     "print(f\"cuts[-1]:  {cuts[-1].id}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sec-3-idxpack",
+   "metadata": {},
+   "source": [
+    "### Packing many shard indexes into one `.idxpack`\n",
+    "\n",
+    "A dataset with many shards normally has one `.idx` sidecar per JSONL or tar file. On a metadata-bound filesystem, opening all of those sidecars and constructing one reader per shard can dominate startup.\n",
+    "\n",
+    "An `.idxpack` combines existing sidecar payloads, their exact shard order, and a small collection catalog into one immutable file. Lhotse opens it with one read-only memory map, and the operating system loads offset pages on demand. The source JSONL files remain unchanged, and checkpoint/restore uses the same graph-token contract as loose indexes.\n",
+    "\n",
+    "Lhotse treats the pack as a generic storage primitive: the caller defines each collection's `role`, `kind`, and original `source_spec`. A practical convention is one pack per independently configured dataset, with one or more logical collections inside it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-build-idxpack",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lhotse.indexing import create_jsonl_index\n",
+    "from lhotse.index_pack import IndexPackCollectionSpec, write_index_pack\n",
+    "from lhotse.packed_lazy import LazyPackedManifestIterator\n",
+    "\n",
+    "# Write two small JSONL shards and their ordinary .idx sidecars.\n",
+    "cut_list = list(cuts_train)\n",
+    "midpoint = len(cut_list) // 2\n",
+    "packed_paths = (\n",
+    "    tmp_dir / \"mini-libri-train.000000.jsonl\",\n",
+    "    tmp_dir / \"mini-libri-train.000001.jsonl\",\n",
+    ")\n",
+    "CutSet.from_cuts(cut_list[:midpoint]).to_jsonl(packed_paths[0])\n",
+    "CutSet.from_cuts(cut_list[midpoint:]).to_jsonl(packed_paths[1])\n",
+    "for path in packed_paths:\n",
+    "    create_jsonl_index(path)\n",
+    "\n",
+    "# Pack the existing sidecars; source files are not rescanned.\n",
+    "pack_spec = IndexPackCollectionSpec(\n",
+    "    role=\"cuts\",\n",
+    "    kind=\"jsonl\",\n",
+    "    source_spec=\"mini-libri-train.{000000..000001}.jsonl\",\n",
+    "    paths=tuple(map(str, packed_paths)),\n",
+    ")\n",
+    "pack_path = tmp_dir / \"mini-libri-train.idxpack\"\n",
+    "write_index_pack(pack_path, [pack_spec], overwrite=True)\n",
+    "print(f\"Wrote {pack_path} ({pack_path.stat().st_size:,} bytes)\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cell-read-idxpack",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The packed iterator exposes both global integer lookup and resumable iteration.\n",
+    "packed_source = LazyPackedManifestIterator(pack_path, pack_spec.key)\n",
+    "packed_cuts = CutSet(packed_source)\n",
+    "assert [cut.id for cut in packed_cuts] == [cut.id for cut in cuts_train]\n",
+    "print(f\"records={len(packed_cuts)}, shards={packed_source.collection.sequence_count}\")\n",
+    "print(f\"packed_cuts[42]: {packed_cuts[42].id}\")\n",
+    "print(f\"offset bytes copied into Python memory: {packed_source.index_pack.resident_offsets_bytes}\")"
    ]
   },
   {
@@ -834,6 +900,8 @@
     "| Shuffled iteration | `CutSet.from_file(path, shuffle=True, seed=42)` |\n",
     "| CutSet checkpoint | `sd = cuts.state_dict()` |\n",
     "| CutSet restore | `cuts.load_state_dict(sd)` |\n",
+    "| Pack many sidecars | `write_index_pack(path, [IndexPackCollectionSpec(...)])` |\n",
+    "| Read a packed JSONL collection | `LazyPackedManifestIterator(pack, collection_key)` |\n",
     "| Shar with indexes | `cuts.to_shar(..., compress_jsonl=False, create_index=True)` |\n",
     "| Shar random access | `CutSet.from_shar(in_dir=...)` then `cuts.data[idx]` |\n",
     "| Single-process pipeline checkpoint | `IterableDatasetWrapper.state_dict()` / `load_state_dict()` with `DataLoader(..., num_workers=0)` |\n",

--- a/lhotse/index_pack.py
+++ b/lhotse/index_pack.py
@@ -1495,7 +1495,7 @@ def _register_index_pack(pack: IndexPack) -> None:
     _INDEX_PACK_CACHE[str(pack.path.absolute())] = pack
 
 
-_INDEX_PACK_CACHE: weakref.WeakValueDictionary[str, IndexPack] = (
-    weakref.WeakValueDictionary()
-)
+_INDEX_PACK_CACHE: weakref.WeakValueDictionary[
+    str, IndexPack
+] = weakref.WeakValueDictionary()
 _INDEX_PACK_CACHE_PID = os.getpid()

--- a/lhotse/index_pack.py
+++ b/lhotse/index_pack.py
@@ -733,9 +733,13 @@ class IndexPack:
         if isinstance(key, str):
             key = bytes.fromhex(key)
         try:
-            sequence_start, sequence_count, total_records, kind, offsets_required = (
-                self._collections[key]
-            )
+            (
+                sequence_start,
+                sequence_count,
+                total_records,
+                kind,
+                offsets_required,
+            ) = self._collections[key]
         except KeyError as ex:
             raise KeyError(
                 f"Collection {key.hex()} is not present in index pack {self.path}"
@@ -1283,7 +1287,7 @@ def _register_index_pack(pack: IndexPack) -> None:
     _INDEX_PACK_CACHE[str(pack.path.absolute())] = pack
 
 
-_INDEX_PACK_CACHE: weakref.WeakValueDictionary[str, IndexPack] = (
-    weakref.WeakValueDictionary()
-)
+_INDEX_PACK_CACHE: weakref.WeakValueDictionary[
+    str, IndexPack
+] = weakref.WeakValueDictionary()
 _INDEX_PACK_CACHE_PID = os.getpid()

--- a/lhotse/index_pack.py
+++ b/lhotse/index_pack.py
@@ -653,18 +653,20 @@ class PackedIndexCollection:
 
 class IndexPack:
     """
-    Read-only, memory-mapped view of an ``.idxpack``.
+    Lazy, read-only view of an ``.idxpack``.
 
-    Opening a pack validates its fixed-size catalog and maps the file into
-    virtual memory; it does not copy the offset payload into Python or NumPy
-    memory. Obtain a logical collection with :meth:`collection`, then use
-    :meth:`PackedIndexCollection.locate` to resolve record indices. The source
-    record itself is intentionally not read by this class.
+    Construction reads the compact collection catalog with temporary
+    positional reads and closes the file before returning. This makes lengths,
+    kinds, and collection lookup available while a data-loader graph is being
+    assembled without leaving a file descriptor or mmap to be inherited by
+    worker processes. The complete pack is opened, deeply validated, and
+    memory-mapped only when a record, shard path, or segment is first accessed.
+    Offset payloads are never copied into Python or NumPy memory.
 
-    The mapping is reopened automatically after ``fork()`` and the object is
-    pickle-safe for data-loader workers. Use it as a context manager when a
-    deterministic close is desired, or use :func:`open_index_pack` to share one
-    mapping per absolute path and process.
+    The lazy mapping is process-local and the object is pickle-safe for
+    data-loader workers. Use it as a context manager when a deterministic close
+    is desired, or use :func:`open_index_pack` to share one view per absolute
+    path and process.
 
     Args:
         path:
@@ -711,7 +713,7 @@ class IndexPack:
         self._pid = None
         self._file_identity = None
         self._collections = {}
-        self._open()
+        self._read_catalog()
 
     def collection(self, key: bytes | str) -> PackedIndexCollection:
         """
@@ -729,7 +731,6 @@ class IndexPack:
             KeyError:
                 If no collection with ``key`` exists in this pack.
         """
-        self._ensure_open()
         if isinstance(key, str):
             key = bytes.fromhex(key)
         try:
@@ -771,6 +772,7 @@ class IndexPack:
             ValueError:
                 If the payload checksum does not match.
         """
+        self._ensure_open()
         segment = self._segment(segment_id)
         offsets_position = segment[1]
         offsets_size = segment[6]
@@ -812,6 +814,20 @@ class IndexPack:
             "path": self.path,
             "expected_layout_hash": self.expected_layout_hash,
             "file_identity": self._file_identity,
+            "catalog": {
+                "collection_offset": self.collection_offset,
+                "num_collections": self.num_collections,
+                "sequence_offset": self.sequence_offset,
+                "num_sequences": self.num_sequences,
+                "segment_offset": self.segment_offset,
+                "num_segments": self.num_segments,
+                "strings_offset": self.strings_offset,
+                "strings_size": self.strings_size,
+                "offsets_offset": self.offsets_offset,
+                "offsets_size": self.offsets_size,
+                "layout_hash": self.layout_hash,
+                "collections": self._collections,
+            },
         }
 
     def __setstate__(self, state):
@@ -821,8 +837,262 @@ class IndexPack:
         self._mmap = None
         self._pid = None
         self._file_identity = state.get("file_identity")
-        self._collections = {}
-        self._open()
+        catalog = state.get("catalog")
+        if catalog is None:
+            # Compatibility with objects pickled before catalog-only opening.
+            self._collections = {}
+            self._read_catalog()
+            return
+        self.collection_offset = catalog["collection_offset"]
+        self.num_collections = catalog["num_collections"]
+        self.sequence_offset = catalog["sequence_offset"]
+        self.num_sequences = catalog["num_sequences"]
+        self.segment_offset = catalog["segment_offset"]
+        self.num_segments = catalog["num_segments"]
+        self.strings_offset = catalog["strings_offset"]
+        self.strings_size = catalog["strings_size"]
+        self.offsets_offset = catalog["offsets_offset"]
+        self.offsets_size = catalog["offsets_size"]
+        self.layout_hash = catalog["layout_hash"]
+        self._collections = catalog["collections"]
+
+    def _read_header(self, source, file_size: int) -> None:
+        """Decode and validate the common on-disk section layout."""
+        (
+            magic,
+            version,
+            header_size,
+            self.collection_offset,
+            self.num_collections,
+            self.sequence_offset,
+            self.num_sequences,
+            self.segment_offset,
+            self.num_segments,
+            self.strings_offset,
+            self.strings_size,
+            self.offsets_offset,
+            self.offsets_size,
+            self.layout_hash,
+        ) = _HEADER.unpack_from(source, 0)
+        if magic != _MAGIC:
+            raise ValueError(
+                f"Invalid index-pack header magic in {self.path}: {magic!r}"
+            )
+        if version != _VERSION or header_size != _HEADER_SIZE:
+            raise ValueError(
+                f"Unsupported index-pack header in {self.path}: "
+                f"version={version}, header_size={header_size}"
+            )
+        sections = (
+            (
+                "collections",
+                self.collection_offset,
+                self.num_collections * _COLLECTION.size,
+            ),
+            (
+                "sequences",
+                self.sequence_offset,
+                self.num_sequences * _SEQUENCE.size,
+            ),
+            (
+                "segments",
+                self.segment_offset,
+                self.num_segments * _SEGMENT.size,
+            ),
+            ("strings", self.strings_offset, self.strings_size),
+            ("offsets", self.offsets_offset, self.offsets_size),
+        )
+        for name, offset, size in sections:
+            if offset < _HEADER_SIZE or size < 0 or offset + size > file_size:
+                raise ValueError(
+                    f"Index pack has truncated/invalid {name} section: "
+                    f"offset={offset}, size={size}, file_size={file_size}"
+                )
+        expected_sections = (
+            ("collections", self.collection_offset, _HEADER_SIZE),
+            (
+                "sequences",
+                self.sequence_offset,
+                self.collection_offset + self.num_collections * _COLLECTION.size,
+            ),
+            (
+                "segments",
+                self.segment_offset,
+                self.sequence_offset + self.num_sequences * _SEQUENCE.size,
+            ),
+            (
+                "strings",
+                self.strings_offset,
+                self.segment_offset + self.num_segments * _SEGMENT.size,
+            ),
+        )
+        for name, actual, expected_offset in expected_sections:
+            if actual != expected_offset:
+                raise ValueError(
+                    f"Index pack has invalid {name} offset: "
+                    f"{actual} != {expected_offset}"
+                )
+        expected_offsets_offset = self.strings_offset + self.strings_size
+        expected_offsets_offset += (-expected_offsets_offset) % _U64.size
+        if (
+            self.offsets_offset != expected_offsets_offset
+            or self.offsets_offset + self.offsets_size != file_size
+        ):
+            raise ValueError(
+                "Index pack sections overlap, contain gaps, or do not cover the complete file"
+            )
+        expected = self.expected_layout_hash
+        if expected is not None:
+            if isinstance(expected, str):
+                expected = bytes.fromhex(expected)
+            if expected != self.layout_hash:
+                raise ValueError(
+                    f"Index-pack layout mismatch for {self.path}: "
+                    f"expected={expected.hex()}, actual={self.layout_hash.hex()}"
+                )
+
+    def _read_catalog(self) -> None:
+        """
+        Read construction-time metadata without retaining an fd or mmap.
+
+        Deep validation of every sequence and segment is intentionally deferred
+        to :meth:`_open`. The catalog phase validates the file layout,
+        collection directory, collection endpoints, and the first segment used
+        to determine whether each collection is path-only.
+        """
+        try:
+            fh = self.path.open("rb")
+        except FileNotFoundError as ex:
+            raise FileNotFoundError(f"Index pack not found: {self.path}") from ex
+        try:
+            stat = os.fstat(fh.fileno())
+            identity = (stat.st_dev, stat.st_ino, stat.st_size, stat.st_mtime_ns)
+            if self._file_identity is not None and identity != self._file_identity:
+                raise RuntimeError(
+                    f"Index pack changed after it was opened: {self.path}; "
+                    "reconstruct the dataset to use the replacement"
+                )
+            file_size = stat.st_size
+            if file_size < _HEADER_SIZE:
+                raise ValueError(
+                    f"Index pack is truncated before its {_HEADER_SIZE}-byte header: {self.path}"
+                )
+            header = _pread_exact(fh.fileno(), _HEADER_SIZE, 0)
+            self._read_header(header, file_size)
+
+            collections = {}
+            expected_sequence_start = 0
+            collection_table = _pread_exact(
+                fh.fileno(),
+                self.num_collections * _COLLECTION.size,
+                self.collection_offset,
+            )
+            for collection_id in range(self.num_collections):
+                (
+                    key,
+                    sequence_start,
+                    sequence_count,
+                    total_records,
+                    kind_position,
+                    kind_length,
+                    flags,
+                ) = _COLLECTION.unpack_from(
+                    collection_table, collection_id * _COLLECTION.size
+                )
+                if flags & ~_COLLECTION_PATHS_ONLY:
+                    raise ValueError(
+                        f"Index pack collection {collection_id} has unsupported flags: {flags:#x}"
+                    )
+                if (
+                    sequence_start != expected_sequence_start
+                    or sequence_start + sequence_count > self.num_sequences
+                ):
+                    raise ValueError(
+                        f"Index pack collection {collection_id} has an invalid sequence range"
+                    )
+                if key in collections:
+                    raise ValueError(
+                        f"Duplicate collection key in index pack: {key.hex()}"
+                    )
+                kind = self._pread_string(
+                    fh.fileno(),
+                    kind_position,
+                    kind_length,
+                    label=f"collection {collection_id} kind",
+                )
+                declared_paths_only = bool(flags & _COLLECTION_PATHS_ONLY)
+                paths_only = declared_paths_only
+                if sequence_count:
+                    segment_id, _ = _SEQUENCE.unpack(
+                        _pread_exact(
+                            fh.fileno(),
+                            _SEQUENCE.size,
+                            self.sequence_offset + sequence_start * _SEQUENCE.size,
+                        )
+                    )
+                    if segment_id >= self.num_segments:
+                        raise ValueError(
+                            f"Index pack collection {collection_id} has corrupt sequence metadata"
+                        )
+                    segment = _SEGMENT.unpack(
+                        _pread_exact(
+                            fh.fileno(),
+                            _SEGMENT.size,
+                            self.segment_offset + segment_id * _SEGMENT.size,
+                        )
+                    )
+                    paths_only = bool(segment[3] & _SEGMENT_PATH_ONLY)
+                    _, final_cumulative = _SEQUENCE.unpack(
+                        _pread_exact(
+                            fh.fileno(),
+                            _SEQUENCE.size,
+                            self.sequence_offset
+                            + (sequence_start + sequence_count - 1) * _SEQUENCE.size,
+                        )
+                    )
+                    if final_cumulative != total_records:
+                        raise ValueError(
+                            f"Index pack collection {collection_id} has corrupt "
+                            f"cumulative count for its final shard: "
+                            f"{final_cumulative} != {total_records}"
+                        )
+                if declared_paths_only and not paths_only:
+                    raise ValueError(
+                        f"Index pack collection {collection_id} is marked path-only "
+                        "but references indexed segments"
+                    )
+                if paths_only and total_records != 0:
+                    raise ValueError(
+                        f"Index pack collection {collection_id} has an invalid total record count"
+                    )
+                collections[key] = (
+                    sequence_start,
+                    sequence_count,
+                    total_records,
+                    kind,
+                    not paths_only,
+                )
+                expected_sequence_start += sequence_count
+            if expected_sequence_start != self.num_sequences:
+                raise ValueError("Index pack contains unreferenced sequence rows")
+            self._collections = collections
+            self._file_identity = identity
+        finally:
+            fh.close()
+
+    def _pread_string(self, fd: int, position: int, length: int, *, label: str) -> str:
+        if (
+            position < self.strings_offset
+            or position + length > self.strings_offset + self.strings_size
+        ):
+            raise ValueError(
+                f"Index pack {label} points outside the strings section: "
+                f"position={position}, length={length}"
+            )
+        try:
+            return _pread_exact(fd, length, position).decode("utf-8")
+        except UnicodeDecodeError as ex:
+            raise ValueError(f"Index pack {label} is not valid UTF-8") from ex
 
     def _open(self) -> None:
         try:
@@ -848,95 +1118,11 @@ class IndexPack:
         self._mmap = mmap.mmap(self._fh.fileno(), 0, access=mmap.ACCESS_READ)
         self._pid = os.getpid()
         self._file_identity = identity
-        values = _HEADER.unpack_from(self._mmap, 0)
-        (
-            magic,
-            version,
-            header_size,
-            self.collection_offset,
-            self.num_collections,
-            self.sequence_offset,
-            self.num_sequences,
-            self.segment_offset,
-            self.num_segments,
-            self.strings_offset,
-            self.strings_size,
-            self.offsets_offset,
-            self.offsets_size,
-            self.layout_hash,
-        ) = values
-        if magic != _MAGIC:
+        try:
+            self._read_header(self._mmap, file_size)
+        except Exception:
             self.close()
-            raise ValueError(
-                f"Invalid index-pack header magic in {self.path}: {magic!r}"
-            )
-        if version != _VERSION or header_size != _HEADER_SIZE:
-            self.close()
-            raise ValueError(
-                f"Unsupported index-pack header in {self.path}: version={version}, header_size={header_size}"
-            )
-        sections = (
-            (
-                "collections",
-                self.collection_offset,
-                self.num_collections * _COLLECTION.size,
-            ),
-            ("sequences", self.sequence_offset, self.num_sequences * _SEQUENCE.size),
-            ("segments", self.segment_offset, self.num_segments * _SEGMENT.size),
-            ("strings", self.strings_offset, self.strings_size),
-            ("offsets", self.offsets_offset, self.offsets_size),
-        )
-        for name, offset, size in sections:
-            if offset < _HEADER_SIZE or size < 0 or offset + size > file_size:
-                self.close()
-                raise ValueError(
-                    f"Index pack has truncated/invalid {name} section: "
-                    f"offset={offset}, size={size}, file_size={file_size}"
-                )
-        expected_sections = (
-            ("collections", self.collection_offset, _HEADER_SIZE),
-            (
-                "sequences",
-                self.sequence_offset,
-                self.collection_offset + self.num_collections * _COLLECTION.size,
-            ),
-            (
-                "segments",
-                self.segment_offset,
-                self.sequence_offset + self.num_sequences * _SEQUENCE.size,
-            ),
-            (
-                "strings",
-                self.strings_offset,
-                self.segment_offset + self.num_segments * _SEGMENT.size,
-            ),
-        )
-        for name, actual, expected_offset in expected_sections:
-            if actual != expected_offset:
-                self.close()
-                raise ValueError(
-                    f"Index pack has invalid {name} offset: {actual} != {expected_offset}"
-                )
-        expected_offsets_offset = self.strings_offset + self.strings_size
-        expected_offsets_offset += (-expected_offsets_offset) % _U64.size
-        if (
-            self.offsets_offset != expected_offsets_offset
-            or self.offsets_offset + self.offsets_size != file_size
-        ):
-            self.close()
-            raise ValueError(
-                "Index pack sections overlap, contain gaps, or do not cover the complete file"
-            )
-        expected = self.expected_layout_hash
-        if expected is not None:
-            if isinstance(expected, str):
-                expected = bytes.fromhex(expected)
-            if expected != self.layout_hash:
-                actual = self.layout_hash.hex()
-                self.close()
-                raise ValueError(
-                    f"Index-pack layout mismatch for {self.path}: expected={expected.hex()}, actual={actual}"
-                )
+            raise
         offsets_cursor = self.offsets_offset
         for segment_id in range(self.num_segments):
             segment = self._segment(segment_id)
@@ -982,6 +1168,7 @@ class IndexPack:
                 "Index pack segment payloads do not cover the offsets section"
             )
 
+        collections = {}
         expected_sequence_start = 0
         for collection_id in range(self.num_collections):
             row = _COLLECTION.unpack_from(
@@ -1010,7 +1197,7 @@ class IndexPack:
                 raise ValueError(
                     f"Index pack collection {collection_id} has an invalid sequence range"
                 )
-            if key in self._collections:
+            if key in collections:
                 self.close()
                 raise ValueError(f"Duplicate collection key in index pack: {key.hex()}")
             kind = self._string(
@@ -1059,7 +1246,7 @@ class IndexPack:
                 raise ValueError(
                     f"Index pack collection {collection_id} has an invalid total record count"
                 )
-            self._collections[key] = (
+            collections[key] = (
                 sequence_start,
                 sequence_count,
                 total_records,
@@ -1071,15 +1258,16 @@ class IndexPack:
         if expected_sequence_start != self.num_sequences:
             self.close()
             raise ValueError("Index pack contains unreferenced sequence rows")
+        self._collections = collections
 
     def _ensure_open(self) -> None:
         if self._mmap is None or self._pid != os.getpid():
             self.close()
-            self._collections = {}
             self._open()
             _register_index_pack(self)
 
     def _sequence(self, index: int) -> tuple[int, int]:
+        self._ensure_open()
         if index < 0 or index >= self.num_sequences:
             raise IndexError(f"Index-pack sequence index out of range: {index}")
         return _SEQUENCE.unpack_from(
@@ -1087,6 +1275,7 @@ class IndexPack:
         )
 
     def _segment(self, index: int):
+        self._ensure_open()
         if index < 0 or index >= self.num_segments:
             raise IndexError(f"Index-pack segment index out of range: {index}")
         return _SEGMENT.unpack_from(
@@ -1094,9 +1283,11 @@ class IndexPack:
         )
 
     def _u64(self, position: int) -> int:
+        self._ensure_open()
         return _U64.unpack_from(self._mmap, position)[0]
 
     def _string(self, position: int, length: int, *, label: str) -> str:
+        self._ensure_open()
         if (
             position < self.strings_offset
             or position + length > self.strings_offset + self.strings_size
@@ -1112,15 +1303,15 @@ class IndexPack:
 
 def open_index_pack(path) -> IndexPack:
     """
-    Return one shared read-only pack mapping per absolute path and process.
+    Return one shared lazy pack view per absolute path and process.
 
     Args:
         path:
             Local ``.idxpack`` path.
 
     Returns:
-        A process-local cached :class:`IndexPack`. After ``fork()``, the child
-        creates its own mapping on first access.
+        A process-local cached :class:`IndexPack`. Construction retains only
+        the catalog; each child creates its own mapping on first data access.
     """
     global _INDEX_PACK_CACHE_PID
     pid = os.getpid()
@@ -1265,6 +1456,23 @@ def _is_remote_path(path) -> bool:
     return is_valid_url(str(path))
 
 
+def _pread_exact(fd: int, size: int, offset: int) -> bytes:
+    """Read exactly ``size`` bytes at ``offset`` without changing fd position."""
+    chunks = []
+    remaining = size
+    while remaining:
+        chunk = os.pread(fd, remaining, offset)
+        if not chunk:
+            raise EOFError(
+                f"Short positional read: requested {size} bytes at offset "
+                f"{offset - (size - remaining)}, received {size - remaining}"
+            )
+        chunks.append(chunk)
+        offset += len(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
 def _fsync_directory(path: Path) -> None:
     if not hasattr(os, "O_DIRECTORY"):
         return
@@ -1287,7 +1495,7 @@ def _register_index_pack(pack: IndexPack) -> None:
     _INDEX_PACK_CACHE[str(pack.path.absolute())] = pack
 
 
-_INDEX_PACK_CACHE: weakref.WeakValueDictionary[
-    str, IndexPack
-] = weakref.WeakValueDictionary()
+_INDEX_PACK_CACHE: weakref.WeakValueDictionary[str, IndexPack] = (
+    weakref.WeakValueDictionary()
+)
 _INDEX_PACK_CACHE_PID = os.getpid()

--- a/lhotse/index_pack.py
+++ b/lhotse/index_pack.py
@@ -1,0 +1,1289 @@
+"""
+Packed, memory-mapped random-access indexes for sharded byte-addressable data.
+
+An ``.idxpack`` combines the contents of many conventional little-endian
+``uint64`` ``.idx`` sidecars into one immutable file. Its catalog and offset
+payload are accessed through a single read-only mmap, so opening a large
+collection does not require one filesystem operation or one in-memory offset
+array per source shard.
+
+This module is deliberately independent of manifest schemas and downstream
+frameworks. Callers describe each logical collection with an application-defined
+role, an arbitrary storage-kind string, the original source specification, and
+the ordered concrete source paths. The pack stores that catalog and provides
+byte-range lookup; interpreting the bytes remains the caller's responsibility.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import mmap
+import os
+import struct
+import uuid
+import weakref
+import zlib
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from lhotse.indexing import index_file_path
+from lhotse.utils import is_valid_url
+
+# Keep these values stable: production packs created by the original format
+# implementation already use this signature and version.
+_MAGIC = b"IDXPACK2"
+_VERSION = 2
+_HEADER_SIZE = 256
+
+# Header fields:
+# magic, format version, header size,
+# (offset, count/size) for collections, sequences, segments, strings, offsets,
+# layout SHA-256.
+_HEADER = struct.Struct("<8sIIQQQQQQQQQQ32s")
+
+# Collection fields:
+# key, sequence start, sequence count, total records,
+# kind-string position, kind-string length, reserved flags.
+_COLLECTION = struct.Struct("<32sQQQQII")
+_COLLECTION_PATHS_ONLY = 1
+
+# Sequence fields:
+# segment ID, cumulative record count through this shard.
+_SEQUENCE = struct.Struct("<QQ")
+
+# Segment fields:
+# path-string position, offsets position, path-string length, flags,
+# offset count, source size, offsets byte size, CRC32, reserved.
+_SEGMENT = struct.Struct("<QQIIQQQII")
+_SEGMENT_PATH_ONLY = 1
+_U64 = struct.Struct("<Q")
+
+
+def index_pack_collection_key(role: str, kind: str, source_spec) -> bytes:
+    """
+    Return the stable SHA-256 key for one logical collection.
+
+    Args:
+        role:
+            Application-defined purpose of the collection, such as
+            ``"manifest"`` or ``"features"``. The value is not interpreted by
+            Lhotse.
+        kind:
+            Application-defined storage/serialization identifier. Any non-empty
+            string is accepted and persisted in the pack.
+        source_spec:
+            JSON-serializable source description used by the caller before
+            concrete paths were expanded. It participates in identity so two
+            differently declared collections may reference the same paths.
+
+    Returns:
+        A 32-byte digest used to retrieve the collection from an
+        :class:`IndexPack`.
+    """
+    _validate_collection_identity(role, kind)
+    payload = json.dumps(
+        {
+            "kind": kind,
+            "role": role,
+            "source_spec": _canonicalize(source_spec),
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return hashlib.sha256(payload).digest()
+
+
+@dataclass(frozen=True)
+class IndexPackCollectionSpec:
+    """
+    Build-time description of one ordered logical collection.
+
+    Args:
+        role:
+            Application-defined purpose of this collection. It distinguishes
+            collections that use the same storage kind and source declaration
+            for different purposes; Lhotse does not interpret it.
+        kind:
+            Application-defined storage/serialization name, for example
+            ``"json-lines"`` or ``"tar-members"``. The string is persisted for
+            runtime validation but does not change how offsets are stored.
+        source_spec:
+            JSON-serializable source expression before expansion (a path
+            template, list, or mapping, for example). Together with ``role`` and
+            ``kind`` it defines :attr:`key`; it is not otherwise interpreted.
+        paths:
+            Concrete source paths in logical shard order. By default every path
+            must have a conventional ``.idx`` sidecar whose final uint64 is the
+            source-size sentinel.
+        offsets_required:
+            When true, copy and validate each path's sidecar. When false, retain
+            only the ordered paths; the resulting collection has zero logical
+            records and is intended for callers that only need
+            :meth:`PackedIndexCollection.path_for_shard`.
+    """
+
+    role: str
+    kind: str
+    source_spec: object
+    paths: tuple[str, ...]
+    offsets_required: bool = True
+
+    def __post_init__(self):
+        _validate_collection_identity(self.role, self.kind)
+        object.__setattr__(self, "paths", tuple(str(path) for path in self.paths))
+
+    @property
+    def key(self) -> bytes:
+        """Return the stable lookup key derived from this specification."""
+        return index_pack_collection_key(self.role, self.kind, self.source_spec)
+
+
+@dataclass(frozen=True)
+class PackedIndexLocation:
+    """
+    Resolved source byte range for one logical record.
+
+    Attributes:
+        path:
+            Concrete source path containing the record.
+        start:
+            Inclusive byte offset in ``path``.
+        end:
+            Exclusive byte offset in ``path``.
+        segment_id:
+            Physical segment-table row used for the lookup. A segment may be
+            shared by several logical collections.
+        shard_index:
+            Position of the source path in this collection's ordered shard
+            sequence.
+        local_index:
+            Zero-based record position within that shard.
+    """
+
+    path: str
+    start: int
+    end: int
+    segment_id: int
+    shard_index: int
+    local_index: int
+
+
+def write_index_pack(
+    output_path,
+    collections: Sequence[IndexPackCollectionSpec],
+    *,
+    indexes_root=None,
+    overwrite: bool = False,
+) -> Path:
+    """
+    Convert existing sidecar indexes into one atomic ``.idxpack``.
+
+    Collection order and path order are preserved. Repeated physical sources
+    are stored once inside a pack and referenced by multiple sequence entries.
+    The output is written to a temporary sibling, flushed with ``fsync()``, and
+    atomically published after all sidecars pass structural validation.
+
+    Args:
+        output_path:
+            Destination pack path.
+        collections:
+            Logical collections belonging to one dataset. A dataset may contain
+            several collections (for example records and payload members).
+        indexes_root:
+            Optional mirror root passed to :func:`lhotse.indexing.index_file_path`
+            when resolving each conventional sidecar.
+        overwrite:
+            Replace an existing destination atomically. The default is to fail
+            if ``output_path`` already exists.
+
+    Returns:
+        ``output_path`` normalized to :class:`~pathlib.Path`.
+
+    Raises:
+        FileNotFoundError:
+            If a required sidecar or local source is absent.
+        ValueError:
+            If identities collide, a source is newer than its sidecar, offsets
+            are malformed/non-monotonic, or a sentinel disagrees with source
+            size.
+
+    Example:
+        Build one pack per dataset for a two-dataset composition. Each pack may
+        still contain multiple logical collections::
+
+            datasets = {
+                "books": [
+                    IndexPackCollectionSpec(
+                        role="records",
+                        kind="json-lines",
+                        source_spec="books-{000..127}.jsonl",
+                        paths=tuple(book_shards),
+                    )
+                ],
+                "speech": [
+                    IndexPackCollectionSpec(
+                        role="records",
+                        kind="json-lines",
+                        source_spec="speech-{000..255}.jsonl",
+                        paths=tuple(speech_manifests),
+                    ),
+                    IndexPackCollectionSpec(
+                        role="payload",
+                        kind="tar-members",
+                        source_spec="speech-{000..255}.tar",
+                        paths=tuple(speech_tars),
+                    ),
+                ],
+            }
+            for dataset_name, specs in datasets.items():
+                write_index_pack(
+                    f"{dataset_name}.idxpack",
+                    specs,
+                    indexes_root="/srv/index-mirror",
+                )
+    """
+    output_path = Path(output_path)
+    collections = tuple(collections)
+    if not collections:
+        raise ValueError("Cannot build an index pack without collections.")
+    if output_path.exists() and not overwrite:
+        raise FileExistsError(f"Index pack already exists: {output_path}")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    collection_keys: set[bytes] = set()
+    segments: list[_BuildSegment] = []
+    segment_ids: dict[tuple[str, bool], int] = {}
+    sequences: list[tuple[int, int]] = []
+    collection_rows: list[tuple[bytes, int, int, int, int, int, int]] = []
+    strings = _StringTableBuilder()
+
+    for collection in collections:
+        if collection.key in collection_keys:
+            raise ValueError(
+                "Duplicate collection key in index pack. Distinguish repeated logical "
+                f"collections with a different role/source spec: {collection.source_spec!r}"
+            )
+        collection_keys.add(collection.key)
+        sequence_start = len(sequences)
+        cumulative_end = 0
+        for path in collection.paths:
+            segment_key = (path, collection.offsets_required)
+            segment_id = segment_ids.get(segment_key)
+            if segment_id is None:
+                segment_id = len(segments)
+                segment_ids[segment_key] = segment_id
+                segments.append(
+                    _read_sidecar_metadata(
+                        path,
+                        indexes_root,
+                        offsets_required=collection.offsets_required,
+                    )
+                )
+            cumulative_end += segments[segment_id].num_records
+            sequences.append((segment_id, cumulative_end))
+        kind_position, kind_length = strings.add(collection.kind)
+        collection_rows.append(
+            (
+                collection.key,
+                sequence_start,
+                len(collection.paths),
+                cumulative_end,
+                kind_position,
+                kind_length,
+                0 if collection.offsets_required else _COLLECTION_PATHS_ONLY,
+            )
+        )
+
+    path_positions = [strings.add(segment.path) for segment in segments]
+    string_blob = bytes(strings.data)
+
+    collection_offset = _HEADER_SIZE
+    sequence_offset = collection_offset + len(collection_rows) * _COLLECTION.size
+    segment_offset = sequence_offset + len(sequences) * _SEQUENCE.size
+    strings_offset = segment_offset + len(segments) * _SEGMENT.size
+    offsets_offset = strings_offset + len(string_blob)
+    offsets_offset += (-offsets_offset) % _U64.size
+    offsets_size = sum(segment.offsets_count * _U64.size for segment in segments)
+    layout_hash = _layout_digest(collections)
+
+    tmp_path = output_path.with_name(
+        f".{output_path.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}"
+    )
+    segment_rows = []
+    try:
+        with tmp_path.open("w+b") as out:
+            header = _HEADER.pack(
+                _MAGIC,
+                _VERSION,
+                _HEADER_SIZE,
+                collection_offset,
+                len(collection_rows),
+                sequence_offset,
+                len(sequences),
+                segment_offset,
+                len(segments),
+                strings_offset,
+                len(string_blob),
+                offsets_offset,
+                offsets_size,
+                layout_hash,
+            )
+            out.write(header)
+            out.write(b"\0" * (_HEADER_SIZE - len(header)))
+
+            for (
+                key,
+                sequence_start,
+                sequence_count,
+                total_records,
+                kind_rel,
+                kind_len,
+                flags,
+            ) in collection_rows:
+                out.write(
+                    _COLLECTION.pack(
+                        key,
+                        sequence_start,
+                        sequence_count,
+                        total_records,
+                        strings_offset + kind_rel,
+                        kind_len,
+                        flags,
+                    )
+                )
+            for row in sequences:
+                out.write(_SEQUENCE.pack(*row))
+
+            # Filled after payload copy, once each sidecar CRC is known.
+            out.write(b"\0" * (len(segments) * _SEGMENT.size))
+
+            out.write(string_blob)
+            if out.tell() < offsets_offset:
+                out.write(b"\0" * (offsets_offset - out.tell()))
+
+            payload_cursor = offsets_offset
+            for segment_id, segment in enumerate(segments):
+                expected_size = segment.offsets_count * _U64.size
+                checksum = 0
+                copied = 0
+                previous: int | None = None
+                if segment.path_only:
+                    chunk = _U64.pack(0)
+                    checksum = zlib.crc32(chunk)
+                    copied = len(chunk)
+                    previous = 0
+                    out.write(chunk)
+                else:
+                    assert segment.index_path is not None
+                    with segment.index_path.open("rb") as src:
+                        while chunk := src.read(1024 * 1024):
+                            if len(chunk) % _U64.size:
+                                raise ValueError(
+                                    f"Index chunk is not uint64-aligned: {segment.index_path}"
+                                )
+                            for (value,) in struct.iter_unpack("<Q", chunk):
+                                if previous is not None and value < previous:
+                                    raise ValueError(
+                                        f"Non-monotonic offsets in {segment.index_path}: "
+                                        f"{value} follows {previous}"
+                                    )
+                                previous = value
+                            checksum = zlib.crc32(chunk, checksum)
+                            copied += len(chunk)
+                            out.write(chunk)
+                if copied != expected_size:
+                    raise ValueError(
+                        f"Index changed while packing {segment.index_path}: "
+                        f"expected {expected_size} bytes, copied {copied}"
+                    )
+                if previous is None:
+                    raise ValueError(
+                        f"Index sidecar contains no sentinel: {segment.index_path}"
+                    )
+                source_size = (
+                    previous if segment.source_size is None else segment.source_size
+                )
+                if previous != source_size:
+                    raise ValueError(
+                        f"Invalid sentinel in {segment.index_path}: metadata={source_size}, payload={previous}"
+                    )
+                path_rel, path_len = path_positions[segment_id]
+                segment_rows.append(
+                    (
+                        strings_offset + path_rel,
+                        payload_cursor,
+                        path_len,
+                        _SEGMENT_PATH_ONLY if segment.path_only else 0,
+                        segment.offsets_count,
+                        source_size,
+                        expected_size,
+                        checksum & 0xFFFFFFFF,
+                        0,
+                    )
+                )
+                payload_cursor += expected_size
+
+            if out.tell() != offsets_offset + offsets_size:
+                raise AssertionError(
+                    f"Internal idxpack size mismatch: {out.tell()} != {offsets_offset + offsets_size}"
+                )
+            out.seek(segment_offset)
+            for row in segment_rows:
+                out.write(_SEGMENT.pack(*row))
+            out.flush()
+            os.fsync(out.fileno())
+        if overwrite:
+            os.replace(tmp_path, output_path)
+        else:
+            try:
+                os.link(tmp_path, output_path)
+            except FileExistsError as ex:
+                raise FileExistsError(
+                    f"Index pack already exists: {output_path}"
+                ) from ex
+            else:
+                tmp_path.unlink()
+        _fsync_directory(output_path.parent)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+    return output_path
+
+
+class PackedIndexCollection:
+    """
+    Zero-copy view of one logical collection inside an :class:`IndexPack`.
+
+    Instances are created by :meth:`IndexPack.collection`; callers normally do
+    not instantiate this class directly. It translates a collection-global
+    record index into a source path and byte range without materializing the
+    shard catalog or offsets.
+
+    Args:
+        pack:
+            Owning memory-mapped pack.
+        key:
+            Stable 32-byte collection identity.
+        sequence_start:
+            First row in the pack-wide shard-sequence table.
+        sequence_count:
+            Number of ordered shards in this collection.
+        total_records:
+            Sum of records across the collection's indexed shards.
+        kind:
+            Caller-defined storage/serialization string persisted by the
+            corresponding :class:`IndexPackCollectionSpec`.
+        offsets_required:
+            Whether this collection contains record offsets. Path-only
+            collections support :meth:`path_for_shard` but contain no records.
+    """
+
+    def __init__(
+        self,
+        pack: IndexPack,
+        key: bytes,
+        sequence_start: int,
+        sequence_count: int,
+        total_records: int,
+        kind: str,
+        offsets_required: bool,
+    ):
+        self.pack = pack
+        self.key = key
+        self.sequence_start = sequence_start
+        self.sequence_count = sequence_count
+        self.total_records = total_records
+        self.kind = kind
+        self.offsets_required = offsets_required
+
+    def __len__(self) -> int:
+        """Return the number of addressable records across all shards."""
+        return self.total_records
+
+    def path_for_shard(self, shard_index: int) -> str:
+        """
+        Return a concrete source path by logical shard position.
+
+        Args:
+            shard_index:
+                Zero-based shard position. Negative indices follow Python
+                sequence semantics.
+
+        Returns:
+            The persisted source path.
+
+        Raises:
+            IndexError:
+                If ``shard_index`` is outside the collection.
+        """
+        if shard_index < 0:
+            shard_index += self.sequence_count
+        if shard_index < 0 or shard_index >= self.sequence_count:
+            raise IndexError(
+                f"shard index {shard_index} out of range for packed collection "
+                f"with {self.sequence_count} shards"
+            )
+        self.pack._ensure_open()
+        segment_id, _ = self.pack._sequence(self.sequence_start + shard_index)
+        segment = self.pack._segment(segment_id)
+        path_position, _, path_length = segment[:3]
+        return self.pack._string(
+            path_position, path_length, label=f"segment {segment_id} path"
+        )
+
+    def shard_length(self, shard_index: int) -> int:
+        """
+        Return the number of records in one logical shard.
+
+        Negative shard indices follow Python sequence semantics.
+        """
+        shard_index = self._normalize_shard_index(shard_index)
+        _, cumulative_end = self.pack._sequence(self.sequence_start + shard_index)
+        previous_end = (
+            self.pack._sequence(self.sequence_start + shard_index - 1)[1]
+            if shard_index
+            else 0
+        )
+        return cumulative_end - previous_end
+
+    def locate_in_shard(
+        self, shard_index: int, local_index: int
+    ) -> PackedIndexLocation:
+        """
+        Resolve a shard-local record index to its source byte range.
+
+        Both indices accept Python-style negative values.
+        """
+        shard_index = self._normalize_shard_index(shard_index)
+        shard_length = self.shard_length(shard_index)
+        if local_index < 0:
+            local_index += shard_length
+        if local_index < 0 or local_index >= shard_length:
+            raise IndexError(
+                f"local index {local_index} out of range for packed shard "
+                f"{shard_index} with {shard_length} records"
+            )
+        pack = self.pack
+        pack._ensure_open()
+        segment_id, _ = pack._sequence(self.sequence_start + shard_index)
+        segment = pack._segment(segment_id)
+        offsets_position = segment[1]
+        start = pack._u64(offsets_position + local_index * _U64.size)
+        end = pack._u64(offsets_position + (local_index + 1) * _U64.size)
+        if end < start or end > segment[5]:
+            raise ValueError(
+                f"Corrupt idxpack offsets for segment {segment_id}: [{start}, {end}) "
+                f"outside source size {segment[5]}"
+            )
+        path_position, _, path_length = segment[:3]
+        return PackedIndexLocation(
+            path=pack._string(
+                path_position, path_length, label=f"segment {segment_id} path"
+            ),
+            start=start,
+            end=end,
+            segment_id=segment_id,
+            shard_index=shard_index,
+            local_index=local_index,
+        )
+
+    def locate(self, index: int) -> PackedIndexLocation:
+        """
+        Resolve a collection-global record index to its source byte range.
+
+        A binary search over cumulative shard lengths finds the physical
+        segment, after which two uint64 values are read directly from the mmap.
+
+        Args:
+            index:
+                Collection-global record index. Negative indices follow Python
+                sequence semantics.
+
+        Returns:
+            The source path, byte range, and resolved shard/local positions.
+
+        Raises:
+            IndexError:
+                If ``index`` is outside the collection.
+            ValueError:
+                If sequence metadata or offsets are internally inconsistent.
+        """
+        if index < 0:
+            index += self.total_records
+        if index < 0 or index >= self.total_records:
+            raise IndexError(
+                f"index {index} out of range for packed collection with {self.total_records} records"
+            )
+        pack = self.pack
+        pack._ensure_open()
+        lo = 0
+        hi = self.sequence_count
+        while lo < hi:
+            mid = (lo + hi) // 2
+            _, cumulative_end = pack._sequence(self.sequence_start + mid)
+            if cumulative_end <= index:
+                lo = mid + 1
+            else:
+                hi = mid
+        shard_index = lo
+        if shard_index >= self.sequence_count:
+            raise ValueError(
+                "Corrupt idxpack collection: record index exceeds the final cumulative shard count"
+            )
+        previous_end = (
+            pack._sequence(self.sequence_start + shard_index - 1)[1]
+            if shard_index
+            else 0
+        )
+        return self.locate_in_shard(shard_index, index - previous_end)
+
+    def _normalize_shard_index(self, shard_index: int) -> int:
+        if shard_index < 0:
+            shard_index += self.sequence_count
+        if shard_index < 0 or shard_index >= self.sequence_count:
+            raise IndexError(
+                f"shard index {shard_index} out of range for packed collection "
+                f"with {self.sequence_count} shards"
+            )
+        return shard_index
+
+
+class IndexPack:
+    """
+    Read-only, memory-mapped view of an ``.idxpack``.
+
+    Opening a pack validates its fixed-size catalog and maps the file into
+    virtual memory; it does not copy the offset payload into Python or NumPy
+    memory. Obtain a logical collection with :meth:`collection`, then use
+    :meth:`PackedIndexCollection.locate` to resolve record indices. The source
+    record itself is intentionally not read by this class.
+
+    The mapping is reopened automatically after ``fork()`` and the object is
+    pickle-safe for data-loader workers. Use it as a context manager when a
+    deterministic close is desired, or use :func:`open_index_pack` to share one
+    mapping per absolute path and process.
+
+    Args:
+        path:
+            Local path to an ``.idxpack`` file. The pack itself must be
+            seekable/mappable even when its indexed source paths are remote.
+        expected_layout_hash:
+            Optional 32-byte digest or hexadecimal string to compare with the
+            pack header. This pins the exact collection identities and ordered
+            source paths expected by the caller.
+
+    Attributes:
+        path:
+            Normalized :class:`~pathlib.Path` of the mapped pack.
+        layout_hash:
+            32-byte digest of collection identities and ordered paths.
+        num_collections:
+            Number of logical collections.
+        num_sequences:
+            Number of collection-to-segment sequence rows.
+        num_segments:
+            Number of deduplicated physical source/index segments.
+
+    Example::
+
+        spec = IndexPackCollectionSpec(
+            role="records",
+            kind="json-lines",
+            source_spec="dataset-{000..127}.jsonl",
+            paths=tuple(expanded_paths),
+        )
+        write_index_pack("dataset.idxpack", [spec])
+        with IndexPack("dataset.idxpack") as pack:
+            location = pack.collection(spec.key).locate(10)
+            with open(location.path, "rb") as source:
+                source.seek(location.start)
+                record = source.read(location.end - location.start)
+    """
+
+    def __init__(self, path, *, expected_layout_hash: str | bytes | None = None):
+        self.path = Path(path)
+        self.expected_layout_hash = expected_layout_hash
+        self._fh = None
+        self._mmap = None
+        self._pid = None
+        self._file_identity = None
+        self._collections = {}
+        self._open()
+
+    def collection(self, key: bytes | str) -> PackedIndexCollection:
+        """
+        Return a zero-copy logical collection view.
+
+        Args:
+            key:
+                The 32-byte result of :func:`index_pack_collection_key`, or its
+                64-character hexadecimal representation.
+
+        Returns:
+            A view supporting length, shard-path, and record-location lookup.
+
+        Raises:
+            KeyError:
+                If no collection with ``key`` exists in this pack.
+        """
+        self._ensure_open()
+        if isinstance(key, str):
+            key = bytes.fromhex(key)
+        try:
+            sequence_start, sequence_count, total_records, kind, offsets_required = (
+                self._collections[key]
+            )
+        except KeyError as ex:
+            raise KeyError(
+                f"Collection {key.hex()} is not present in index pack {self.path}"
+            ) from ex
+        return PackedIndexCollection(
+            self,
+            key,
+            sequence_start,
+            sequence_count,
+            total_records,
+            kind,
+            offsets_required,
+        )
+
+    def verify_segment(self, segment_id: int) -> None:
+        """
+        Verify one packed offset payload against its stored CRC32.
+
+        Validation is explicit because scanning every offset payload at open
+        time would defeat fast startup.
+
+        Args:
+            segment_id:
+                Zero-based physical segment-table row.
+
+        Raises:
+            IndexError:
+                If ``segment_id`` is outside the segment table.
+            ValueError:
+                If the payload checksum does not match.
+        """
+        segment = self._segment(segment_id)
+        offsets_position = segment[1]
+        offsets_size = segment[6]
+        expected_crc = segment[7]
+        actual_crc = (
+            zlib.crc32(self._mmap[offsets_position : offsets_position + offsets_size])
+            & 0xFFFFFFFF
+        )
+        if actual_crc != expected_crc:
+            raise ValueError(
+                f"Index-pack CRC mismatch for segment {segment_id} in {self.path}: "
+                f"expected={expected_crc:#x}, actual={actual_crc:#x}"
+            )
+
+    def close(self) -> None:
+        """Close the mmap and its underlying file descriptor."""
+        if self._mmap is not None:
+            self._mmap.close()
+            self._mmap = None
+        if self._fh is not None:
+            self._fh.close()
+            self._fh = None
+        self._pid = None
+
+    def __enter__(self):
+        """Return this mapped pack for context-manager use."""
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """Close the mapping when leaving a context manager."""
+        self.close()
+
+    def __del__(self):
+        if hasattr(self, "_mmap"):
+            self.close()
+
+    def __getstate__(self):
+        return {
+            "path": self.path,
+            "expected_layout_hash": self.expected_layout_hash,
+            "file_identity": self._file_identity,
+        }
+
+    def __setstate__(self, state):
+        self.path = state["path"]
+        self.expected_layout_hash = state["expected_layout_hash"]
+        self._fh = None
+        self._mmap = None
+        self._pid = None
+        self._file_identity = state.get("file_identity")
+        self._collections = {}
+        self._open()
+
+    def _open(self) -> None:
+        try:
+            self._fh = self.path.open("rb")
+        except FileNotFoundError as ex:
+            raise FileNotFoundError(f"Index pack not found: {self.path}") from ex
+        stat = os.fstat(self._fh.fileno())
+        identity = (stat.st_dev, stat.st_ino, stat.st_size, stat.st_mtime_ns)
+        if self._file_identity is not None and identity != self._file_identity:
+            self._fh.close()
+            self._fh = None
+            raise RuntimeError(
+                f"Index pack changed after it was opened: {self.path}; "
+                "reconstruct the dataset to use the replacement"
+            )
+        file_size = stat.st_size
+        if file_size < _HEADER_SIZE:
+            self._fh.close()
+            self._fh = None
+            raise ValueError(
+                f"Index pack is truncated before its {_HEADER_SIZE}-byte header: {self.path}"
+            )
+        self._mmap = mmap.mmap(self._fh.fileno(), 0, access=mmap.ACCESS_READ)
+        self._pid = os.getpid()
+        self._file_identity = identity
+        values = _HEADER.unpack_from(self._mmap, 0)
+        (
+            magic,
+            version,
+            header_size,
+            self.collection_offset,
+            self.num_collections,
+            self.sequence_offset,
+            self.num_sequences,
+            self.segment_offset,
+            self.num_segments,
+            self.strings_offset,
+            self.strings_size,
+            self.offsets_offset,
+            self.offsets_size,
+            self.layout_hash,
+        ) = values
+        if magic != _MAGIC:
+            self.close()
+            raise ValueError(
+                f"Invalid index-pack header magic in {self.path}: {magic!r}"
+            )
+        if version != _VERSION or header_size != _HEADER_SIZE:
+            self.close()
+            raise ValueError(
+                f"Unsupported index-pack header in {self.path}: version={version}, header_size={header_size}"
+            )
+        sections = (
+            (
+                "collections",
+                self.collection_offset,
+                self.num_collections * _COLLECTION.size,
+            ),
+            ("sequences", self.sequence_offset, self.num_sequences * _SEQUENCE.size),
+            ("segments", self.segment_offset, self.num_segments * _SEGMENT.size),
+            ("strings", self.strings_offset, self.strings_size),
+            ("offsets", self.offsets_offset, self.offsets_size),
+        )
+        for name, offset, size in sections:
+            if offset < _HEADER_SIZE or size < 0 or offset + size > file_size:
+                self.close()
+                raise ValueError(
+                    f"Index pack has truncated/invalid {name} section: "
+                    f"offset={offset}, size={size}, file_size={file_size}"
+                )
+        expected_sections = (
+            ("collections", self.collection_offset, _HEADER_SIZE),
+            (
+                "sequences",
+                self.sequence_offset,
+                self.collection_offset + self.num_collections * _COLLECTION.size,
+            ),
+            (
+                "segments",
+                self.segment_offset,
+                self.sequence_offset + self.num_sequences * _SEQUENCE.size,
+            ),
+            (
+                "strings",
+                self.strings_offset,
+                self.segment_offset + self.num_segments * _SEGMENT.size,
+            ),
+        )
+        for name, actual, expected_offset in expected_sections:
+            if actual != expected_offset:
+                self.close()
+                raise ValueError(
+                    f"Index pack has invalid {name} offset: {actual} != {expected_offset}"
+                )
+        expected_offsets_offset = self.strings_offset + self.strings_size
+        expected_offsets_offset += (-expected_offsets_offset) % _U64.size
+        if (
+            self.offsets_offset != expected_offsets_offset
+            or self.offsets_offset + self.offsets_size != file_size
+        ):
+            self.close()
+            raise ValueError(
+                "Index pack sections overlap, contain gaps, or do not cover the complete file"
+            )
+        expected = self.expected_layout_hash
+        if expected is not None:
+            if isinstance(expected, str):
+                expected = bytes.fromhex(expected)
+            if expected != self.layout_hash:
+                actual = self.layout_hash.hex()
+                self.close()
+                raise ValueError(
+                    f"Index-pack layout mismatch for {self.path}: expected={expected.hex()}, actual={actual}"
+                )
+        offsets_cursor = self.offsets_offset
+        for segment_id in range(self.num_segments):
+            segment = self._segment(segment_id)
+            (
+                path_position,
+                offsets_position,
+                path_length,
+                flags,
+                offsets_count,
+                source_size,
+                size,
+                _,
+                _,
+            ) = segment
+            if flags & ~_SEGMENT_PATH_ONLY:
+                self.close()
+                raise ValueError(
+                    f"Index pack segment {segment_id} has unsupported flags: {flags:#x}"
+                )
+            self._string(path_position, path_length, label=f"segment {segment_id} path")
+            if offsets_count < 1 or size != offsets_count * _U64.size:
+                self.close()
+                raise ValueError(
+                    f"Index pack segment {segment_id} has inconsistent offset count/size"
+                )
+            if (
+                offsets_position != offsets_cursor
+                or offsets_position + size > self.offsets_offset + self.offsets_size
+            ):
+                self.close()
+                raise ValueError(
+                    f"Index pack segment {segment_id} has an invalid offset payload range"
+                )
+            if flags & _SEGMENT_PATH_ONLY and (offsets_count != 1 or source_size != 0):
+                self.close()
+                raise ValueError(
+                    f"Index pack path-only segment {segment_id} contains record metadata"
+                )
+            offsets_cursor += size
+        if offsets_cursor != self.offsets_offset + self.offsets_size:
+            self.close()
+            raise ValueError(
+                "Index pack segment payloads do not cover the offsets section"
+            )
+
+        expected_sequence_start = 0
+        for collection_id in range(self.num_collections):
+            row = _COLLECTION.unpack_from(
+                self._mmap,
+                self.collection_offset + collection_id * _COLLECTION.size,
+            )
+            (
+                key,
+                sequence_start,
+                sequence_count,
+                total_records,
+                kind_position,
+                kind_length,
+                flags,
+            ) = row
+            if flags & ~_COLLECTION_PATHS_ONLY:
+                self.close()
+                raise ValueError(
+                    f"Index pack collection {collection_id} has unsupported flags: {flags:#x}"
+                )
+            if (
+                sequence_start != expected_sequence_start
+                or sequence_start + sequence_count > self.num_sequences
+            ):
+                self.close()
+                raise ValueError(
+                    f"Index pack collection {collection_id} has an invalid sequence range"
+                )
+            if key in self._collections:
+                self.close()
+                raise ValueError(f"Duplicate collection key in index pack: {key.hex()}")
+            kind = self._string(
+                kind_position, kind_length, label=f"collection {collection_id} kind"
+            )
+            cumulative = 0
+            declared_paths_only = bool(flags & _COLLECTION_PATHS_ONLY)
+            paths_only = None
+            for local_shard in range(sequence_count):
+                segment_id, cumulative_end = self._sequence(
+                    sequence_start + local_shard
+                )
+                if segment_id >= self.num_segments:
+                    self.close()
+                    raise ValueError(
+                        f"Index pack collection {collection_id} has corrupt sequence metadata"
+                    )
+                segment = self._segment(segment_id)
+                expected_cumulative_end = cumulative + segment[4] - 1
+                if cumulative_end != expected_cumulative_end:
+                    self.close()
+                    raise ValueError(
+                        f"Index pack collection {collection_id} has corrupt "
+                        f"cumulative count for shard {local_shard}: "
+                        f"{cumulative_end} != {expected_cumulative_end}"
+                    )
+                segment_paths_only = bool(segment[3] & _SEGMENT_PATH_ONLY)
+                if paths_only is None:
+                    paths_only = segment_paths_only
+                elif segment_paths_only != paths_only:
+                    self.close()
+                    raise ValueError(
+                        f"Index pack collection {collection_id} mixes path-only and indexed segments"
+                    )
+                cumulative = cumulative_end
+            if paths_only is None:
+                paths_only = declared_paths_only
+            if declared_paths_only and not paths_only:
+                self.close()
+                raise ValueError(
+                    f"Index pack collection {collection_id} is marked path-only "
+                    "but references indexed segments"
+                )
+            if cumulative != total_records or (paths_only and total_records != 0):
+                self.close()
+                raise ValueError(
+                    f"Index pack collection {collection_id} has an invalid total record count"
+                )
+            self._collections[key] = (
+                sequence_start,
+                sequence_count,
+                total_records,
+                kind,
+                not paths_only,
+            )
+            expected_sequence_start += sequence_count
+
+        if expected_sequence_start != self.num_sequences:
+            self.close()
+            raise ValueError("Index pack contains unreferenced sequence rows")
+
+    def _ensure_open(self) -> None:
+        if self._mmap is None or self._pid != os.getpid():
+            self.close()
+            self._collections = {}
+            self._open()
+            _register_index_pack(self)
+
+    def _sequence(self, index: int) -> tuple[int, int]:
+        if index < 0 or index >= self.num_sequences:
+            raise IndexError(f"Index-pack sequence index out of range: {index}")
+        return _SEQUENCE.unpack_from(
+            self._mmap, self.sequence_offset + index * _SEQUENCE.size
+        )
+
+    def _segment(self, index: int):
+        if index < 0 or index >= self.num_segments:
+            raise IndexError(f"Index-pack segment index out of range: {index}")
+        return _SEGMENT.unpack_from(
+            self._mmap, self.segment_offset + index * _SEGMENT.size
+        )
+
+    def _u64(self, position: int) -> int:
+        return _U64.unpack_from(self._mmap, position)[0]
+
+    def _string(self, position: int, length: int, *, label: str) -> str:
+        if (
+            position < self.strings_offset
+            or position + length > self.strings_offset + self.strings_size
+        ):
+            raise ValueError(
+                f"Index pack {label} points outside the strings section: position={position}, length={length}"
+            )
+        try:
+            return self._mmap[position : position + length].decode("utf-8")
+        except UnicodeDecodeError as ex:
+            raise ValueError(f"Index pack {label} is not valid UTF-8") from ex
+
+
+def open_index_pack(path) -> IndexPack:
+    """
+    Return one shared read-only pack mapping per absolute path and process.
+
+    Args:
+        path:
+            Local ``.idxpack`` path.
+
+    Returns:
+        A process-local cached :class:`IndexPack`. After ``fork()``, the child
+        creates its own mapping on first access.
+    """
+    global _INDEX_PACK_CACHE_PID
+    pid = os.getpid()
+    if pid != _INDEX_PACK_CACHE_PID:
+        _INDEX_PACK_CACHE.clear()
+        _INDEX_PACK_CACHE_PID = pid
+    key = str(Path(path).absolute())
+    pack = _INDEX_PACK_CACHE.get(key)
+    if pack is None:
+        pack = IndexPack(key)
+        _INDEX_PACK_CACHE[key] = pack
+    return pack
+
+
+@dataclass(frozen=True)
+class _BuildSegment:
+    """
+    Normalized metadata for one physical source/index pair while writing.
+
+    Attributes:
+        path:
+            Persisted source path.
+        index_path:
+            Resolved local sidecar path, or ``None`` for a path-only segment.
+        offsets_count:
+            Number of uint64 values, including the final source-size sentinel.
+            Therefore the addressable record count is one less.
+        source_size:
+            Current local source size when it can be checked, otherwise
+            ``None`` and the copied sidecar sentinel becomes authoritative.
+        path_only:
+            Whether this segment intentionally stores no record offsets.
+    """
+
+    path: str
+    index_path: Path | None
+    offsets_count: int
+    source_size: int | None
+    path_only: bool = False
+
+    @property
+    def num_records(self) -> int:
+        """Return addressable records represented by this segment."""
+        return self.offsets_count - 1
+
+
+class _StringTableBuilder:
+    """Deduplicating UTF-8 string table used while writing a pack."""
+
+    def __init__(self):
+        self.data = bytearray()
+        self._positions: dict[bytes, tuple[int, int]] = {}
+
+    def add(self, value: str) -> tuple[int, int]:
+        encoded = value.encode("utf-8")
+        position = self._positions.get(encoded)
+        if position is None:
+            position = (len(self.data), len(encoded))
+            self._positions[encoded] = position
+            self.data.extend(encoded)
+        return position
+
+
+def _validate_collection_identity(role: str, kind: str) -> None:
+    if not isinstance(role, str) or not role:
+        raise ValueError(f"Index-pack role must be a non-empty string, got {role!r}")
+    if not isinstance(kind, str) or not kind:
+        raise ValueError(f"Index-pack kind must be a non-empty string, got {kind!r}")
+
+
+def _canonicalize(value):
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, Mapping):
+        return {str(key): _canonicalize(value[key]) for key in sorted(value, key=str)}
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_canonicalize(item) for item in value]
+    return value
+
+
+def _read_sidecar_metadata(
+    path: str, indexes_root, *, offsets_required: bool
+) -> _BuildSegment:
+    if not offsets_required:
+        return _BuildSegment(
+            path=path,
+            index_path=None,
+            offsets_count=1,
+            source_size=0,
+            path_only=True,
+        )
+    idx = index_file_path(path, indexes_root)
+    if _is_remote_path(idx):
+        raise ValueError(
+            "Index-pack conversion currently requires a local sidecar; "
+            f"got remote index path: {idx}"
+        )
+    idx = Path(idx)
+    try:
+        index_stat = idx.stat()
+    except FileNotFoundError as ex:
+        raise FileNotFoundError(f"Missing .idx sidecar for {path}: {idx}") from ex
+    size = index_stat.st_size
+    if size < _U64.size or size % _U64.size:
+        raise ValueError(
+            f"Invalid .idx sidecar {idx}: size must be a positive multiple of {_U64.size}, got {size}"
+        )
+
+    source_size = None
+    if not _is_remote_path(path):
+        try:
+            source_stat = Path(path).stat()
+        except FileNotFoundError as ex:
+            raise FileNotFoundError(f"Indexed source not found: {path}") from ex
+        if source_stat.st_mtime_ns > index_stat.st_mtime_ns:
+            raise ValueError(
+                f"Source {path} is newer than index sidecar {idx}; rebuild the .idx before packing"
+            )
+        source_size = source_stat.st_size
+    return _BuildSegment(
+        path=path,
+        index_path=idx,
+        offsets_count=size // _U64.size,
+        source_size=source_size,
+    )
+
+
+def _layout_digest(collections: Sequence[IndexPackCollectionSpec]) -> bytes:
+    digest = hashlib.sha256()
+    for collection in collections:
+        digest.update(collection.key)
+        digest.update(bytes((collection.offsets_required,)))
+        digest.update(_U64.pack(len(collection.paths)))
+        for path in collection.paths:
+            encoded = path.encode("utf-8")
+            digest.update(_U64.pack(len(encoded)))
+            digest.update(encoded)
+    return digest.digest()
+
+
+def _is_remote_path(path) -> bool:
+    return is_valid_url(str(path))
+
+
+def _fsync_directory(path: Path) -> None:
+    if not hasattr(os, "O_DIRECTORY"):
+        return
+    try:
+        fd = os.open(path, os.O_RDONLY | os.O_DIRECTORY)
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+def _register_index_pack(pack: IndexPack) -> None:
+    global _INDEX_PACK_CACHE_PID
+    pid = os.getpid()
+    if pid != _INDEX_PACK_CACHE_PID:
+        _INDEX_PACK_CACHE.clear()
+        _INDEX_PACK_CACHE_PID = pid
+    _INDEX_PACK_CACHE[str(pack.path.absolute())] = pack
+
+
+_INDEX_PACK_CACHE: weakref.WeakValueDictionary[str, IndexPack] = (
+    weakref.WeakValueDictionary()
+)
+_INDEX_PACK_CACHE_PID = os.getpid()

--- a/lhotse/packed_lazy.py
+++ b/lhotse/packed_lazy.py
@@ -1,0 +1,484 @@
+"""
+Lazy manifest iteration backed by :mod:`lhotse.index_pack`.
+
+The iterator in this module replaces a chain of per-shard indexed readers with
+one logical collection stored in an ``.idxpack``. It retains random access,
+worker partitioning, deterministic global shuffling, and checkpoint/resume
+semantics while avoiding eager shard-path expansion, one reader object per
+shard, and one in-memory offset array per sidecar.
+"""
+
+from __future__ import annotations
+
+import os
+import warnings
+import weakref
+from collections import OrderedDict
+from collections.abc import Callable
+from json import JSONDecodeError
+from typing import Any
+
+from lhotse.index_pack import IndexPack, open_index_pack
+from lhotse.lazy import (
+    IteratorNode,
+    attach_graph_origin,
+    normalize_graph_token,
+    resolve_iteration_seed,
+)
+from lhotse.serialization import decode_json_line, deserialize_item
+from lhotse.utils import is_valid_url
+
+
+def read_packed_range(
+    index_pack: IndexPack,
+    path: str,
+    start: int,
+    end: int,
+    *,
+    max_open_files: int = 32,
+) -> bytes:
+    """
+    Read an exact local byte range through a pack-shared descriptor cache.
+
+    All readers using the same :class:`~lhotse.index_pack.IndexPack` share one
+    process-local LRU, so ``max_open_files`` is a bound per dataset pack rather
+    than per logical collection. Remote source URLs are rejected because
+    ``os.pread()`` requires a local, seekable file.
+    """
+    cache = _file_cache_for_pack(index_pack, max_open_files)
+    return cache.read(path, start, end)
+
+
+class LazyPackedManifestIterator(IteratorNode):
+    """
+    Lazily decode an ordered sharded manifest collection from an ``.idxpack``.
+
+    A conventional large sharded dataset is often represented as a
+    ``LazyIteratorChain`` containing one ``LazyIndexedManifestIterator`` per
+    file. Constructing that graph expands every path and loads or maps every
+    sidecar separately. This iterator presents the same shards as one virtual
+    sequence: the pack mmap resolves a logical index to ``(path, start, end)``,
+    and only that record is read with ``pread()`` through a bounded descriptor
+    cache.
+
+    Integer lookup addresses the virtual concatenation. A
+    ``(shard_index, local_index)`` tuple addresses one record in one shard and
+    preserves graph-origin tokens expected by Lhotse transforms. Sequential
+    iteration partitions records within each shard across data-loader workers;
+    ``shuffle_shards=True`` uses Lhotse's deterministic lazy permutation across
+    the entire collection. Both modes support :meth:`state_dict` and
+    :meth:`load_state_dict`.
+
+    Args:
+        index_pack:
+            An :class:`~lhotse.index_pack.IndexPack` or local pack path. Paths
+            use the process-local mapping cache returned by
+            :func:`~lhotse.index_pack.open_index_pack`.
+        collection_key:
+            The collection's 32-byte identity or hexadecimal representation.
+        shuffle_shards:
+            Apply a deterministic lazy global permutation on each iteration.
+            The name matches the corresponding sharded-manifest configuration
+            option.
+        seed:
+            Base seed used to derive each iteration's permutation.
+        decode:
+            Optional callable applied to the dictionary decoded from each JSON
+            line. The default is :func:`lhotse.serialization.deserialize_item`.
+        skip_decode_errors:
+            Skip malformed UTF-8 or JSON records instead of raising.
+        decode_error_callback:
+            Optional ``callback(exception, global_index, path)`` invoked for
+            each skipped record.
+        max_open_files:
+            Maximum number of source files held open by the descriptor cache
+            shared by all iterators reading this pack in the current process.
+
+    Example::
+
+        from lhotse.index_pack import index_pack_collection_key
+
+        key = index_pack_collection_key(
+            role="records",
+            kind="json-lines",
+            source_spec="cuts-{000..127}.jsonl",
+        )
+        source = LazyPackedManifestIterator(
+            "dataset.idxpack",
+            key,
+            shuffle_shards=True,
+            seed=42,
+        )
+        first_cut = next(iter(source))
+    """
+
+    is_checkpointable = True
+    is_indexed = True
+    has_constant_time_access = True
+
+    def __init__(
+        self,
+        index_pack,
+        collection_key: bytes | str,
+        *,
+        shuffle_shards: bool = False,
+        seed: int = 0,
+        decode: Callable[[dict], Any] | None = None,
+        skip_decode_errors: bool = False,
+        decode_error_callback: Callable[[BaseException, int, str], None] | None = None,
+        max_open_files: int = 32,
+    ):
+        self.index_pack = (
+            index_pack
+            if isinstance(index_pack, IndexPack)
+            else open_index_pack(index_pack)
+        )
+        self.collection_key = collection_key
+        self.collection = self.index_pack.collection(collection_key)
+        self.shuffle_shards = shuffle_shards
+        self.seed = seed
+        self._decode = decode if decode is not None else deserialize_item
+        self.skip_decode_errors = skip_decode_errors
+        self.decode_error_callback = decode_error_callback
+        if max_open_files < 1:
+            raise ValueError("max_open_files must be positive")
+        self.max_open_files = max_open_files
+
+        self.num_iters = 0
+        self._current_shard = 0
+        self._current_position = 0
+        self._global_position = 0
+        self._global_seed = None
+        self._shard_id = None
+        self._num_shards = None
+        self._restored = False
+
+    def __len__(self) -> int:
+        """Return the total number of records in the packed collection."""
+        return len(self.collection)
+
+    def __getitem__(self, token):
+        """
+        Decode one record by global index or ``(shard, local_index)`` token.
+
+        Negative global, shard, and local indices follow Python sequence
+        semantics.
+        """
+        return self._decode_token(token)
+
+    def read_with_location(self, token):
+        """
+        Decode one record and return it together with its packed byte location.
+
+        This avoids resolving the same token twice in adapters that also need
+        the manifest shard/local position to locate an associated payload.
+        """
+        normalized_token, global_index, location = self._location_for_token(token)
+        raw = read_packed_range(
+            self.index_pack,
+            location.path,
+            location.start,
+            location.end,
+            max_open_files=self.max_open_files,
+        )
+        decoded_line = raw.decode("utf-8")
+        try:
+            item = self._decode(decode_json_line(decoded_line))
+        except JSONDecodeError as ex:
+            preview = decoded_line[:120].replace("\n", "\\n").replace("\r", "\\r")
+            msg = (
+                f"{ex.msg} while decoding packed JSONL record "
+                f"path={location.path!r} pack={str(self.index_pack.path)!r} "
+                f"idx={global_index} byte_range=[{location.start}, {location.end}) "
+                f"preview={preview!r}"
+            )
+            raise JSONDecodeError(msg, ex.doc, ex.pos) from ex
+        return attach_graph_origin(item, normalized_token), location
+
+    def __iter__(self):
+        """Iterate using the configured deterministic ordering and worker partition."""
+        if self.shuffle_shards:
+            return self._iter_globally_shuffled()
+        return self._iter_sequential()
+
+    def state_dict(self) -> dict:
+        """
+        Return the resumable iterator state.
+
+        The common keys intentionally match ``LazyIteratorChain`` where
+        possible; ``packed_current_position`` records the within-shard
+        position needed by sequential iteration.
+        """
+        return {
+            "current_iter_idx": self._current_shard,
+            "num_iters": self.num_iters,
+            "iter_order": None,
+            "global_position": self._global_position,
+            "global_seed": self._global_seed,
+            "global_shard_id": self._shard_id,
+            "global_num_shards": self._num_shards,
+            "packed_current_position": self._current_position,
+        }
+
+    def load_state_dict(self, state: dict) -> None:
+        """
+        Restore a state produced by :meth:`state_dict`.
+
+        Worker partition compatibility is checked when iteration resumes so a
+        checkpoint cannot silently continue under a different partition.
+        """
+        self._current_shard = state.get("current_iter_idx", 0)
+        self._current_position = state.get("packed_current_position", 0)
+        self.num_iters = state.get("num_iters", 0)
+        self._global_position = state.get("global_position", 0)
+        self._global_seed = state.get("global_seed")
+        self._shard_id = state.get("global_shard_id")
+        self._num_shards = state.get("global_num_shards")
+        self._restored = True
+
+    def close(self) -> None:
+        """
+        Release no resources.
+
+        Pack mappings and source descriptors are shared across iterators and
+        are reclaimed when the owning :class:`IndexPack` is no longer used.
+        """
+        return
+
+    def _location_for_token(self, token):
+        normalized_token = normalize_graph_token(token)
+        if isinstance(normalized_token, tuple) and len(normalized_token) == 2:
+            shard_index, local_index = normalized_token
+            location = self.collection.locate_in_shard(shard_index, local_index)
+            previous_end = (
+                self.index_pack._sequence(
+                    self.collection.sequence_start + location.shard_index - 1
+                )[1]
+                if location.shard_index
+                else 0
+            )
+            return normalized_token, previous_end + location.local_index, location
+        if not isinstance(normalized_token, int):
+            raise TypeError(
+                f"Unsupported packed manifest graph token: {normalized_token!r}"
+            )
+        global_index = normalized_token
+        if global_index < 0:
+            global_index += len(self.collection)
+        return normalized_token, global_index, self.collection.locate(global_index)
+
+    def _decode_token(self, token):
+        item, _ = self.read_with_location(token)
+        return item
+
+    def _decode_or_skip(self, token):
+        try:
+            return self._decode_token(token)
+        except (JSONDecodeError, UnicodeDecodeError) as ex:
+            if not self.skip_decode_errors:
+                raise
+            _, global_index, location = self._location_for_token(token)
+            if self.decode_error_callback is not None:
+                self.decode_error_callback(ex, global_index, location.path)
+            else:
+                warnings.warn(
+                    f"Skipping malformed packed manifest record "
+                    f"{global_index} in {location.path}: {ex}",
+                    stacklevel=2,
+                )
+            return None
+
+    def _iter_globally_shuffled(self):
+        from lhotse.dataset.dataloading import get_worker_partition
+        from lhotse.indexing import LazyShuffledRange
+
+        shard_id, num_shards = get_worker_partition()
+        if self._restored:
+            self._restored = False
+            start = self._global_position
+            base_seed = self._global_seed
+            if base_seed is None:
+                base_seed = resolve_iteration_seed(self.seed)
+            if self._num_shards is not None and (
+                self._shard_id != shard_id or self._num_shards != num_shards
+            ):
+                raise ValueError(
+                    "LazyPackedManifestIterator partition mismatch on resume: "
+                    f"saved (shard_id={self._shard_id}, num_shards={self._num_shards}), "
+                    f"current (shard_id={shard_id}, num_shards={num_shards})."
+                )
+        else:
+            start = 0
+            self._global_position = 0
+            base_seed = resolve_iteration_seed(self.seed)
+            self._global_seed = base_seed
+        self._shard_id = shard_id
+        self._num_shards = num_shards
+
+        shuffled = LazyShuffledRange(
+            len(self),
+            seed=base_seed + self.num_iters,
+            shard_id=shard_id,
+            num_shards=num_shards,
+        )
+        for position in range(start, len(shuffled)):
+            self._global_position = position + 1
+            token = shuffled[position]
+            item = self._decode_or_skip(token)
+            if item is not None:
+                yield item
+        self.num_iters += 1
+
+    def _iter_sequential(self):
+        from lhotse.dataset.dataloading import get_worker_partition
+
+        shard_id, num_shards = get_worker_partition()
+        if self._restored:
+            self._restored = False
+            start_shard = self._current_shard
+            start_position = self._current_position
+            if self._num_shards is not None and (
+                self._shard_id != shard_id or self._num_shards != num_shards
+            ):
+                raise ValueError(
+                    "LazyPackedManifestIterator partition mismatch on resume: "
+                    f"saved (shard_id={self._shard_id}, num_shards={self._num_shards}), "
+                    f"current (shard_id={shard_id}, num_shards={num_shards})."
+                )
+        else:
+            start_shard = 0
+            start_position = 0
+        self._shard_id = shard_id
+        self._num_shards = num_shards
+
+        for shard_index in range(start_shard, self.collection.sequence_count):
+            shard_length = self.collection.shard_length(shard_index)
+            local_count = (
+                (shard_length - shard_id + num_shards - 1) // num_shards
+                if shard_length > shard_id
+                else 0
+            )
+            first_position = start_position if shard_index == start_shard else 0
+            for position in range(first_position, local_count):
+                self._current_shard = shard_index
+                self._current_position = position + 1
+                token = (shard_index, shard_id + position * num_shards)
+                item = self._decode_or_skip(token)
+                if item is not None:
+                    yield item
+            self._current_shard = shard_index + 1
+            self._current_position = 0
+
+
+class _PackedFileCache:
+    """
+    Process-local least-recently-used cache of read-only file descriptors.
+
+    The cache uses ``os.pread`` so concurrent reads do not mutate a shared file
+    position. It discards inherited descriptors after ``fork()`` and is
+    pickle-safe for data-loader workers.
+
+    Args:
+        max_open_files:
+            Positive descriptor limit. The least recently used descriptor is
+            closed when opening another source would exceed it.
+    """
+
+    def __init__(self, max_open_files: int = 32):
+        if max_open_files < 1:
+            raise ValueError("max_open_files must be positive")
+        self.max_open_files = max_open_files
+        self._pid = os.getpid()
+        self._fds: OrderedDict[str, int] = OrderedDict()
+
+    def read(self, path: str, start: int, end: int) -> bytes:
+        """
+        Read the exact half-open byte range ``[start, end)`` from ``path``.
+
+        Raises:
+            EOFError:
+                If the underlying file returns fewer bytes than requested.
+        """
+        if is_valid_url(path):
+            raise ValueError(
+                "Packed lazy reads require local source files; "
+                f"cannot use os.pread() with {path!r}"
+            )
+        if start < 0 or end < start:
+            raise ValueError(f"Invalid packed byte range: [{start}, {end})")
+        self._ensure_process()
+        fd = self._fds.pop(path, None)
+        if fd is None:
+            fd = os.open(path, os.O_RDONLY)
+        self._fds[path] = fd
+        while len(self._fds) > self.max_open_files:
+            _, evicted = self._fds.popitem(last=False)
+            os.close(evicted)
+        chunks = []
+        position = start
+        while position < end:
+            chunk = os.pread(fd, end - position, position)
+            if not chunk:
+                received = position - start
+                raise EOFError(
+                    f"Short indexed read from {path}: requested [{start}, {end}), "
+                    f"received {received} bytes"
+                )
+            chunks.append(chunk)
+            position += len(chunk)
+        return b"".join(chunks)
+
+    def limit_to(self, max_open_files: int) -> None:
+        """Tighten this shared cache's descriptor bound."""
+        if max_open_files < 1:
+            raise ValueError("max_open_files must be positive")
+        self.max_open_files = min(self.max_open_files, max_open_files)
+        while len(self._fds) > self.max_open_files:
+            _, evicted = self._fds.popitem(last=False)
+            os.close(evicted)
+
+    def close(self) -> None:
+        """Close all cached descriptors."""
+        for fd in self._fds.values():
+            os.close(fd)
+        self._fds.clear()
+
+    def __getstate__(self):
+        return {"max_open_files": self.max_open_files}
+
+    def __setstate__(self, state):
+        self.max_open_files = state["max_open_files"]
+        self._pid = os.getpid()
+        self._fds = OrderedDict()
+
+    def __del__(self):
+        if hasattr(self, "_fds"):
+            self.close()
+
+    def _ensure_process(self) -> None:
+        if self._pid != os.getpid():
+            self.close()
+            self._pid = os.getpid()
+
+
+def _file_cache_for_pack(
+    index_pack: IndexPack, max_open_files: int
+) -> _PackedFileCache:
+    global _PACKED_FILE_CACHE_PID
+    pid = os.getpid()
+    if pid != _PACKED_FILE_CACHE_PID:
+        _PACKED_FILE_CACHES.clear()
+        _PACKED_FILE_CACHE_PID = pid
+    cache = _PACKED_FILE_CACHES.get(index_pack)
+    if cache is None:
+        cache = _PackedFileCache(max_open_files)
+        _PACKED_FILE_CACHES[index_pack] = cache
+    else:
+        cache.limit_to(max_open_files)
+    return cache
+
+
+_PACKED_FILE_CACHES: weakref.WeakKeyDictionary[IndexPack, _PackedFileCache] = (
+    weakref.WeakKeyDictionary()
+)
+_PACKED_FILE_CACHE_PID = os.getpid()

--- a/lhotse/packed_lazy.py
+++ b/lhotse/packed_lazy.py
@@ -478,7 +478,7 @@ def _file_cache_for_pack(
     return cache
 
 
-_PACKED_FILE_CACHES: weakref.WeakKeyDictionary[IndexPack, _PackedFileCache] = (
-    weakref.WeakKeyDictionary()
-)
+_PACKED_FILE_CACHES: weakref.WeakKeyDictionary[
+    IndexPack, _PackedFileCache
+] = weakref.WeakKeyDictionary()
 _PACKED_FILE_CACHE_PID = os.getpid()

--- a/test/test_index_pack.py
+++ b/test/test_index_pack.py
@@ -1,5 +1,7 @@
 import json
+import multiprocessing as mp
 import os
+import pickle
 import struct
 from pathlib import Path
 
@@ -26,6 +28,23 @@ def _write_jsonl(path: Path, records: list[dict]) -> None:
     with path.open("w") as f:
         for record in records:
             f.write(json.dumps(record) + "\n")
+
+
+def _inspect_pack_mapping_in_child(pack, collection_key, connection) -> None:
+    try:
+        connection.send((pack._fh is None, pack._mmap is None, pack._pid))
+        location = pack.collection(collection_key).locate(0)
+        connection.send(
+            (
+                pack._fh is not None,
+                pack._mmap is not None,
+                pack._pid,
+                location.local_index,
+            )
+        )
+    finally:
+        connection.close()
+        pack.close()
 
 
 def test_index_pack_converts_existing_sidecars_and_reads_lazily(tmp_path):
@@ -63,6 +82,69 @@ def test_index_pack_converts_existing_sidecars_and_reads_lazily(tmp_path):
                 actual.append(json.loads(f.read(location.end - location.start)))
 
         assert actual == [record for shard in records for record in shard]
+
+
+def test_index_pack_defers_mmap_through_catalog_lookup_and_pickle(tmp_path):
+    path = tmp_path / "data.jsonl"
+    _write_jsonl(path, [{"id": "a"}])
+    create_jsonl_index(path)
+    spec = IndexPackCollectionSpec(
+        role="manifest", kind="jsonl", source_spec=str(path), paths=(str(path),)
+    )
+    pack_path = tmp_path / "dataset.idxpack"
+    write_index_pack(pack_path, [spec])
+
+    pack = IndexPack(pack_path)
+    collection = pack.collection(spec.key)
+    assert len(collection) == 1
+    assert pack._fh is None
+    assert pack._mmap is None
+    assert pack._pid is None
+
+    restored = pickle.loads(pickle.dumps(pack))
+    assert len(restored.collection(spec.key)) == 1
+    assert restored._fh is None
+    assert restored._mmap is None
+    assert restored._pid is None
+
+    assert restored.collection(spec.key).locate(0).local_index == 0
+    assert restored._fh is not None
+    assert restored._mmap is not None
+    assert restored._pid == os.getpid()
+    restored.close()
+
+
+def test_index_pack_first_mmap_is_opened_in_forked_worker(tmp_path):
+    if "fork" not in mp.get_all_start_methods():
+        pytest.skip("requires the fork multiprocessing start method")
+    path = tmp_path / "data.jsonl"
+    _write_jsonl(path, [{"id": "a"}])
+    create_jsonl_index(path)
+    spec = IndexPackCollectionSpec(
+        role="manifest", kind="jsonl", source_spec=str(path), paths=(str(path),)
+    )
+    pack_path = tmp_path / "dataset.idxpack"
+    write_index_pack(pack_path, [spec])
+    pack = IndexPack(pack_path)
+
+    receive, send = mp.get_context("fork").Pipe(duplex=False)
+    process = mp.get_context("fork").Process(
+        target=_inspect_pack_mapping_in_child, args=(pack, spec.key, send)
+    )
+    process.start()
+    send.close()
+    assert receive.poll(10)
+    before = receive.recv()
+    assert receive.poll(10)
+    after = receive.recv()
+    process.join(10)
+
+    assert process.exitcode == 0
+    assert before == (True, True, None)
+    assert after == (True, True, process.pid, 0)
+    assert pack._fh is None
+    assert pack._mmap is None
+    receive.close()
 
 
 def test_index_pack_deduplicates_segments_within_dataset(tmp_path):
@@ -298,8 +380,9 @@ def test_index_pack_refuses_replaced_file_on_reopen(tmp_path):
     pack = IndexPack(pack_path)
     pack.close()
     os.replace(replacement, pack_path)
+    collection = pack.collection(spec.key)
     with pytest.raises(RuntimeError, match="changed after it was opened"):
-        pack.collection(spec.key)
+        collection.locate(0)
 
 
 def test_packed_range_retries_short_pread(tmp_path, monkeypatch):

--- a/test/test_index_pack.py
+++ b/test/test_index_pack.py
@@ -1,0 +1,461 @@
+import json
+import os
+import struct
+from pathlib import Path
+
+import pytest
+
+import lhotse.packed_lazy as packed_lazy_module
+from lhotse.index_pack import (
+    IndexPack,
+    IndexPackCollectionSpec,
+    index_pack_collection_key,
+    write_index_pack,
+)
+from lhotse.indexing import create_jsonl_index
+from lhotse.lazy import (
+    GraphOriginDict,
+    LazyIndexedManifestIterator,
+    LazyIteratorChain,
+    get_graph_origin,
+)
+from lhotse.packed_lazy import LazyPackedManifestIterator, read_packed_range
+
+
+def _write_jsonl(path: Path, records: list[dict]) -> None:
+    with path.open("w") as f:
+        for record in records:
+            f.write(json.dumps(record) + "\n")
+
+
+def test_index_pack_converts_existing_sidecars_and_reads_lazily(tmp_path):
+    paths = [tmp_path / "shard-0.jsonl", tmp_path / "shard-1.jsonl"]
+    records = [
+        [{"id": "a0"}, {"id": "a1"}],
+        [{"id": "b0"}, {"id": "b1"}, {"id": "b2"}],
+    ]
+    for path, shard_records in zip(paths, records):
+        _write_jsonl(path, shard_records)
+        create_jsonl_index(path)
+
+    source_spec = str(tmp_path / "shard-__OP_0..1_CL_.jsonl")
+    spec = IndexPackCollectionSpec(
+        role="manifest",
+        kind="jsonl",
+        source_spec=source_spec,
+        paths=tuple(map(str, paths)),
+    )
+    pack_path = tmp_path / "dataset.idxpack"
+    write_index_pack(pack_path, [spec])
+    assert pack_path.read_bytes()[:16] == b"IDXPACK2\x02\x00\x00\x00\x00\x01\x00\x00"
+
+    with IndexPack(pack_path) as pack:
+        collection = pack.collection(
+            index_pack_collection_key("manifest", "jsonl", source_spec)
+        )
+        assert len(collection) == 5
+
+        actual = []
+        for idx in range(len(collection)):
+            location = collection.locate(idx)
+            with open(location.path, "rb") as f:
+                f.seek(location.start)
+                actual.append(json.loads(f.read(location.end - location.start)))
+
+        assert actual == [record for shard in records for record in shard]
+
+
+def test_index_pack_deduplicates_segments_within_dataset(tmp_path):
+    path = tmp_path / "shared.jsonl"
+    records = [{"id": "a"}, {"id": "b"}]
+    _write_jsonl(path, records)
+    create_jsonl_index(path)
+
+    specs = [
+        IndexPackCollectionSpec(
+            role="manifest",
+            kind="jsonl",
+            source_spec=f"alias-{idx}",
+            paths=(str(path),),
+        )
+        for idx in range(2)
+    ]
+    pack_path = tmp_path / "dataset.idxpack"
+    write_index_pack(pack_path, specs)
+
+    with IndexPack(pack_path) as pack:
+        assert pack.num_segments == 1
+        assert pack.num_collections == 2
+        for spec in specs:
+            collection = pack.collection(spec.key)
+            assert len(collection) == 2
+            assert collection.locate(1).path == str(path)
+
+
+def test_index_pack_persists_arbitrary_application_kind(tmp_path):
+    source = tmp_path / "records.jsonl"
+    _write_jsonl(source, [{"id": "first"}])
+    create_jsonl_index(source)
+    spec = IndexPackCollectionSpec(
+        role="primary-records",
+        kind="application/vnd.example.records+json",
+        source_spec={"template": "records.jsonl"},
+        paths=(str(source),),
+    )
+
+    pack_path = tmp_path / "dataset.idxpack"
+    write_index_pack(pack_path, [spec])
+
+    with IndexPack(pack_path) as pack:
+        collection = pack.collection(spec.key)
+        assert collection.kind == "application/vnd.example.records+json"
+        assert collection.locate(0).path == str(source)
+
+
+def test_index_pack_path_only_collection_needs_no_sidecars(tmp_path):
+    paths = (str(tmp_path / "payload-0.tar"), str(tmp_path / "payload-1.tar"))
+    spec = IndexPackCollectionSpec(
+        role="payload",
+        kind="application/x-tar",
+        source_spec="payload-{0..1}.tar",
+        paths=paths,
+        offsets_required=False,
+    )
+    pack_path = tmp_path / "dataset.idxpack"
+    write_index_pack(pack_path, [spec])
+
+    with IndexPack(pack_path) as pack:
+        collection = pack.collection(spec.key)
+        assert not collection.offsets_required
+        assert len(collection) == 0
+        assert collection.path_for_shard(-1) == paths[-1]
+        with pytest.raises(IndexError):
+            collection.locate(0)
+
+
+def test_index_pack_opens_v2_path_only_collection_without_collection_flag(tmp_path):
+    """Early v2 writers marked path-only segments but not their collection."""
+    spec = IndexPackCollectionSpec(
+        role="payload",
+        kind="application/x-tar",
+        source_spec="payload.tar",
+        paths=(str(tmp_path / "payload.tar"),),
+        offsets_required=False,
+    )
+    pack_path = tmp_path / "dataset.idxpack"
+    write_index_pack(pack_path, [spec])
+
+    collection_flags_offset = 256 + struct.calcsize("<32sQQQQI")
+    with pack_path.open("r+b") as f:
+        f.seek(collection_flags_offset)
+        f.write(struct.pack("<I", 0))
+
+    with IndexPack(pack_path) as pack:
+        collection = pack.collection(spec.key)
+        assert not collection.offsets_required
+        assert collection.path_for_shard(0) == str(tmp_path / "payload.tar")
+
+
+def test_index_pack_locates_directly_within_shard(tmp_path):
+    paths = [tmp_path / "shard-0.jsonl", tmp_path / "shard-1.jsonl"]
+    for path, records in zip(
+        paths,
+        ([{"id": "a"}], [{"id": "b0"}, {"id": "b1"}]),
+    ):
+        _write_jsonl(path, records)
+        create_jsonl_index(path)
+    spec = IndexPackCollectionSpec(
+        role="manifest",
+        kind="jsonl",
+        source_spec="two-shards",
+        paths=tuple(map(str, paths)),
+    )
+    pack_path = tmp_path / "dataset.idxpack"
+    write_index_pack(pack_path, [spec])
+
+    with IndexPack(pack_path) as pack:
+        collection = pack.collection(spec.key)
+        assert collection.shard_length(1) == 2
+        location = collection.locate_in_shard(1, -1)
+        assert (location.shard_index, location.local_index) == (1, 1)
+        assert json.loads(
+            read_packed_range(pack, location.path, location.start, location.end)
+        ) == {"id": "b1"}
+
+
+def test_index_pack_rejects_stale_jsonl_sentinel(tmp_path):
+    path = tmp_path / "data.jsonl"
+    _write_jsonl(path, [{"id": "a-longer-value"}])
+    create_jsonl_index(path)
+    _write_jsonl(path, [{"id": "short"}])
+    newer = path.stat().st_mtime_ns + 2_000_000_000
+    os.utime(Path(str(path) + ".idx"), ns=(newer, newer))
+    spec = IndexPackCollectionSpec(
+        role="manifest",
+        kind="jsonl",
+        source_spec=str(path),
+        paths=(str(path),),
+    )
+
+    with pytest.raises(ValueError, match="Invalid sentinel"):
+        write_index_pack(tmp_path / "dataset.idxpack", [spec])
+
+
+def test_index_pack_rejects_newer_same_size_jsonl(tmp_path):
+    path = tmp_path / "data.jsonl"
+    _write_jsonl(path, [{"id": "one"}])
+    idx = create_jsonl_index(path)
+    newer = idx.stat().st_mtime_ns + 2_000_000_000
+    os.utime(path, ns=(newer, newer))
+    spec = IndexPackCollectionSpec(
+        role="manifest",
+        kind="jsonl",
+        source_spec=str(path),
+        paths=(str(path),),
+    )
+
+    with pytest.raises(ValueError, match="newer than index"):
+        write_index_pack(tmp_path / "dataset.idxpack", [spec])
+
+
+def test_index_pack_rejects_truncated_file(tmp_path):
+    path = tmp_path / "data.jsonl"
+    _write_jsonl(path, [{"id": "a"}])
+    create_jsonl_index(path)
+    pack_path = tmp_path / "dataset.idxpack"
+    write_index_pack(
+        pack_path,
+        [
+            IndexPackCollectionSpec(
+                role="manifest",
+                kind="jsonl",
+                source_spec=str(path),
+                paths=(str(path),),
+            )
+        ],
+    )
+    pack_path.write_bytes(pack_path.read_bytes()[:64])
+
+    with pytest.raises(ValueError, match="truncated|header"):
+        IndexPack(pack_path)
+
+
+def test_index_pack_rejects_sequence_outside_segment_table(tmp_path):
+    path = tmp_path / "data.jsonl"
+    _write_jsonl(path, [{"id": "a"}])
+    create_jsonl_index(path)
+    spec = IndexPackCollectionSpec(
+        role="manifest", kind="jsonl", source_spec=str(path), paths=(str(path),)
+    )
+    pack_path = tmp_path / "dataset.idxpack"
+    write_index_pack(pack_path, [spec])
+    with IndexPack(pack_path) as pack:
+        sequence_offset = pack.sequence_offset
+        invalid_segment_id = pack.num_segments
+    contents = bytearray(pack_path.read_bytes())
+    struct.pack_into("<Q", contents, sequence_offset, invalid_segment_id)
+    pack_path.write_bytes(contents)
+
+    with pytest.raises(ValueError, match="corrupt sequence"):
+        IndexPack(pack_path)
+
+
+def test_index_pack_rejects_incorrect_cumulative_shard_count(tmp_path):
+    paths = [tmp_path / "data-0.jsonl", tmp_path / "data-1.jsonl"]
+    for path in paths:
+        _write_jsonl(path, [{"id": "a"}])
+        create_jsonl_index(path)
+    spec = IndexPackCollectionSpec(
+        role="manifest",
+        kind="jsonl",
+        source_spec="two-shards",
+        paths=tuple(map(str, paths)),
+    )
+    pack_path = tmp_path / "dataset.idxpack"
+    write_index_pack(pack_path, [spec])
+    with IndexPack(pack_path) as pack:
+        second_cumulative_offset = pack.sequence_offset + struct.calcsize("<QQ") + 8
+    contents = bytearray(pack_path.read_bytes())
+    struct.pack_into("<Q", contents, second_cumulative_offset, 1)
+    pack_path.write_bytes(contents)
+
+    with pytest.raises(ValueError, match="corrupt cumulative count"):
+        IndexPack(pack_path)
+
+
+def test_index_pack_refuses_replaced_file_on_reopen(tmp_path):
+    path = tmp_path / "data.jsonl"
+    _write_jsonl(path, [{"id": "a"}])
+    create_jsonl_index(path)
+    spec = IndexPackCollectionSpec(
+        role="manifest", kind="jsonl", source_spec=str(path), paths=(str(path),)
+    )
+    pack_path = tmp_path / "dataset.idxpack"
+    replacement = tmp_path / "replacement.idxpack"
+    write_index_pack(pack_path, [spec])
+    write_index_pack(replacement, [spec])
+
+    pack = IndexPack(pack_path)
+    pack.close()
+    os.replace(replacement, pack_path)
+    with pytest.raises(RuntimeError, match="changed after it was opened"):
+        pack.collection(spec.key)
+
+
+def test_packed_range_retries_short_pread(tmp_path, monkeypatch):
+    path = tmp_path / "data.bin"
+    path.write_bytes(b"abcdefgh")
+    source = tmp_path / "source.jsonl"
+    _write_jsonl(source, [{"id": "a"}])
+    create_jsonl_index(source)
+    spec = IndexPackCollectionSpec(
+        role="manifest", kind="jsonl", source_spec=str(source), paths=(str(source),)
+    )
+    pack_path = tmp_path / "dataset.idxpack"
+    write_index_pack(pack_path, [spec])
+    real_pread = os.pread
+
+    def short_pread(fd, size, offset):
+        return real_pread(fd, min(size, 2), offset)
+
+    monkeypatch.setattr(packed_lazy_module.os, "pread", short_pread)
+    with IndexPack(pack_path) as pack:
+        assert read_packed_range(pack, str(path), 1, 7) == b"bcdefg"
+
+
+@pytest.mark.parametrize("shuffle", [False, True])
+def test_lazy_packed_manifest_matches_legacy_sharded_iterator(tmp_path, shuffle):
+    paths = [tmp_path / "shard-0.jsonl", tmp_path / "shard-1.jsonl"]
+    records = [
+        [{"id": "a0"}, {"id": "a1"}],
+        [{"id": "b0"}, {"id": "b1"}, {"id": "b2"}],
+    ]
+    for path, shard_records in zip(paths, records):
+        _write_jsonl(path, shard_records)
+        create_jsonl_index(path)
+
+    source_spec = str(tmp_path / "shard-__OP_0..1_CL_.jsonl")
+    spec = IndexPackCollectionSpec(
+        role="manifest",
+        kind="jsonl",
+        source_spec=source_spec,
+        paths=tuple(map(str, paths)),
+    )
+    pack_path = tmp_path / "dataset.idxpack"
+    write_index_pack(pack_path, [spec])
+
+    legacy_sources = [
+        LazyIndexedManifestIterator(path, decode=GraphOriginDict) for path in paths
+    ]
+    legacy = LazyIteratorChain(
+        *legacy_sources,
+        shuffle_iters=shuffle,
+        seed=42,
+    )
+    packed = LazyPackedManifestIterator(
+        pack_path,
+        spec.key,
+        shuffle_shards=shuffle,
+        seed=42,
+        decode=GraphOriginDict,
+    )
+
+    legacy_items = list(legacy)
+    packed_items = list(packed)
+    assert [item["id"] for item in packed_items] == [
+        item["id"] for item in legacy_items
+    ]
+    assert [get_graph_origin(item) for item in packed_items] == [
+        get_graph_origin(item) for item in legacy_items
+    ]
+
+
+def test_lazy_packed_manifest_restores_global_shuffle(tmp_path):
+    paths = [tmp_path / "shard-0.jsonl", tmp_path / "shard-1.jsonl"]
+    for shard, path in enumerate(paths):
+        _write_jsonl(path, [{"id": f"{shard}-{idx}"} for idx in range(20)])
+        create_jsonl_index(path)
+    source_spec = "two-shards"
+    spec = IndexPackCollectionSpec(
+        role="manifest",
+        kind="jsonl",
+        source_spec=source_spec,
+        paths=tuple(map(str, paths)),
+    )
+    pack_path = tmp_path / "dataset.idxpack"
+    write_index_pack(pack_path, [spec])
+
+    source = LazyPackedManifestIterator(
+        pack_path,
+        spec.key,
+        shuffle_shards=True,
+        seed=17,
+        decode=GraphOriginDict,
+    )
+    iterator = iter(source)
+    consumed = [next(iterator)["id"] for _ in range(13)]
+    assert len(consumed) == 13
+    state = source.state_dict()
+    expected = [item["id"] for item in iterator]
+
+    restored = LazyPackedManifestIterator(
+        pack_path,
+        spec.key,
+        shuffle_shards=True,
+        seed=17,
+        decode=GraphOriginDict,
+    )
+    restored.load_state_dict(state)
+    assert [item["id"] for item in restored] == expected
+
+
+def test_lazy_packed_manifest_restores_sequential_iteration(tmp_path):
+    paths = [tmp_path / "shard-0.jsonl", tmp_path / "shard-1.jsonl"]
+    for shard, path in enumerate(paths):
+        _write_jsonl(path, [{"id": f"{shard}-{idx}"} for idx in range(6)])
+        create_jsonl_index(path)
+    spec = IndexPackCollectionSpec(
+        role="manifest",
+        kind="jsonl",
+        source_spec="two-shards",
+        paths=tuple(map(str, paths)),
+    )
+    pack_path = tmp_path / "dataset.idxpack"
+    write_index_pack(pack_path, [spec])
+    source = LazyPackedManifestIterator(pack_path, spec.key, decode=GraphOriginDict)
+    iterator = iter(source)
+    assert [next(iterator)["id"] for _ in range(8)] == [
+        "0-0",
+        "0-1",
+        "0-2",
+        "0-3",
+        "0-4",
+        "0-5",
+        "1-0",
+        "1-1",
+    ]
+    state = source.state_dict()
+    expected = [item["id"] for item in iterator]
+    restored = LazyPackedManifestIterator(pack_path, spec.key, decode=GraphOriginDict)
+    restored.load_state_dict(state)
+    assert [item["id"] for item in restored] == expected
+
+
+def test_lazy_packed_manifest_warns_when_skipping_decode_error(tmp_path):
+    path = tmp_path / "data.jsonl"
+    path.write_text('{"id": "good"}\nnot-json\n')
+    create_jsonl_index(path)
+    spec = IndexPackCollectionSpec(
+        role="manifest", kind="jsonl", source_spec=str(path), paths=(str(path),)
+    )
+    pack_path = tmp_path / "dataset.idxpack"
+    write_index_pack(pack_path, [spec])
+    source = LazyPackedManifestIterator(
+        pack_path,
+        spec.key,
+        decode=GraphOriginDict,
+        skip_decode_errors=True,
+    )
+
+    with pytest.warns(UserWarning, match="Skipping malformed packed manifest"):
+        assert [item["id"] for item in source] == ["good"]

--- a/test/test_iterator_node_e2e_checkpoint.py
+++ b/test/test_iterator_node_e2e_checkpoint.py
@@ -13,6 +13,12 @@ from lhotse.dataset.sampling.base import CutSampler
 from lhotse.dataset.sampling.dynamic_bucketing import DynamicBucketingSampler
 from lhotse.dataset.webdataset import LazyWebdatasetIterator, export_to_webdataset
 from lhotse.hf import LazyHFDatasetIterator
+from lhotse.index_pack import (
+    IndexPackCollectionSpec,
+    index_pack_collection_key,
+    write_index_pack,
+)
+from lhotse.indexing import create_jsonl_index
 from lhotse.lazy import (
     IteratorNode,
     LazyFilter,
@@ -29,6 +35,7 @@ from lhotse.lazy import (
     LazySlicer,
     LazyTxtIterator,
 )
+from lhotse.packed_lazy import LazyPackedManifestIterator
 from lhotse.shar.readers.indexed import LazyIndexedSharIterator
 from lhotse.shar.readers.lazy import LazySharIterator
 from lhotse.testing.dummies import DummyManifest
@@ -82,6 +89,17 @@ def iterator_node_sources(tmp_path) -> Dict[str, Path]:
     DummyManifest(CutSet, begin_id=2000, end_id=2016).to_jsonl(shar_0)
     DummyManifest(CutSet, begin_id=3000, end_id=3016).to_jsonl(shar_1)
 
+    packed_spec = IndexPackCollectionSpec(
+        role="cuts",
+        kind="application/x-lhotse-cut-jsonl",
+        source_spec="cuts_[ab].jsonl",
+        paths=(str(cuts_a), str(cuts_b)),
+    )
+    create_jsonl_index(cuts_a)
+    create_jsonl_index(cuts_b)
+    packed = tmp_path / "cuts.idxpack"
+    write_index_pack(packed, [packed_spec])
+
     webdataset_tar = tmp_path / "cuts.tar"
     if is_module_available("webdataset"):
         base_cut = CutSet.from_file("test/fixtures/libri/cuts.json")[0]
@@ -103,6 +121,7 @@ def iterator_node_sources(tmp_path) -> Dict[str, Path]:
         "shar_0": shar_0,
         "shar_1": shar_1,
         "webdataset_tar": webdataset_tar,
+        "packed": packed,
     }
 
 
@@ -112,6 +131,21 @@ def _build_lazy_manifest(sources: Dict[str, Path]) -> CutSet:
 
 def _build_lazy_indexed_manifest(sources: Dict[str, Path]) -> CutSet:
     return CutSet(LazyIndexedManifestIterator(sources["cuts_a"], shuffle=True, seed=19))
+
+
+def _build_lazy_packed_manifest(sources: Dict[str, Path]) -> CutSet:
+    return CutSet(
+        LazyPackedManifestIterator(
+            sources["packed"],
+            index_pack_collection_key(
+                "cuts",
+                "application/x-lhotse-cut-jsonl",
+                "cuts_[ab].jsonl",
+            ),
+            shuffle_shards=True,
+            seed=19,
+        )
+    )
 
 
 def _build_lazy_iterator_chain(sources: Dict[str, Path]) -> CutSet:
@@ -243,6 +277,11 @@ def _build_lazy_hf_dataset_iterator(_: Dict[str, Path]) -> CutSet:
 
 
 INDEXED_E2E_CASES = [
+    pytest.param(
+        "LazyPackedManifestIterator",
+        _build_lazy_packed_manifest,
+        id="LazyPackedManifestIterator",
+    ),
     pytest.param(
         "LazyIndexedManifestIterator",
         _build_lazy_indexed_manifest,


### PR DESCRIPTION
## Summary

- add a generic, immutable `.idxpack` storage primitive that combines many conventional uint64 sidecars and their ordered source catalog into one file
- mmap the pack read-only and resolve records on demand without allocating per-shard offset arrays or opening every sidecar during dataset construction
- add `LazyPackedManifestIterator` with indexed access, deterministic shuffling, worker partitioning, checkpoint/resume, and a pack-shared bounded file-descriptor cache
- add an atomic converter with source/sidecar validation, CRCs, layout identity, corruption checks, fork/pickle safety, and compatibility with existing version-2 packs

The format deliberately does not know about downstream frameworks or manifest schemas. Collection roles and storage-kind strings are application-defined; Lhotse only stores the catalog and resolves byte ranges.

## Motivation

Datasets with hundreds of thousands of shards can spend tens of minutes opening and copying loose indexes on high-latency filesystems before the first batch. A single mmap keeps construction metadata-small and lets the OS page in only the catalog/offset pages actually touched.

## Validation

- `20 passed` — focused pack, corruption, lookup, fork, and checkpoint/restore tests
- Black and isort checks pass on all touched files; Ruff passes on the new modules/tests
- opened 13 different dataset packs (about 2.14 million segment rows) with the exact committed reader in 35.431s
- downstream NeMo integration: `11 passed` focused idxpack tests plus `68 passed` inherited preference-sampling/partition tests
- one-node / eight-GPU training with all 13 packs and real audio: 5 optimizer steps, validation, checkpoint save, clean exit