### PR TITLE
Speedup AISBatchLoader construction using new Batch.add() string API

### DIFF
--- a/lhotse/ais/batch_loader.py
+++ b/lhotse/ais/batch_loader.py
@@ -111,7 +111,7 @@ class AISBatchLoader:
         if self._client is None:
             if not is_module_available("aistore"):
                 raise ImportError(
-                    "Please run 'pip install aistore>=1.17.0' to use AISBatchLoader."
+                    "Please run 'pip install aistore>=1.26.0' to use AISBatchLoader."
                 )
             self._client, _ = get_aistore_client()
         return self._client
@@ -122,7 +122,7 @@ class AISBatchLoader:
         Normalise an AIStore batch request/result entry into ``(bck, provider,
         obj_name, archpath)``.
 
-        Verified empirically against ``aistore==1.23.0`` and ``1.25.0``:
+        Verified empirically against ``aistore==1.26.0``:
           * ``Batch.requests_list`` items are ``aistore.sdk.batch.types.MossIn``
             with the original short attribute names (``bck``, ``provider``,
             ``obj_name``, ``archpath``).
@@ -653,51 +653,15 @@ class AISBatchLoader:
     @staticmethod
     @lru_cache(maxsize=1)
     def _aistore_byte_range_supported() -> bool:
-        """
-        Detect whether the installed aistore SDK/cluster generation supports
-        byte-range MOSS entries.
-
-        ``aistore==1.25.0`` removed the older ``BatchRequest`` class and still
-        has ``Batch.add(..., start=, length=)`` guarded by ``NotImplementedError``.
-        The supported API is the lower-level MOSS request schema:
-        ``Batch.requests_list`` exposes ``MossReq.moss_in`` and ``MossIn``
-        serializes ``start`` / ``length`` in the GetBatch JSON body. Older SDKs
-        had partial client-side fields before server support existed, so keep a
-        conservative version gate and schema check here.
-        """
+        """Return True if the SDK supports byte-range entries in Batch.add() (requires aistore>=1.26.0)."""
         try:
             import re
 
             import aistore
-            from aistore.sdk.batch.batch import Batch
-            from aistore.sdk.batch.types import MossIn, MossReq
         except Exception:
             return False
-
         m = re.match(r"^(\d+)\.(\d+)\.(\d+)", getattr(aistore, "__version__", ""))
-        if m is None or tuple(map(int, m.groups())) < (1, 25, 0):
-            return False
-
-        try:
-            descriptor = vars(Batch).get("requests_list")
-            if not isinstance(descriptor, property):
-                return False
-            if "moss_in" not in MossReq.model_fields:
-                return False
-            if not {"start", "length"}.issubset(MossIn.model_fields):
-                return False
-            probe = MossIn.model_construct(
-                obj_name="__lhotse_probe__.tar",
-                bck="__lhotse_probe__",
-                provider="ais",
-                start=0,
-                length=1,
-            )
-            dumped = probe.model_dump(by_alias=True, exclude_defaults=True)
-        except Exception:
-            return False
-
-        return dumped.get("start") == 0 and dumped.get("length") == 1
+        return m is not None and tuple(map(int, m.groups())) >= (1, 26, 0)
 
     def _add_shar_ptr_to_batch(
         self,
@@ -776,81 +740,15 @@ class AISBatchLoader:
         start: Optional[int] = None,
         length: Optional[int] = None,
     ) -> None:
-        """Append one MossIn entry to the batch request, bypassing the SDK's
-        ``Batch.add(bucket.object(obj_name), ...)`` path.
-
-        Why this bypass exists
-        ----------------------
-        ``Batch.add`` builds a fresh ``Bucket`` + ``BucketDetails``
-        (Pydantic v2) + ``Object`` + ``MossIn`` (Pydantic v2 with field
-        aliases) per call. With ~45 manifests per minibatch in a Granary
-        blend, profiling (nsys 2026-05-15, NVTX scope ``ais.collect_urls``)
-        showed this loop spends **~1.58 s mean / 4.31 s max per batch on
-        pure CPU**, which is ~2/3 of the AIS GetBatch wall time and the
-        single biggest hotspot in the worker.
-
-        ``MossIn.model_construct(...)`` skips validation entirely — the
-        downstream HTTP serialization only consumes the field values.
-        Construction reduces to one dict write into ``batch.request.moss_in``,
-        which empirically drops ``ais.collect_urls`` by ~20-50×.
-
-        Risks
-        -----
-        - Skipping Pydantic validation means a future ``aistore`` SDK that
-          adds a required ``MossIn`` field will silently produce invalid
-          requests. Pinned to ``aistore<2.0`` at the call site below; the
-          unit test in ``test/test_ais_batch_loader_collect_urls.py``
-          round-trips ``model_construct`` vs the validating constructor
-          and asserts ``model_dump`` equality.
-        - ``batch.request.moss_in`` is a non-public attribute. Stable
-          through 1.20.0 → 1.25.0; bumping the SDK major version requires
-          re-verifying that the field still exists with the same shape.
-        """
-        # Local imports kept local: aistore is an optional dependency and
-        # the module top-level is intentionally aistore-free so AISBatchLoader
-        # can be constructed on hosts without the SDK installed (see
-        # :pyattr:`client` doc and ``_cuts_have_ais_data`` short-circuit).
-        from aistore.sdk.batch.types import MossIn
-
-        # Construct kwargs sparsely so optional fields that the SDK's MossIn
-        # schema may not accept (e.g. older versions without start/length)
-        # don't surface as model_construct kwargs.
-        kwargs = {"bck": bck, "provider": provider, "obj_name": obj_name}
-        if archpath is not None:
-            kwargs["archpath"] = archpath
-        if start is not None:
-            kwargs["start"] = start
-        if length is not None:
-            kwargs["length"] = length
-
-        # Fast path. ``Batch.requests_list`` is the public property accessor
-        # for ``Batch.request.moss_in`` (the underlying ``List[MossIn]``);
-        # mutating the returned list is equivalent to mutating the field
-        # in-place. If the SDK shape ever drifts (rename, restructure), fall
-        # back to ``Batch.add(bucket.object(...))`` so we degrade in
-        # performance rather than crash. The fast path is exercised by the
-        # unit test which round-trips ``model_construct`` against the
-        # validating constructor.
-        try:
-            requests_list = batch.requests_list
-            if isinstance(requests_list, list):
-                requests_list.append(MossIn.model_construct(**kwargs))
-                return
-            raise AttributeError
-        except AttributeError:
-            pass
-        # Fallback: original aistore client path. Reaches client.bucket and
-        # bucket.object, both of which validate; this is the pre-optimization
-        # behavior preserved for forward compatibility and for tests/mocks
-        # that don't provide a real Batch.requests_list list.
-        if not hasattr(self, "_client"):
-            batch.add(obj_name, start=start, length=length, archpath=archpath)
-            return
-        bucket = self.client.bucket(bck, provider)
-        if start is not None or length is not None:
-            batch.add(bucket.object(obj_name), start=start, length=length)
-        else:
-            batch.add(bucket.object(obj_name), archpath=archpath)
+        """Add one entry to the MOSS batch; string-based add avoids per-call Bucket/Object construction."""
+        batch.add(
+            obj_name,
+            bck=bck,
+            provider=provider,
+            archpath=archpath,
+            start=start,
+            length=length,
+        )
 
     def _inject_data_into_manifest(self, manifest: Any, content: bytes) -> None:
         """Replace manifest storage references with in-memory content."""

--- a/setup.py
+++ b/setup.py
@@ -180,7 +180,7 @@ tests_require = [
     "isort==5.10.1",
     "pre-commit>=2.17.0,<=2.19.0",
 ] + lilcom_requires
-aistore_requires = ["aistore>=1.17.0"]
+aistore_requires = ["aistore>=1.26.0"]
 orjson_requires = ["orjson>=3.6.6"]
 webdataset_requires = ["webdataset==0.2.5"]
 dill_requires = ["dill"]

--- a/test/ais/test_batch_loader_moss_in.py
+++ b/test/ais/test_batch_loader_moss_in.py
@@ -1,168 +1,119 @@
-"""Schema-drift guard for ``AISBatchLoader._append_moss_in``'s fast path.
+"""Guards against SDK drift for AISBatchLoader's batch construction path.
 
-The fast path bypasses Pydantic v2 validation by calling
-``MossIn.model_construct(...)`` directly and appending to
-``batch.request.moss_in``. If a future ``aistore`` SDK adds a required
-field, renames one of the fields we pass, or restructures
-``batch.request.moss_in`` away from a list, the bypass silently produces
-invalid requests. These tests pin the assumption and fail loudly on drift.
+``AISBatchLoader._append_moss_in`` now uses ``Batch.add(str, bck=, provider=)``
+introduced in aistore 1.26.0. These tests verify that the SDK API we rely on
+still exists and behaves correctly, and document the construction speedup vs
+the previous ``MossIn.model_construct`` bypass.
 
 Run with::
 
     pytest test/ais/test_batch_loader_moss_in.py -v
+    pytest test/ais/test_batch_loader_moss_in.py -v -k bench  # timing only
 """
 
 from __future__ import annotations
 
+import inspect
+import time
+
 import pytest
 
-aistore = pytest.importorskip("aistore")
+aistore = pytest.importorskip("aistore", minversion="1.26.0")
 
+from aistore.sdk.batch.batch import Batch
 from aistore.sdk.batch.types import MossIn, MossReq
 
 # ---------------------------------------------------------------------------
-# Field presence: the fast path passes specific kwargs to MossIn — assert
-# they're all real fields on the current SDK so a rename surfaces here.
+# SDK field presence: catch renames before they cause silent bad requests
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
-    "field",
-    ["obj_name", "bck", "provider", "archpath", "start", "length"],
+    "field", ["obj_name", "bck", "provider", "archpath", "start", "length"]
 )
-def test_mossin_has_required_field(field: str):
-    """Every kwarg ``_append_moss_in`` passes must exist on ``MossIn``."""
+def test_mossin_has_field(field: str):
+    """MossIn must expose every field that AISBatchLoader reads via _moss_attrs/_moss_range."""
     assert field in MossIn.model_fields, (
-        f"AISBatchLoader._append_moss_in passes '{field}' to "
-        f"MossIn.model_construct, but the field is missing on aistore "
-        f"{aistore.__version__}. Update the fast path or pin the SDK."
+        f"MossIn.{field} missing on aistore {aistore.__version__}; "
+        f"AISBatchLoader reads this field for fallback GET and saved_requests_list recovery."
     )
 
 
-def test_mossin_obj_name_is_required():
-    """``obj_name`` is the only required field today; if more get added,
-    the fast path's kwargs-sparse build silently produces an invalid request."""
-    required = [
-        name for name, info in MossIn.model_fields.items() if info.is_required()
-    ]
-    assert set(required) <= {"obj_name"}, (
-        f"MossIn introduced new required fields {set(required) - {'obj_name'}} "
-        f"in aistore {aistore.__version__}. AISBatchLoader._append_moss_in's "
-        f"sparse-kwargs build will skip them and produce invalid requests. "
-        f"Update the fast path."
+def test_mossreq_has_moss_in_field():
+    """MossReq.moss_in is the list AISBatchLoader reads via saved_requests_list for fallback recovery."""
+    assert (
+        "moss_in" in MossReq.model_fields
+    ), f"MossReq.moss_in missing on aistore {aistore.__version__}."
+
+
+def test_batch_requests_list_is_property():
+    """Batch.requests_list must remain a property — AISBatchLoader snapshots it for fallback recovery."""
+    descriptor = vars(Batch).get("requests_list")
+    assert isinstance(descriptor, property), (
+        f"Batch.requests_list is {type(descriptor).__name__!r}, expected property "
+        f"on aistore {aistore.__version__}."
     )
 
 
 # ---------------------------------------------------------------------------
-# Round-trip equivalence: model_construct() must produce the same payload
-# as the validating constructor for every (kwargs-sparse) combination the
-# fast path actually emits.
+# Batch.add(str, bck=, provider=) API: verify the new string-based path works
 # ---------------------------------------------------------------------------
 
 
-_FAST_KWARG_COMBOS = [
-    # (description, kwargs)
-    (
-        "url-only (e.g. recording.source.type='url')",
-        {"obj_name": "audio.wav", "bck": "bkt", "provider": "ais"},
-    ),
-    (
-        "url with archpath (tar member)",
-        {
-            "obj_name": "shard.tar",
-            "bck": "bkt",
-            "provider": "ais",
-            "archpath": "rec1.wav",
-        },
-    ),
-    (
-        "shar_ptr (byte-range)",
-        {
-            "obj_name": "shard.tar",
-            "bck": "bkt",
-            "provider": "ais",
-            "start": 4096,
-            "length": 65536,
-        },
-    ),
-    (
-        "aws provider variant",
-        {"obj_name": "shard.tar", "bck": "bkt", "provider": "aws"},
-    ),
+@pytest.mark.parametrize(
+    "param",
+    ["obj", "bck", "provider", "archpath", "start", "length"],
+)
+def test_batch_add_accepts_param(param: str):
+    """Batch.add must accept every kwarg that _append_moss_in passes — catch renames early."""
+    sig = inspect.signature(Batch.add)
+    assert param in sig.parameters, (
+        f"Batch.add no longer has a '{param}' parameter on aistore {aistore.__version__}. "
+        f"AISBatchLoader._append_moss_in passes this kwarg — update the call site."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Timing: document construction speedup vs old model_construct bypass
+# ---------------------------------------------------------------------------
+
+_N_ITERS = 500
+_COMBOS = [
+    {"obj_name": "audio.wav", "bck": "bkt", "provider": "ais"},
+    {"obj_name": "shard.tar", "bck": "bkt", "provider": "ais", "archpath": "rec1.wav"},
+    {
+        "obj_name": "shard.tar",
+        "bck": "bkt",
+        "provider": "ais",
+        "start": 4096,
+        "length": 65536,
+    },
 ]
 
 
-@pytest.mark.parametrize(
-    "desc,kwargs", _FAST_KWARG_COMBOS, ids=[c[0] for c in _FAST_KWARG_COMBOS]
-)
-def test_model_construct_matches_validating_constructor(desc: str, kwargs: dict):
-    """``MossIn.model_construct(**kwargs)`` must serialize identically to
-    ``MossIn(**kwargs)`` — same field values, same defaults for omitted
-    fields. If they ever diverge, the fast path is no longer a no-op."""
-    fast = MossIn.model_construct(**kwargs)
-    slow = MossIn(**kwargs)
-    assert fast.model_dump() == slow.model_dump(), (
-        f"MossIn.model_construct dump differs from MossIn(...) dump for {desc!r}.\n"
-        f"  fast: {fast.model_dump()}\n  slow: {slow.model_dump()}"
-    )
+def _time_fn(fn, n: int) -> float:
+    t0 = time.perf_counter()
+    for _ in range(n):
+        for kwargs in _COMBOS:
+            fn(kwargs)
+    return time.perf_counter() - t0
 
 
-def test_model_construct_dump_json_matches_validating_constructor():
-    """Wire-format equivalence: the SDK serializes via ``model_dump_json``
-    or equivalent; that's the surface the AIStore proxy actually sees."""
-    kwargs = {"obj_name": "x.tar", "bck": "b", "provider": "ais", "archpath": "y.wav"}
-    fast = MossIn.model_construct(**kwargs).model_dump_json()
-    slow = MossIn(**kwargs).model_dump_json()
-    assert fast == slow, f"JSON serialization differs: fast={fast!r} slow={slow!r}"
+def test_mossin_validating_constructor_not_slower_than_model_construct():
+    """The validating constructor must be at least as fast as model_construct.
 
+    model_construct was used as a bypass to avoid Pydantic validation overhead,
+    but Pydantic v2 with frozen=True makes MossIn(**kwargs) faster. If this
+    ever regresses, the bypass may need to be reintroduced.
+    """
+    # Warmup
+    _time_fn(lambda kw: MossIn.model_construct(**kw), 50)
+    _time_fn(lambda kw: MossIn(**kw), 50)
 
-# ---------------------------------------------------------------------------
-# Container shape: the fast path appends to ``batch.requests_list`` (public
-# property returning ``MossReq.moss_in``) — assert that ``MossReq.moss_in``
-# exists, is list-typed, and that ``Batch.requests_list`` is the accessor.
-# We can't easily instantiate ``Batch`` without an AIStore client, so we
-# verify the shape at the type-system level instead.
-# ---------------------------------------------------------------------------
+    t_construct = _time_fn(lambda kw: MossIn.model_construct(**kw), _N_ITERS)
+    t_validate = _time_fn(lambda kw: MossIn(**kw), _N_ITERS)
 
-
-def test_mossreq_has_moss_in_list_field():
-    """``MossReq.moss_in`` is the underlying ``List[MossIn]`` we append to
-    via ``batch.requests_list``. If this field name or type changes, the
-    fast path breaks."""
-    assert "moss_in" in MossReq.model_fields, (
-        f"MossReq.moss_in missing on aistore {aistore.__version__}; "
-        f"AISBatchLoader fast path uses batch.requests_list which delegates "
-        f"to this field."
-    )
-    annotation = MossReq.model_fields["moss_in"].annotation
-    # typing.List[MossIn] subscripts; check origin is list-like.
-    import typing as _t
-
-    assert _t.get_origin(annotation) is list, (
-        f"MossReq.moss_in type changed from List[MossIn] to {annotation} "
-        f"on aistore {aistore.__version__}. Fast path's append() may break."
-    )
-
-
-def test_batch_requests_list_is_public_accessor():
-    """``Batch.requests_list`` must be a ``@property`` returning the
-    underlying ``MossReq.moss_in`` list — that's what the fast path
-    mutates. If it's renamed or turned into a getter that returns a copy,
-    the fast path silently no-ops."""
-    from aistore.sdk.batch.batch import Batch
-
-    descriptor = vars(Batch).get("requests_list")
-    assert isinstance(descriptor, property), (
-        f"Batch.requests_list is {type(descriptor).__name__}, expected property "
-        f"on aistore {aistore.__version__}."
-    )
-    # Sanity-check the getter body: must reach back into MossReq.moss_in.
-    # Most robust check is source inspection (kept lenient — only flag a hard
-    # rename of 'moss_in', anything else gets caught by the round-trip tests).
-    import inspect
-
-    src = inspect.getsource(descriptor.fget)
-    assert "moss_in" in src, (
-        f"Batch.requests_list source no longer references moss_in on "
-        f"aistore {aistore.__version__}: {src!r}"
+    assert t_validate <= t_construct * 1.5, (
+        f"MossIn(**kwargs) ({t_validate*1000:.1f}ms) is significantly slower than "
+        f"model_construct ({t_construct*1000:.1f}ms) — the bypass may need to be reintroduced."
     )

--- a/test/shar/test_lazy_pointers.py
+++ b/test/shar/test_lazy_pointers.py
@@ -333,6 +333,28 @@ def test_ais_byte_range_path_when_sdk_supports_it():
         def __init__(self):
             self.requests_list = []
 
+        def add(
+            self, obj_name, *, bck, provider, archpath=None, start=None, length=None
+        ):
+            from aistore.sdk.batch.types import MossIn
+
+            self.requests_list.append(
+                MossIn(
+                    obj_name=obj_name,
+                    bck=bck,
+                    provider=provider,
+                    **{
+                        k: v
+                        for k, v in [
+                            ("archpath", archpath),
+                            ("start", start),
+                            ("length", length),
+                        ]
+                        if v is not None
+                    },
+                )
+            )
+
     with patch.object(
         AISBatchLoader, "_aistore_byte_range_supported", staticmethod(lambda: True)
     ):


### PR DESCRIPTION
`AISBatchLoader._append_moss_in` previously bypassed Pydantic validation using `MossIn.model_construct` and directly mutated `batch.request.moss_in` to avoid per-entry `Bucket`/`Object` construction overhead. This relied on private SDK internals and was fragile across SDK versions.

aistore 1.26.0 introduces `Batch.add(str, bck=, provider=)` as well as many other performance optimizations (see commits [dc0cf9b](https://github.com/NVIDIA/aistore/commit/dc0cf9bd8cd89072ea1c3d46dd436d6fbe5c4d5e) and [1391d0b](https://github.com/NVIDIA/aistore/commit/1391d0b96b716e60284405b8d03ec1865498b5fd)), accepting object names as plain strings and skipping intermediate wrapper construction at the SDK level. Benchmarking shows that the new SDK validating constructor is **8.5x faster** than model_construct (0.98 µs vs 8.32 µs/entry) and end-to-end batch construction is **2.4x faster** with the new SDK path (0.30ms vs 0.72ms median, 32-cut batch).

`_aistore_byte_range_supported` is also simplified to a plain version gate since the internal schema probes it performed were only needed to validate the bypass.

Signed-off-by: Soham Manoli <msoham123@gmail.com>