### PR TITLE
Add source metadata for path-only index packs

### DIFF
--- a/lhotse/index_pack.py
+++ b/lhotse/index_pack.py
@@ -58,6 +58,7 @@ _SEQUENCE = struct.Struct("<QQ")
 # offset count, source size, offsets byte size, CRC32, reserved.
 _SEGMENT = struct.Struct("<QQIIQQQII")
 _SEGMENT_PATH_ONLY = 1
+_SEGMENT_PATH_ONLY_SOURCE_SIZE_PRESENT = 1
 _U64 = struct.Struct("<Q")
 
 
@@ -94,6 +95,19 @@ def index_pack_collection_key(role: str, kind: str, source_spec) -> bytes:
         sort_keys=True,
     ).encode("utf-8")
     return hashlib.sha256(payload).digest()
+
+
+def index_pack_layout_hash(
+    collections: Sequence[IndexPackCollectionSpec],
+) -> bytes:
+    """Return the exact layout digest persisted for ``collections``.
+
+    This lets orchestration validate an existing pack against its current
+    declarative collection contract without creating or scanning a pack.
+    Source paths and collection identities participate in the digest; source
+    sizes are validated separately against per-segment metadata.
+    """
+    return _layout_digest(collections)
 
 
 @dataclass(frozen=True)
@@ -203,9 +217,11 @@ def write_index_pack(
         source_size_overrides:
             Explicit current sizes for selected sources. The corresponding
             sidecar sentinel is replaced in the pack without modifying the
-            sidecar itself. Callers are responsible for verifying that bytes
-            beyond the original sentinel are safe to include, for example
-            archive padding rather than another record.
+            sidecar itself. For path-only collections, the supplied size is
+            persisted as validation metadata even though no record offsets are
+            stored. Callers are responsible for verifying that bytes beyond
+            an indexed sentinel are safe to include, for example archive
+            padding rather than another record.
         index_path_overrides:
             Alternative local sidecars for selected sources. This supports
             private repair overlays without mutating a shared index mirror.
@@ -322,7 +338,7 @@ def write_index_pack(
     offsets_offset = strings_offset + len(string_blob)
     offsets_offset += (-offsets_offset) % _U64.size
     offsets_size = sum(segment.offsets_count * _U64.size for segment in segments)
-    layout_hash = _layout_digest(collections)
+    layout_hash = index_pack_layout_hash(collections)
 
     tmp_path = output_path.with_name(
         f".{output_path.name}.tmp.{os.getpid()}.{uuid.uuid4().hex}"
@@ -385,11 +401,17 @@ def write_index_pack(
                 checksum = 0
                 copied = 0
                 previous: int | None = None
+                metadata_flags = 0
                 if segment.path_only:
-                    chunk = _U64.pack(0)
+                    if segment.source_size is None:
+                        path_only_source_size = 0
+                    else:
+                        path_only_source_size = segment.source_size
+                        metadata_flags |= _SEGMENT_PATH_ONLY_SOURCE_SIZE_PRESENT
+                    chunk = _U64.pack(path_only_source_size)
                     checksum = zlib.crc32(chunk)
                     copied = len(chunk)
-                    previous = 0
+                    previous = path_only_source_size
                     out.write(chunk)
                 else:
                     assert segment.index_path is not None
@@ -425,13 +447,21 @@ def write_index_pack(
                     raise ValueError(
                         f"Index sidecar contains no sentinel: {segment.index_path}"
                     )
-                source_size = (
-                    previous if segment.source_size is None else segment.source_size
-                )
-                if previous != source_size:
-                    raise ValueError(
-                        f"Invalid sentinel in {segment.index_path}: metadata={source_size}, payload={previous}"
+                if segment.path_only:
+                    # Keep the v2 segment-row invariant required by existing
+                    # readers. Optional source-size metadata lives in the
+                    # otherwise ignored one-uint64 payload and is identified
+                    # by the reserved metadata field below.
+                    source_size = 0
+                else:
+                    source_size = (
+                        previous if segment.source_size is None else segment.source_size
                     )
+                    if previous != source_size:
+                        raise ValueError(
+                            f"Invalid sentinel in {segment.index_path}: "
+                            f"metadata={source_size}, payload={previous}"
+                        )
                 path_rel, path_len = path_positions[segment_id]
                 segment_rows.append(
                     (
@@ -443,7 +473,7 @@ def write_index_pack(
                         source_size,
                         expected_size,
                         checksum & 0xFFFFFFFF,
-                        0,
+                        metadata_flags,
                     )
                 )
                 payload_cursor += expected_size
@@ -570,6 +600,25 @@ class PackedIndexCollection:
             else 0
         )
         return cumulative_end - previous_end
+
+    def source_size_for_shard(self, shard_index: int) -> int | None:
+        """Return the source size persisted for one logical shard.
+
+        Returns ``None`` for path-only v2 packs written before source-size
+        metadata was supported. A known empty source returns zero.
+        """
+        shard_index = self._normalize_shard_index(shard_index)
+        pack = self.pack
+        pack._ensure_open()
+        segment_id, _ = pack._sequence(self.sequence_start + shard_index)
+        segment = pack._segment(segment_id)
+        if segment[3] & _SEGMENT_PATH_ONLY:
+            if segment[8] & _SEGMENT_PATH_ONLY_SOURCE_SIZE_PRESENT:
+                return int(pack._u64(segment[1]))
+            # Briefly, development versions stored this value directly in the
+            # segment row. Retain read compatibility with packs they produced.
+            return int(segment[5]) or None
+        return int(segment[5])
 
     def locate_in_shard(
         self, shard_index: int, local_index: int
@@ -1157,7 +1206,7 @@ class IndexPack:
                 source_size,
                 size,
                 _,
-                _,
+                metadata_flags,
             ) = segment
             if flags & ~_SEGMENT_PATH_ONLY:
                 self.close()
@@ -1178,10 +1227,20 @@ class IndexPack:
                 raise ValueError(
                     f"Index pack segment {segment_id} has an invalid offset payload range"
                 )
-            if flags & _SEGMENT_PATH_ONLY and (offsets_count != 1 or source_size != 0):
+            if flags & _SEGMENT_PATH_ONLY and offsets_count != 1:
                 self.close()
                 raise ValueError(
                     f"Index pack path-only segment {segment_id} contains record metadata"
+                )
+            if (
+                flags & _SEGMENT_PATH_ONLY
+                and metadata_flags & _SEGMENT_PATH_ONLY_SOURCE_SIZE_PRESENT
+                and source_size != 0
+            ):
+                self.close()
+                raise ValueError(
+                    f"Index pack path-only segment {segment_id} mixes source-size "
+                    "encodings"
                 )
             offsets_cursor += size
         if offsets_cursor != self.offsets_offset + self.offsets_size:
@@ -1427,11 +1486,26 @@ def _read_sidecar_metadata(
     index_path_override: Pathlike | None = None,
 ) -> _BuildSegment:
     if not offsets_required:
+        if source_size_override is not None and source_size_override < 0:
+            raise ValueError(
+                f"Invalid negative source-size override for {path}: "
+                f"{source_size_override}"
+            )
+        if source_size_override is not None and not _is_remote_path(path):
+            try:
+                local_source_size = Path(path).stat().st_size
+            except FileNotFoundError as ex:
+                raise FileNotFoundError(f"Indexed source not found: {path}") from ex
+            if source_size_override != local_source_size:
+                raise ValueError(
+                    f"Source-size override for {path} is {source_size_override}, "
+                    f"but the local source is {local_source_size} bytes"
+                )
         return _BuildSegment(
             path=path,
             index_path=None,
             offsets_count=1,
-            source_size=0,
+            source_size=source_size_override,
             path_only=True,
         )
     idx = (

--- a/test/test_index_pack.py
+++ b/test/test_index_pack.py
@@ -12,6 +12,7 @@ from lhotse.index_pack import (
     IndexPack,
     IndexPackCollectionSpec,
     index_pack_collection_key,
+    index_pack_layout_hash,
     write_index_pack,
 )
 from lhotse.indexing import create_jsonl_index
@@ -82,6 +83,40 @@ def test_index_pack_converts_existing_sidecars_and_reads_lazily(tmp_path):
                 actual.append(json.loads(f.read(location.end - location.start)))
 
         assert actual == [record for shard in records for record in shard]
+
+
+def test_index_pack_layout_hash_matches_persisted_contract(tmp_path):
+    paths = (str(tmp_path / "payload-0.tar"), str(tmp_path / "payload-1.tar"))
+    spec = IndexPackCollectionSpec(
+        role="payload",
+        kind="application/x-tar",
+        source_spec="payload-{0..1}.tar",
+        paths=paths,
+        offsets_required=False,
+    )
+    expected = index_pack_layout_hash([spec])
+    pack_path = tmp_path / "dataset.idxpack"
+    write_index_pack(pack_path, [spec])
+
+    with IndexPack(pack_path, expected_layout_hash=expected) as pack:
+        assert pack.layout_hash == expected
+
+    reversed_paths = IndexPackCollectionSpec(
+        role=spec.role,
+        kind=spec.kind,
+        source_spec=spec.source_spec,
+        paths=tuple(reversed(paths)),
+        offsets_required=False,
+    )
+    indexed = IndexPackCollectionSpec(
+        role=spec.role,
+        kind=spec.kind,
+        source_spec=spec.source_spec,
+        paths=paths,
+        offsets_required=True,
+    )
+    assert index_pack_layout_hash([reversed_paths]) != expected
+    assert index_pack_layout_hash([indexed]) != expected
 
 
 def test_index_pack_defers_mmap_through_catalog_lookup_and_pickle(tmp_path):
@@ -210,9 +245,91 @@ def test_index_pack_path_only_collection_needs_no_sidecars(tmp_path):
         collection = pack.collection(spec.key)
         assert not collection.offsets_required
         assert len(collection) == 0
+        assert collection.source_size_for_shard(0) is None
         assert collection.path_for_shard(-1) == paths[-1]
         with pytest.raises(IndexError):
             collection.locate(0)
+
+
+def test_index_pack_path_only_collection_persists_validated_source_sizes(tmp_path):
+    local_path = tmp_path / "payload.tar"
+    local_path.write_bytes(b"payload")
+    empty_path = tmp_path / "empty.tar"
+    empty_path.write_bytes(b"")
+    remote_path = "s3://sealed-bucket/payload.tar"
+    spec = IndexPackCollectionSpec(
+        role="payload",
+        kind="application/x-tar",
+        source_spec=[str(local_path), str(empty_path), remote_path],
+        paths=(str(local_path), str(empty_path), remote_path),
+        offsets_required=False,
+    )
+    pack_path = tmp_path / "dataset.idxpack"
+    write_index_pack(
+        pack_path,
+        [spec],
+        source_size_overrides={
+            str(local_path): local_path.stat().st_size,
+            str(empty_path): empty_path.stat().st_size,
+            remote_path: 1234,
+        },
+    )
+
+    with IndexPack(pack_path) as pack:
+        collection = pack.collection(spec.key)
+        assert collection.source_size_for_shard(0) == len(b"payload")
+        assert collection.source_size_for_shard(1) == 0
+        assert collection.source_size_for_shard(2) == 1234
+
+        # Preserve the segment-row invariant enforced by pre-change v2 readers.
+        for shard_index, expected_size in enumerate((len(b"payload"), 0, 1234)):
+            segment_id, _ = pack._sequence(collection.sequence_start + shard_index)
+            segment = pack._segment(segment_id)
+            assert segment[5] == 0
+            assert segment[8] == 1
+            assert pack._u64(segment[1]) == expected_size
+
+
+def test_index_pack_reads_interim_path_only_source_size_encoding(tmp_path):
+    path = str(tmp_path / "payload.tar")
+    spec = IndexPackCollectionSpec(
+        role="payload",
+        kind="application/x-tar",
+        source_spec=path,
+        paths=(path,),
+        offsets_required=False,
+    )
+    pack_path = tmp_path / "dataset.idxpack"
+    write_index_pack(pack_path, [spec])
+
+    with IndexPack(pack_path) as pack:
+        segment_offset = pack.segment_offset
+    source_size_offset = segment_offset + struct.calcsize("<QQIIQ")
+    with pack_path.open("r+b") as f:
+        f.seek(source_size_offset)
+        f.write(struct.pack("<Q", 1234))
+
+    with IndexPack(pack_path) as pack:
+        assert pack.collection(spec.key).source_size_for_shard(0) == 1234
+
+
+def test_index_pack_path_only_rejects_incorrect_local_source_size(tmp_path):
+    path = tmp_path / "payload.tar"
+    path.write_bytes(b"payload")
+    spec = IndexPackCollectionSpec(
+        role="payload",
+        kind="application/x-tar",
+        source_spec=str(path),
+        paths=(str(path),),
+        offsets_required=False,
+    )
+
+    with pytest.raises(ValueError, match="Source-size override"):
+        write_index_pack(
+            tmp_path / "dataset.idxpack",
+            [spec],
+            source_size_overrides={str(path): path.stat().st_size + 1},
+        )
 
 
 def test_index_pack_opens_v2_path_only_collection_without_collection_flag(tmp_path):


### PR DESCRIPTION
## Summary
- expose the deterministic index-pack layout hash for reuse validation
- persist caller-validated source sizes for path-only collections while preserving the v2 segment-row contract
- read stable legacy packs, interim development packs, and the new marked-payload encoding
- distinguish absent path-only metadata from a validated zero-byte source

## Backward compatibility
- newly written packs retain the invariants expected by existing v2 readers
- the exact pre-change reader was loaded separately and successfully opened a newly written pack
- new readers continue to open older packs and return `None` when path-only size metadata is unavailable

## Validation
- `pytest -q test/test_index_pack.py` (27 passed)
- `pre-commit run --files lhotse/index_pack.py test/test_index_pack.py`
- `git diff --check`

An adjacent iterator checkpoint suite was also run: 60 tests passed and one unrelated `LazyHFDatasetIterator` case failed identically on pristine `origin/master` because the fixture produced only two batches.