### PR TITLE
Defer indexed tar member validation to payload loading

### DIFF
--- a/lhotse/ais/batch_loader.py
+++ b/lhotse/ais/batch_loader.py
@@ -522,11 +522,18 @@ class AISBatchLoader:
         loaders constructed in environments where AIStore isn't configured
         still pass cuts through unchanged.
         """
-        from lhotse.shar.lazy_pointer import decode_pointer
+        from lhotse.shar.lazy_pointer import (
+            decode_pointer_with_name,
+            resolve_pointer_path,
+        )
 
         def _shar_ptr_is_url(pointer: str) -> bool:
-            tar_path, _, _ = decode_pointer(pointer)
-            return is_valid_url(tar_path)
+            tar_path, _, _, expected_name = decode_pointer_with_name(pointer)
+            return (
+                expected_name is None
+                and is_valid_url(tar_path)
+                and resolve_pointer_path(tar_path) == tar_path
+            )
 
         for cut in cuts:
             for _, manifest in cut.iter_data():
@@ -722,9 +729,14 @@ class AISBatchLoader:
         """
         from aistore.sdk.utils import parse_url
 
-        from lhotse.shar.lazy_pointer import decode_pointer
+        from lhotse.shar.lazy_pointer import (
+            decode_pointer_with_name,
+            resolve_pointer_path,
+        )
 
-        tar_path, offset, end_offset = decode_pointer(pointer)
+        tar_path, offset, end_offset, expected_name = decode_pointer_with_name(pointer)
+        if expected_name is not None or resolve_pointer_path(tar_path) != tar_path:
+            return False
         if not is_valid_url(tar_path):
             return False
         provider, bck_name, obj_name = parse_url(tar_path)

--- a/lhotse/recipes/chime6.py
+++ b/lhotse/recipes/chime6.py
@@ -423,9 +423,7 @@ def _verify_md5_checksums(
     # First download checksum file and read it into a dictionary
     temp_dir = Path(tempfile.mkdtemp())
     checksum_file = temp_dir / "md5sums.txt"
-    resumable_download(
-        CHIME6_MD5SUM_FILE, str(checksum_file)
-    )
+    resumable_download(CHIME6_MD5SUM_FILE, str(checksum_file))
     checksums = {}
     with open(checksum_file, "r") as f:
         for line in f:

--- a/lhotse/shar/lazy_pointer.py
+++ b/lhotse/shar/lazy_pointer.py
@@ -5,59 +5,104 @@ A "Shar pointer" is a string that uniquely identifies a single sample's data
 member inside an indexed Shar tar shard, *without* requiring any tar header
 read at construction time:
 
-    <tar_path>?o=<offset>&e=<end_offset>
+    <tar_path>?o=<offset>&e=<end_offset>[&n=<expected_member_name>]
 
-where ``offset`` is the byte offset of the sample's data tar header (sourced
-from the existing ``.idx`` sidecar's offset array) and ``end_offset`` is the
-offset of the next sample's data header (or the tar's total file size for the
-last sample, taken from the ``.idx`` sentinel). The half-open interval
-``[offset, end_offset)`` covers ``data_header(512) + data_payload + pad +
-meta_header(512) + meta_payload + pad``.
+where ``offset`` and ``end_offset`` delimit the sample's indexed tar byte
+range. The optional percent-encoded member name enables load-time validation
+and recovery when a manifest is filtered or reordered. Pointers without a
+member name retain their original behavior and wire format.
 
-At load time, :func:`read_payload` does a single ranged read of that interval,
-parses the leading 512 bytes via :func:`lhotse.indexing.read_tar_member_at`,
-and returns just the payload bytes.
+At load time, :func:`read_payload` parses the indexed tar headers (including PAX
+and GNU long-name records) and reads the first regular member's payload. When an
+expected name is present, it is checked as part of that parsing and does not
+require a separate storage read.
 
-The pointer never encodes the file extension or member name — formats are
-sniffed from the payload's magic bytes (audio: soundfile auto-detect from
-:class:`io.BytesIO`; arrays: NPY ``\x93NUMPY`` vs lilcom).
+The file extension is not encoded separately. Formats are sniffed from the
+payload's magic bytes (audio: soundfile auto-detect from :class:`io.BytesIO`;
+arrays: NPY ``\x93NUMPY`` vs lilcom).
 """
 
 from __future__ import annotations
 
 import os
 import re
+import tarfile
 import threading
-from typing import Any, Dict, Tuple
+from collections import OrderedDict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, BinaryIO, Dict, Optional, Tuple
+from urllib.parse import quote_from_bytes, unquote_to_bytes
 
-from lhotse.indexing import read_tar_member_at
-from lhotse.serialization import open_best
-from lhotse.utils import Pathlike
+from lhotse.audio.source import resolve_s3_to_local_mirror
+from lhotse.audio.utils import AudioLoadingError
+from lhotse.serialization import (
+    AIStoreIOBackend,
+    CompositeIOBackend,
+    get_current_io_backend,
+    open_best,
+)
+from lhotse.utils import Pathlike, is_valid_url
 
-_POINTER_RE = re.compile(r"^(?P<tar>[^?]+)\?o=(?P<o>\d+)&e=(?P<e>\d+)$")
+_POINTER_RE = re.compile(
+    r"^(?P<tar>[^?]+)\?o=(?P<o>\d+)&e=(?P<e>\d+)(?:&n=(?P<n>[^&]*))?$"
+)
+_MIRROR_ROOTS_ENV = "LHOTSE_S3_LOCAL_MIRROR_ROOTS"
+_MAX_OPEN_FILES = 32
+_MAX_RESOLVED_PATHS = 256
 
-# Process-local file-handle reuse for repeated payload fetches from the same
-# tar. Intentionally not an LRU — typical workloads have tens of shards in
-# flight; eviction is unnecessary. ``close_all()`` is exposed for tests.
-#
-# Each tar gets its own ``threading.Lock`` so concurrent readers on different
-# tars don't serialize against each other; the global ``_REGISTRY_LOCK``
-# only guards lookup/insertion in the registry itself.
-_HANDLES: Dict[str, Tuple[Any, threading.Lock]] = {}
+
+@dataclass
+class _HandleEntry:
+    handle: BinaryIO
+    lock: threading.Lock
+    users: int = 0
+    member_index: Optional[Dict[str, Tuple[int, int]]] = None
+    close_requested: bool = False
+
+
+# Both caches are process-local. Handles are keyed by resolved physical path so
+# logical S3 identities sharing a local mirror also share the same descriptor.
+_HANDLES: OrderedDict[str, _HandleEntry] = OrderedDict()
+_RESOLVED_PATHS: OrderedDict[Tuple[str, Optional[str]], str] = OrderedDict()
 _REGISTRY_LOCK = threading.Lock()
 
 
-def encode_pointer(tar_path: Pathlike, offset: int, end_offset: int) -> str:
-    """Encode a Shar lazy-pointer string."""
-    return f"{tar_path}?o={int(offset)}&e={int(end_offset)}"
+def encode_pointer(
+    tar_path: Pathlike,
+    offset: int,
+    end_offset: int,
+    *,
+    expected_name: Optional[str] = None,
+) -> str:
+    """Encode a Shar lazy-pointer string.
+
+    ``expected_name`` is optional so existing callers retain the original wire
+    format. When present, :func:`read_payload` validates it while loading the
+    indexed range.
+    """
+    pointer = f"{tar_path}?o={int(offset)}&e={int(end_offset)}"
+    if expected_name is not None:
+        encoded_name = quote_from_bytes(
+            str(expected_name).encode("utf-8", errors="surrogateescape"), safe=""
+        )
+        pointer += f"&n={encoded_name}"
+    return pointer
 
 
 def decode_pointer(s: str) -> Tuple[str, int, int]:
-    """Parse a Shar lazy-pointer string into ``(tar_path, offset, end_offset)``."""
-    m = _POINTER_RE.match(s)
-    if m is None:
-        raise ValueError(f"Not a Shar pointer: {s!r}")
-    return m.group("tar"), int(m.group("o")), int(m.group("e"))
+    """Parse a Shar pointer into ``(tar_path, offset, end_offset)``.
+
+    The return type intentionally remains a three-tuple when the pointer also
+    carries an expected member name, preserving the public API.
+    """
+    tar_path, offset, end_offset, _expected_name = _decode_pointer(s)
+    return tar_path, offset, end_offset
+
+
+def decode_pointer_with_name(s: str) -> Tuple[str, int, int, Optional[str]]:
+    """Parse a Shar pointer, including its optional expected member name."""
+    return _decode_pointer(s)
 
 
 def is_shar_pointer(s: Any) -> bool:
@@ -65,42 +110,322 @@ def is_shar_pointer(s: Any) -> bool:
     return isinstance(s, str) and _POINTER_RE.match(s) is not None
 
 
-def _get_handle(tar_path: str) -> Tuple[Any, threading.Lock]:
-    with _REGISTRY_LOCK:
-        entry = _HANDLES.get(tar_path)
-        if entry is None:
-            entry = (open_best(tar_path, "rb"), threading.Lock())
-            _HANDLES[tar_path] = entry
-        return entry
-
-
 def read_payload(pointer: str) -> bytes:
     """Resolve a Shar lazy pointer to the underlying data member's payload."""
-    tar_path, offset, _end_offset = decode_pointer(pointer)
-    fh, fh_lock = _get_handle(tar_path)
-    with fh_lock:
-        data, _path, _info = read_tar_member_at(fh, offset)
-    if data is None:
-        raise RuntimeError(
-            f"Shar pointer {pointer!r} points at a placeholder (.nodata/.nometa) member."
+    tar_path, offset, end_offset, expected_name = _decode_pointer(pointer)
+    try:
+        resolved_path, entry = _acquire_handle(tar_path)
+        try:
+            with entry.lock:
+                if expected_name is not None and entry.member_index is not None:
+                    data = _read_named_payload(
+                        entry.handle,
+                        entry.member_index,
+                        expected_name,
+                        resolved_path,
+                    )
+                else:
+                    data, actual_name = _read_first_regular_member(
+                        entry.handle,
+                        offset,
+                        end_offset,
+                        pointer,
+                        expected_name=expected_name,
+                    )
+                    if expected_name is not None and actual_name != expected_name:
+                        entry.member_index = _build_member_index(
+                            entry.handle, resolved_path
+                        )
+                        data = _read_named_payload(
+                            entry.handle,
+                            entry.member_index,
+                            expected_name,
+                            resolved_path,
+                        )
+        finally:
+            _release_handle(entry)
+        if data is None:
+            message = (
+                f"Shar pointer {pointer!r} points at a placeholder "
+                "(.nodata/.nometa) member."
+            )
+            if expected_name is None:
+                raise RuntimeError(message)
+            raise AudioLoadingError(message)
+        return data
+    except AudioLoadingError:
+        raise
+    except Exception as ex:
+        if expected_name is None:
+            raise
+        raise AudioLoadingError(
+            f"Failed to load indexed tar payload from Shar pointer {pointer!r}: {ex}"
+        ) from ex
+
+
+def close_all() -> None:
+    """Close cached tar handles, deferring active ones until their read completes."""
+    with _REGISTRY_LOCK:
+        for path, entry in list(_HANDLES.items()):
+            if entry.users:
+                entry.close_requested = True
+                continue
+            _HANDLES.pop(path)
+            try:
+                entry.handle.close()
+            except Exception:
+                pass
+        _RESOLVED_PATHS.clear()
+
+
+def _decode_pointer(s: str) -> Tuple[str, int, int, Optional[str]]:
+    match = _POINTER_RE.match(s)
+    if match is None:
+        raise ValueError(f"Not a Shar pointer: {s!r}")
+    offset = int(match.group("o"))
+    end_offset = int(match.group("e"))
+    if end_offset < offset:
+        raise ValueError(
+            f"Invalid Shar pointer byte range [{offset}, {end_offset}): {s!r}"
+        )
+    encoded_name = match.group("n")
+    expected_name = (
+        unquote_to_bytes(encoded_name).decode("utf-8", errors="surrogateescape")
+        if encoded_name is not None
+        else None
+    )
+    return match.group("tar"), offset, end_offset, expected_name
+
+
+def resolve_pointer_path(tar_path: str) -> str:
+    """Resolve and cache the physical path used to load a pointer's tar."""
+    cache_key = (tar_path, os.environ.get(_MIRROR_ROOTS_ENV))
+    with _REGISTRY_LOCK:
+        try:
+            resolved = _RESOLVED_PATHS.pop(cache_key)
+        except KeyError:
+            pass
+        else:
+            _RESOLVED_PATHS[cache_key] = resolved
+            return resolved
+
+    resolved = resolve_s3_to_local_mirror(tar_path)
+    with _REGISTRY_LOCK:
+        try:
+            resolved = _RESOLVED_PATHS.pop(cache_key)
+        except KeyError:
+            pass
+        _RESOLVED_PATHS[cache_key] = resolved
+        while len(_RESOLVED_PATHS) > _MAX_RESOLVED_PATHS:
+            _RESOLVED_PATHS.popitem(last=False)
+    return resolved
+
+
+def _acquire_handle(tar_path: str) -> Tuple[str, _HandleEntry]:
+    resolved_path = resolve_pointer_path(tar_path)
+    with _REGISTRY_LOCK:
+        try:
+            entry = _HANDLES.pop(resolved_path)
+        except KeyError:
+            pass
+        else:
+            entry.users += 1
+            _HANDLES[resolved_path] = entry
+            return resolved_path, entry
+
+    new_entry = _HandleEntry(
+        handle=_open_seekable(resolved_path),
+        lock=threading.Lock(),
+    )
+    with _REGISTRY_LOCK:
+        try:
+            entry = _HANDLES.pop(resolved_path)
+        except KeyError:
+            entry = new_entry
+        else:
+            new_entry.handle.close()
+        entry.users += 1
+        _HANDLES[resolved_path] = entry
+        _evict_unused_handles()
+    return resolved_path, entry
+
+
+def _open_seekable(path: str) -> BinaryIO:
+    if path.startswith("ais://") or _uses_aistore_backend(path):
+        from lhotse.ais import AISRangeReader
+
+        return AISRangeReader(path)
+    return open_best(path, "rb")
+
+
+def _release_handle(entry: _HandleEntry) -> None:
+    with _REGISTRY_LOCK:
+        entry.users -= 1
+        if entry.users == 0 and entry.close_requested:
+            for path, candidate in list(_HANDLES.items()):
+                if candidate is entry:
+                    _HANDLES.pop(path)
+                    entry.handle.close()
+                    break
+            return
+        _evict_unused_handles()
+
+
+def _evict_unused_handles() -> None:
+    if len(_HANDLES) <= _MAX_OPEN_FILES:
+        return
+    for path, entry in list(_HANDLES.items()):
+        if len(_HANDLES) <= _MAX_OPEN_FILES:
+            break
+        if entry.users:
+            continue
+        _HANDLES.pop(path)
+        entry.handle.close()
+
+
+def _read_exact_range(
+    handle: BinaryIO, start: int, end: int, source_path: str
+) -> bytes:
+    handle.seek(start)
+    data = handle.read(end - start)
+    if len(data) != end - start:
+        raise EOFError(
+            f"Short Shar pointer read from {source_path}: requested "
+            f"[{start}, {end}), received {len(data)} bytes"
         )
     return data
 
 
-def close_all() -> None:
-    """Close all cached tar file handles. Intended for tests / cleanup."""
-    with _REGISTRY_LOCK:
-        for fh, _lock in _HANDLES.values():
-            try:
-                fh.close()
-            except Exception:
-                pass
-        _HANDLES.clear()
+class _BoundedReader:
+    """Seekable view over one byte range of an already-open file."""
+
+    def __init__(self, handle: BinaryIO, start: int, end: int):
+        self.handle = handle
+        self.start = start
+        self.end = end
+        self.position = 0
+
+    def read(self, size: int = -1) -> bytes:
+        available = max(0, self.end - self.start - self.position)
+        size = available if size is None or size < 0 else min(size, available)
+        self.handle.seek(self.start + self.position)
+        data = self.handle.read(size)
+        self.position += len(data)
+        return data
+
+    def seek(self, offset: int, whence: int = os.SEEK_SET) -> int:
+        if whence == os.SEEK_SET:
+            position = offset
+        elif whence == os.SEEK_CUR:
+            position = self.position + offset
+        elif whence == os.SEEK_END:
+            position = self.end - self.start + offset
+        else:
+            raise ValueError(f"Unsupported seek mode: {whence}")
+        if position < 0:
+            raise ValueError(f"Cannot seek before indexed tar range: {position}")
+        self.position = position
+        return position
+
+    def tell(self) -> int:
+        return self.position
 
 
-# Worker processes inherit ``_HANDLES`` across ``fork()`` but inherit only
-# duplicated FDs from the parent — concurrent reads from parent + child against
-# the same FD will corrupt each other's seek positions. Reset the registry in
-# the child so each worker opens its own fresh handle on first use.
+def _read_first_regular_member(
+    handle: BinaryIO,
+    start: int,
+    end: int,
+    pointer: str,
+    *,
+    expected_name: Optional[str],
+) -> Tuple[Optional[bytes], str]:
+    if end <= start:
+        raise EOFError(f"Empty indexed tar range [{start}, {end}) for {pointer!r}")
+    bounded = _BoundedReader(handle, start, end)
+    try:
+        with tarfile.open(fileobj=bounded, mode="r:") as archive:
+            for member in archive:
+                if not member.isfile():
+                    continue
+                if expected_name is not None and member.name != expected_name:
+                    return None, member.name
+                if Path(member.name).suffix in (".nodata", ".nometa"):
+                    return None, member.name
+                extracted = archive.extractfile(member)
+                if extracted is None:
+                    raise RuntimeError(
+                        f"Unable to extract tar member {member.name!r} for {pointer!r}."
+                    )
+                return extracted.read(), member.name
+    except tarfile.TarError as ex:
+        raise type(ex)(f"{ex} while reading Shar pointer {pointer!r}") from ex
+    raise RuntimeError(f"Shar pointer {pointer!r} contains no regular tar member.")
+
+
+def _build_member_index(
+    handle: BinaryIO, source_path: str
+) -> Dict[str, Tuple[int, int]]:
+    index: Dict[str, Tuple[int, int]] = {}
+    handle.seek(0)
+    try:
+        with tarfile.open(fileobj=handle, mode="r:") as archive:
+            for member in archive:
+                if not member.isfile():
+                    continue
+                if member.name in index:
+                    raise ValueError(
+                        f"Duplicate tar member name {member.name!r} in {source_path}; "
+                        "name-keyed lazy pointer access is ambiguous."
+                    )
+                index[member.name] = (member.offset_data, member.size)
+    except tarfile.TarError as ex:
+        raise type(ex)(f"{ex} while indexing tar members in {source_path}") from ex
+    return index
+
+
+def _read_named_payload(
+    handle: BinaryIO,
+    member_index: Dict[str, Tuple[int, int]],
+    expected_name: str,
+    source_path: str,
+) -> Optional[bytes]:
+    try:
+        start, size = member_index[expected_name]
+    except KeyError as ex:
+        raise KeyError(
+            f"Tar {source_path} has no member named {expected_name!r}."
+        ) from ex
+    if Path(expected_name).suffix in (".nodata", ".nometa"):
+        return None
+    return _read_exact_range(handle, start, start + size, source_path)
+
+
+def _reset_after_fork() -> None:
+    # Child processes inherit file descriptors and locks in unsafe states.
+    # Do not close duplicated parent descriptors here; simply forget them.
+    global _REGISTRY_LOCK
+    _HANDLES.clear()
+    _RESOLVED_PATHS.clear()
+    _REGISTRY_LOCK = threading.Lock()
+
+
+def _uses_aistore_backend(path: str) -> bool:
+    """Return whether ``open_best`` would route this URL through AIStore."""
+    if not is_valid_url(path):
+        return False
+    backend = get_current_io_backend()
+    if isinstance(backend, CompositeIOBackend):
+        for candidate in backend.backends:
+            if candidate.handles_special_case(path):
+                backend = candidate
+                break
+        else:
+            for candidate in backend.backends:
+                if candidate.is_applicable(path):
+                    backend = candidate
+                    break
+    return isinstance(backend, AIStoreIOBackend)
+
+
 if hasattr(os, "register_at_fork"):
-    os.register_at_fork(after_in_child=lambda: _HANDLES.clear())
+    os.register_at_fork(after_in_child=_reset_after_fork)

--- a/test/audio/test_s3_local_mirror.py
+++ b/test/audio/test_s3_local_mirror.py
@@ -6,6 +6,7 @@ from lhotse import CutSet
 from lhotse.ais.batch_loader import AISBatchLoader
 from lhotse.audio.recording import Recording
 from lhotse.audio.source import AudioSource, resolve_s3_to_local_mirror
+from lhotse.shar.lazy_pointer import encode_pointer
 
 _ENV_VAR = "LHOTSE_S3_LOCAL_MIRROR_ROOTS"
 
@@ -109,3 +110,41 @@ def test_ais_batch_loader_routes_mirrored_tar_member_locally(tmp_path, monkeypat
 
     assert not has_ais_url
     assert recording.sources[0].source == f"{archive}/nested/member.wav"
+
+
+def test_ais_batch_loader_leaves_mirrored_shar_pointer_for_local_loading(
+    tmp_path, monkeypatch
+):
+    archive = tmp_path / "bucket" / "key" / "audio.tar"
+    archive.parent.mkdir(parents=True)
+    archive.write_bytes(b"tar-placeholder")
+    monkeypatch.setenv(_ENV_VAR, str(tmp_path))
+    recording = Recording(
+        id="recording",
+        sources=[
+            AudioSource(
+                type="shar_ptr",
+                channels=[0],
+                source=encode_pointer(
+                    "s3://bucket/key/audio.tar",
+                    0,
+                    1024,
+                    expected_name="nested/member.wav",
+                ),
+            )
+        ],
+        sampling_rate=16000,
+        num_samples=16000,
+        duration=1.0,
+    )
+    loader = AISBatchLoader.__new__(AISBatchLoader)
+
+    has_ais_url = loader._collect_manifest_urls(
+        recording,
+        object(),
+        shar_ptr_uses_batch=False,
+        shar_ptr_fallback=[],
+        manifest_idx=0,
+    )
+
+    assert not has_ais_url

--- a/test/shar/test_lazy_pointers.py
+++ b/test/shar/test_lazy_pointers.py
@@ -7,10 +7,14 @@ from __future__ import annotations
 
 import pickle
 import re
+import tarfile
+from concurrent.futures import ThreadPoolExecutor
+from io import BytesIO
 from pathlib import Path
 
 # Reuse the standard shar test fixture which specifies all fields
 from test.shar.conftest import cuts  # noqa: F401
+from threading import Barrier
 from unittest.mock import patch
 
 import numpy as np
@@ -19,6 +23,7 @@ import pytest
 from lhotse.shar.lazy_pointer import (
     close_all,
     decode_pointer,
+    decode_pointer_with_name,
     encode_pointer,
     is_shar_pointer,
 )
@@ -90,6 +95,34 @@ def test_encode_decode_pointer_roundtrip():
     assert decode_pointer(p) == ("/some/where.tar", 1024, 65536)
 
 
+def test_encode_pointer_with_expected_member_name_is_backward_compatible():
+    p = encode_pointer(
+        "/some/where.tar",
+        1024,
+        65536,
+        expected_name="nested/audio with spaces&symbols.wav",
+    )
+
+    assert p == (
+        "/some/where.tar?o=1024&e=65536&n=nested%2Faudio%20with%20spaces%26symbols.wav"
+    )
+    assert decode_pointer(p) == ("/some/where.tar", 1024, 65536)
+    assert decode_pointer_with_name(p) == (
+        "/some/where.tar",
+        1024,
+        65536,
+        "nested/audio with spaces&symbols.wav",
+    )
+    assert is_shar_pointer(p)
+
+
+def test_expected_member_name_roundtrips_surrogateescaped_bytes():
+    name = "audio-\udcff.wav"
+    pointer = encode_pointer("/some/where.tar", 0, 1024, expected_name=name)
+
+    assert decode_pointer_with_name(pointer)[3] == name
+
+
 def test_is_shar_pointer():
     assert is_shar_pointer("/x.tar?o=0&e=10")
     assert not is_shar_pointer("/x.tar")
@@ -101,6 +134,364 @@ def test_decode_pointer_rejects_malformed():
     for bad in ("garbage", "/x.tar?o=10", "/x.tar?o=10&e=20&extra=1"):
         with pytest.raises(ValueError):
             decode_pointer(bad)
+
+
+def _tar_member_ranges(path: Path) -> dict[str, tuple[int, int]]:
+    with tarfile.open(path, "r:") as archive:
+        members = [member for member in archive if member.isfile()]
+    return {
+        member.name: (
+            member.offset,
+            members[idx + 1].offset if idx + 1 < len(members) else path.stat().st_size,
+        )
+        for idx, member in enumerate(members)
+    }
+
+
+def test_read_payload_validates_member_name_while_loading(tmp_path):
+    tar_path = tmp_path / "audio.tar"
+    payloads = {"first.wav": b"first-audio", "second.wav": b"second-audio"}
+    with tarfile.open(tar_path, "w") as archive:
+        for name, payload in payloads.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            archive.addfile(info, BytesIO(payload))
+    ranges = _tar_member_ranges(tar_path)
+    start, end = ranges["first.wav"]
+
+    pointer = encode_pointer(tar_path, start, end, expected_name="first.wav")
+
+    from lhotse.shar.lazy_pointer import read_payload
+
+    assert read_payload(pointer) == payloads["first.wav"]
+
+
+def test_read_payload_does_not_read_trailing_shar_metadata(tmp_path, monkeypatch):
+    from lhotse.shar import lazy_pointer
+
+    tar_path = tmp_path / "recording.tar"
+    audio = b"audio"
+    metadata = b"x" * (1024 * 1024)
+    with tarfile.open(tar_path, "w") as archive:
+        for name, payload in (
+            ("sample.wav", audio),
+            ("sample.json", metadata),
+        ):
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            archive.addfile(info, BytesIO(payload))
+
+    class CountingFile:
+        def __init__(self, path):
+            self.file = open(path, "rb")
+            self.bytes_read = 0
+
+        def read(self, size=-1):
+            data = self.file.read(size)
+            self.bytes_read += len(data)
+            return data
+
+        def seek(self, *args):
+            return self.file.seek(*args)
+
+        def tell(self):
+            return self.file.tell()
+
+        def close(self):
+            self.file.close()
+
+    opened = []
+
+    def counting_open_best(path, mode):
+        handle = CountingFile(path)
+        opened.append(handle)
+        return handle
+
+    close_all()
+    monkeypatch.setattr(lazy_pointer, "open_best", counting_open_best)
+    pointer = encode_pointer(
+        tar_path,
+        0,
+        tar_path.stat().st_size,
+        expected_name="sample.wav",
+    )
+
+    assert lazy_pointer.read_payload(pointer) == audio
+    assert len(opened) == 1
+    assert opened[0].bytes_read < len(metadata)
+
+
+def test_read_payload_resolves_filtered_manifest_member_on_first_mismatch(tmp_path):
+    tar_path = tmp_path / "audio.tar"
+    payloads = {
+        "discarded.wav": b"discarded-audio",
+        "selected.wav": b"selected-audio",
+    }
+    with tarfile.open(tar_path, "w") as archive:
+        for name, payload in payloads.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            archive.addfile(info, BytesIO(payload))
+    ranges = _tar_member_ranges(tar_path)
+    candidate_start, candidate_end = ranges["discarded.wav"]
+
+    pointer = encode_pointer(
+        tar_path,
+        candidate_start,
+        candidate_end,
+        expected_name="selected.wav",
+    )
+
+    from lhotse.shar.lazy_pointer import read_payload
+
+    assert read_payload(pointer) == payloads["selected.wav"]
+
+
+def test_read_payload_reuses_filtered_manifest_name_index(tmp_path):
+    from lhotse.shar import lazy_pointer
+
+    tar_path = tmp_path / "audio.tar"
+    payloads = {
+        "discarded.wav": b"discarded-audio",
+        "selected.wav": b"selected-audio",
+    }
+    with tarfile.open(tar_path, "w") as archive:
+        for name, payload in payloads.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            archive.addfile(info, BytesIO(payload))
+    candidate_range = _tar_member_ranges(tar_path)["discarded.wav"]
+    pointer = encode_pointer(
+        tar_path,
+        *candidate_range,
+        expected_name="selected.wav",
+    )
+
+    close_all()
+    assert lazy_pointer.read_payload(pointer) == payloads["selected.wav"]
+    with patch.object(
+        lazy_pointer,
+        "_read_first_regular_member",
+        side_effect=AssertionError("cached names must bypass the candidate range"),
+    ):
+        assert lazy_pointer.read_payload(pointer) == payloads["selected.wav"]
+
+
+def test_read_payload_reports_missing_expected_member_as_audio_error(tmp_path):
+    from lhotse.audio import AudioLoadingError
+    from lhotse.shar.lazy_pointer import read_payload
+
+    tar_path = tmp_path / "audio.tar"
+    with tarfile.open(tar_path, "w") as archive:
+        payload = b"audio"
+        info = tarfile.TarInfo("present.wav")
+        info.size = len(payload)
+        archive.addfile(info, BytesIO(payload))
+    start, end = _tar_member_ranges(tar_path)["present.wav"]
+    pointer = encode_pointer(
+        tar_path,
+        start,
+        end,
+        expected_name="missing.wav",
+    )
+
+    with pytest.raises(AudioLoadingError, match="no member named 'missing.wav'"):
+        read_payload(pointer)
+
+
+def test_read_payload_rejects_corrupt_candidate_range_without_scanning(tmp_path):
+    from lhotse.audio import AudioLoadingError
+    from lhotse.shar import lazy_pointer
+
+    tar_path = tmp_path / "audio.tar"
+    payloads = {"first.wav": b"first-audio", "second.wav": b"second-audio"}
+    with tarfile.open(tar_path, "w") as archive:
+        for name, payload in payloads.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            archive.addfile(info, BytesIO(payload))
+    candidate_end = tar_path.stat().st_size
+    pointer = encode_pointer(
+        tar_path,
+        candidate_end - 1,
+        candidate_end,
+        expected_name="second.wav",
+    )
+
+    close_all()
+    with patch.object(
+        lazy_pointer,
+        "_build_member_index",
+        wraps=lazy_pointer._build_member_index,
+    ) as build_member_index:
+        with pytest.raises(AudioLoadingError):
+            lazy_pointer.read_payload(pointer)
+    build_member_index.assert_not_called()
+
+
+def test_read_payload_preserves_malformed_pointer_error():
+    from lhotse.shar.lazy_pointer import read_payload
+
+    with pytest.raises(ValueError, match="Not a Shar pointer"):
+        read_payload("not-a-pointer")
+
+
+@pytest.mark.parametrize("tar_format", [tarfile.PAX_FORMAT, tarfile.GNU_FORMAT])
+def test_read_payload_parses_extended_name_from_indexed_range(tmp_path, tar_format):
+    tar_path = tmp_path / "audio.tar"
+    member_name = f"nested/{'long-' * 24}audio.wav"
+    payload = b"pax-audio"
+    with tarfile.open(tar_path, "w", format=tar_format) as archive:
+        info = tarfile.TarInfo(member_name)
+        info.size = len(payload)
+        archive.addfile(info, BytesIO(payload))
+    start, end = _tar_member_ranges(tar_path)[member_name]
+
+    pointer = encode_pointer(tar_path, start, end, expected_name=member_name)
+
+    from lhotse.shar.lazy_pointer import read_payload
+
+    assert read_payload(pointer) == payload
+
+
+def test_read_payload_resolves_s3_pointer_to_local_mirror_once(tmp_path, monkeypatch):
+    from lhotse.shar import lazy_pointer
+
+    tar_path = tmp_path / "bucket" / "key" / "audio.tar"
+    tar_path.parent.mkdir(parents=True)
+    payload = b"mirrored-audio"
+    with tarfile.open(tar_path, "w") as archive:
+        info = tarfile.TarInfo("audio.wav")
+        info.size = len(payload)
+        archive.addfile(info, BytesIO(payload))
+    start, end = _tar_member_ranges(tar_path)["audio.wav"]
+    pointer = encode_pointer(
+        "s3://bucket/key/audio.tar",
+        start,
+        end,
+        expected_name="audio.wav",
+    )
+    opened = []
+    real_open_best = lazy_pointer.open_best
+
+    def recording_open_best(path, mode):
+        opened.append(str(path))
+        return real_open_best(path, mode)
+
+    close_all()
+    monkeypatch.setenv("LHOTSE_S3_LOCAL_MIRROR_ROOTS", str(tmp_path))
+    monkeypatch.setattr(lazy_pointer, "open_best", recording_open_best)
+
+    assert lazy_pointer.read_payload(pointer) == payload
+    assert lazy_pointer.read_payload(pointer) == payload
+    assert opened == [str(tar_path)]
+
+
+def test_read_payload_is_thread_safe_for_shared_tar(tmp_path):
+    from lhotse.shar.lazy_pointer import read_payload
+
+    tar_path = tmp_path / "audio.tar"
+    payloads = {f"audio-{idx}.wav": bytes([idx]) * 100 for idx in range(4)}
+    with tarfile.open(tar_path, "w") as archive:
+        for name, payload in payloads.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            archive.addfile(info, BytesIO(payload))
+    ranges = _tar_member_ranges(tar_path)
+    pointers = [
+        encode_pointer(tar_path, *ranges[name], expected_name=name) for name in payloads
+    ]
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        actual = list(executor.map(read_payload, pointers * 10))
+
+    assert actual == [payloads[name] for name in payloads] * 10
+
+
+def test_opening_different_archives_is_not_serialized(tmp_path, monkeypatch):
+    from lhotse.shar import lazy_pointer
+
+    pointers = []
+    for idx in range(2):
+        tar_path = tmp_path / f"audio-{idx}.tar"
+        payload = bytes([idx])
+        with tarfile.open(tar_path, "w") as archive:
+            info = tarfile.TarInfo(f"audio-{idx}.wav")
+            info.size = len(payload)
+            archive.addfile(info, BytesIO(payload))
+        pointers.append(
+            encode_pointer(
+                tar_path,
+                *_tar_member_ranges(tar_path)[f"audio-{idx}.wav"],
+                expected_name=f"audio-{idx}.wav",
+            )
+        )
+
+    barrier = Barrier(2)
+    real_open_best = lazy_pointer.open_best
+
+    def synchronized_open(path, mode):
+        barrier.wait(timeout=2)
+        return real_open_best(path, mode)
+
+    close_all()
+    monkeypatch.setattr(lazy_pointer, "open_best", synchronized_open)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        assert list(executor.map(lazy_pointer.read_payload, pointers)) == [b"\0", b"\1"]
+
+
+def test_read_payload_evicts_unused_handles(tmp_path, monkeypatch):
+    from lhotse.shar import lazy_pointer
+
+    pointers = []
+    for idx in range(2):
+        tar_path = tmp_path / f"audio-{idx}.tar"
+        with tarfile.open(tar_path, "w") as archive:
+            payload = bytes([idx])
+            info = tarfile.TarInfo(f"audio-{idx}.wav")
+            info.size = len(payload)
+            archive.addfile(info, BytesIO(payload))
+        start, end = _tar_member_ranges(tar_path)[f"audio-{idx}.wav"]
+        pointers.append(
+            encode_pointer(
+                tar_path,
+                start,
+                end,
+                expected_name=f"audio-{idx}.wav",
+            )
+        )
+
+    close_all()
+    monkeypatch.setattr(lazy_pointer, "_MAX_OPEN_FILES", 1)
+
+    assert lazy_pointer.read_payload(pointers[0]) == b"\0"
+    first_entry = next(iter(lazy_pointer._HANDLES.values()))
+    assert lazy_pointer.read_payload(pointers[1]) == b"\1"
+    assert first_entry.handle.closed
+    assert len(lazy_pointer._HANDLES) == 1
+    assert list(lazy_pointer._HANDLES) == [str(tmp_path / "audio-1.tar")]
+    assert lazy_pointer.read_payload(pointers[0]) == b"\0"
+
+
+def test_close_all_defers_closing_an_active_handle():
+    from lhotse.shar import lazy_pointer
+
+    handle = BytesIO(b"tar")
+    entry = lazy_pointer._HandleEntry(
+        handle=handle,
+        lock=lazy_pointer.threading.Lock(),
+        users=1,
+    )
+    close_all()
+    lazy_pointer._HANDLES["archive.tar"] = entry
+
+    close_all()
+
+    assert not handle.closed
+    assert entry.close_requested
+    lazy_pointer._release_handle(entry)
+    assert handle.closed
+    assert "archive.tar" not in lazy_pointer._HANDLES
 
 
 # ---------------------------------------------------------------------------
@@ -307,6 +698,154 @@ def test_ais_collect_queues_shar_ptr_fallback_when_byte_range_unsupported():
     assert obj_name == "recording.000000.tar"
     assert offset == 1024
     assert length == 8192 - 1024
+
+
+def test_ais_does_not_batch_name_validated_pointer():
+    """Name-aware pointers stay on the path that can validate and recover."""
+    pytest.importorskip("aistore")
+    from lhotse import AudioSource, Recording
+    from lhotse.ais.batch_loader import AISBatchLoader
+
+    rec = Recording(
+        id="x",
+        sources=[
+            AudioSource(
+                type="shar_ptr",
+                channels=[0],
+                source=encode_pointer(
+                    "ais://b/recording.000000.tar",
+                    1024,
+                    8192,
+                    expected_name="wanted.wav",
+                ),
+            )
+        ],
+        sampling_rate=16000,
+        num_samples=16000,
+        duration=1.0,
+    )
+    loader = AISBatchLoader.__new__(AISBatchLoader)
+    shar_ptr_fallback = []
+
+    assert not loader._collect_manifest_urls(
+        rec,
+        object(),
+        shar_ptr_uses_batch=True,
+        shar_ptr_fallback=shar_ptr_fallback,
+        manifest_idx=0,
+    )
+    assert shar_ptr_fallback == []
+
+
+def test_name_validated_ais_pointer_uses_seekable_range_reader(tmp_path, monkeypatch):
+    pytest.importorskip("aistore")
+    from lhotse import AudioSource, CutSet, Recording
+    from lhotse.ais.batch_loader import AISBatchLoader
+    from lhotse.shar.lazy_pointer import read_payload
+
+    tar_path = tmp_path / "audio.tar"
+    payloads = {"discarded.wav": b"discarded", "selected.wav": b"selected"}
+    with tarfile.open(tar_path, "w") as archive:
+        for name, payload in payloads.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(payload)
+            archive.addfile(info, BytesIO(payload))
+    ranges = _tar_member_ranges(tar_path)
+    tar_bytes = tar_path.read_bytes()
+    candidate_start, candidate_end = ranges["discarded.wav"]
+    pointer = encode_pointer(
+        "ais://bucket/audio.tar",
+        candidate_start,
+        candidate_end,
+        expected_name="selected.wav",
+    )
+    recording = Recording(
+        id="x",
+        sources=[AudioSource(type="shar_ptr", channels=[0], source=pointer)],
+        sampling_rate=16000,
+        num_samples=16000,
+        duration=1.0,
+    )
+    loader = AISBatchLoader.__new__(AISBatchLoader)
+    opened = []
+
+    def fake_range_reader(path):
+        opened.append(path)
+        return BytesIO(tar_bytes)
+
+    close_all()
+    monkeypatch.setattr("lhotse.ais.AISRangeReader", fake_range_reader)
+
+    assert not loader._cuts_have_ais_data(CutSet.from_cuts([recording.to_cut()]))
+    assert read_payload(pointer) == payloads["selected.wav"]
+    assert opened == ["ais://bucket/audio.tar"]
+
+
+def test_s3_pointer_uses_range_reader_with_active_aistore_backend(
+    tmp_path, monkeypatch
+):
+    from lhotse.serialization import AIStoreIOBackend, io_backend
+    from lhotse.shar import lazy_pointer
+
+    tar_path = tmp_path / "audio.tar"
+    payload = b"audio"
+    with tarfile.open(tar_path, "w") as archive:
+        info = tarfile.TarInfo("audio.wav")
+        info.size = len(payload)
+        archive.addfile(info, BytesIO(payload))
+    start, end = _tar_member_ranges(tar_path)["audio.wav"]
+    pointer = encode_pointer(
+        "s3://bucket/audio.tar",
+        start,
+        end,
+        expected_name="audio.wav",
+    )
+    opened = []
+
+    def fake_range_reader(path):
+        opened.append(path)
+        return BytesIO(tar_path.read_bytes())
+
+    close_all()
+    monkeypatch.setattr("lhotse.ais.AISRangeReader", fake_range_reader)
+    with io_backend(AIStoreIOBackend()):
+        assert lazy_pointer.read_payload(pointer) == payload
+    assert opened == ["s3://bucket/audio.tar"]
+
+
+def test_non_ais_url_pointer_retains_open_best_backend(tmp_path, monkeypatch):
+    from lhotse.shar import lazy_pointer
+
+    tar_path = tmp_path / "audio.tar"
+    payload = b"audio"
+    with tarfile.open(tar_path, "w") as archive:
+        info = tarfile.TarInfo("audio.wav")
+        info.size = len(payload)
+        archive.addfile(info, BytesIO(payload))
+    start, end = _tar_member_ranges(tar_path)["audio.wav"]
+    pointer = encode_pointer(
+        "https://example.com/audio.tar",
+        start,
+        end,
+        expected_name="audio.wav",
+    )
+    opened = []
+
+    def fake_open_best(path, mode):
+        opened.append((path, mode))
+        return BytesIO(tar_path.read_bytes())
+
+    close_all()
+    monkeypatch.setattr(lazy_pointer, "open_best", fake_open_best)
+    monkeypatch.setattr(
+        "lhotse.ais.AISRangeReader",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("non-AIStore URLs must retain their existing backend")
+        ),
+    )
+
+    assert lazy_pointer.read_payload(pointer) == payload
+    assert opened == [("https://example.com/audio.tar", "rb")]
 
 
 def test_ais_byte_range_path_when_sdk_supports_it():


### PR DESCRIPTION
## Summary

- extend lazy Shar pointers with an optional expected member name while preserving the existing pointer format and three-value decoder API
- validate the member name while parsing the indexed range at payload-load time, avoiding a separate validation read
- on a valid name mismatch, build and cache a header-only member index for filtered or reordered manifests; malformed ranges fail without scanning
- resolve configured local mirrors before opening and cache physical handles with bounded, thread-safe, fork-safe lifetime management
- preserve the selected URL backend, including seekable AIStore range access, and keep legacy unnamed-pointer batch loading unchanged

## Compatibility

Pointers without an expected member name retain their wire format and loading behavior. Name-validated pointers are loaded directly so validation cannot be bypassed by batch injection.

## Validation

- `python -m pytest -q test/shar/test_lazy_pointers.py test/audio/test_s3_local_mirror.py test/cut/test_ais_batch_loader.py test/ais/test_batch_loader_moss_in.py` (85 passed, 2 skipped)
- `pre-commit run --files lhotse/ais/batch_loader.py lhotse/shar/lazy_pointer.py test/audio/test_s3_local_mirror.py test/shar/test_lazy_pointers.py`
- `git diff --check`

The module-level lazy-pointer documentation covers the optional name field and load-time behavior; no broader user-facing workflow changes are required.