### PR TITLE
Fix 'lhotse prepare iwslt22-ta' always raising TypeError (clean= vs normalize_text=)

### DIFF
--- a/lhotse/bin/modes/recipes/iwslt22_ta.py
+++ b/lhotse/bin/modes/recipes/iwslt22_ta.py
@@ -52,6 +52,6 @@ def iwslt22_ta(
         splits,
         output_dir=output_dir,
         num_jobs=num_jobs,
-        clean=normalize_text,
+        normalize_text=normalize_text,
         langs=langs_list,
     )


### PR DESCRIPTION
`lhotse prepare iwslt22-ta` fails with `TypeError` on every invocation.

The Click command forwards its `--normalize-text` option under the name
`clean=` (`lhotse/bin/modes/recipes/iwslt22_ta.py:55`):

```python
    prepare_iwslt22_ta(
        corpus_dir,
        splits,
        output_dir=output_dir,
        num_jobs=num_jobs,
        clean=normalize_text,
        langs=langs_list,
    )
```

but the recipe names that parameter `normalize_text`
(`lhotse/recipes/iwslt22_ta.py:74`):

```python
def prepare_iwslt22_ta(
    corpus_dir: Pathlike,
    splits: Pathlike,
    output_dir: Optional[Pathlike] = None,
    normalize_text: bool = False,
    langs: Optional[List[str]] = ["ta", "eng"],
    num_jobs: int = 1,
) -> ...
```

There is no `**kwargs`, so the call cannot succeed regardless of the option
value. Binding the real upstream signature against the call site, with the
corrected call as a control:

```
prepare_iwslt22_ta (corpus_dir, splits, output_dir, normalize_text, langs, num_jobs)
  TypeError bin/modes/recipes/iwslt22_ta.py:50 (the CLI entry point) -> got an unexpected keyword argument 'clean'
  OK        CONTROL same call with normalize_text=
```

Note the other three keyword arguments at this call site (`output_dir`,
`num_jobs`, `langs`) all match the signature — only `clean` is stale.

Renaming it to `normalize_text=` makes the command runnable and connects
`--normalize-text` to the Arabic text normalization it is documented to control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
