### PR TITLE
Avoid repeated graph checks in bucketer checkpoints

### DIFF
--- a/lhotse/dataset/sampling/dynamic_bucketing.py
+++ b/lhotse/dataset/sampling/dynamic_bucketing.py
@@ -649,8 +649,15 @@ class DynamicBucketer:
     def _supports_graph_restore(source: Any) -> bool:
         return source is not None and supports_graph_restore(source)
 
-    def _capture_item_token(self, item: Cut, source: Any) -> Any:
-        if not self._supports_graph_restore(source):
+    def _restore_source_capabilities(self) -> List[bool]:
+        """Check each restore source once for the current save/restore operation."""
+        return [
+            self._supports_graph_restore(source)
+            for source in self.restore_sources or ()
+        ]
+
+    def _capture_item_token(self, item: Cut, source_is_restorable: bool) -> Any:
+        if not source_is_restorable:
             raise RuntimeError(
                 "DynamicBucketer checkpoint requires graph-restorable sources "
                 "when saving buffered O(1) restore state."
@@ -659,8 +666,10 @@ class DynamicBucketer:
             item, "DynamicBucketer checkpoint", "buffered items"
         )
 
-    def _restore_item_token(self, token: Any, source: Any) -> Cut:
-        if not self._supports_graph_restore(source):
+    def _restore_item_token(
+        self, token: Any, source: Any, source_is_restorable: bool
+    ) -> Cut:
+        if not source_is_restorable:
             raise RuntimeError(
                 "DynamicBucketer checkpoint captured a graph-local restore token, "
                 "but the current iterator graph does not support constant-time "
@@ -676,6 +685,7 @@ class DynamicBucketer:
         """Capture bucketer state for checkpoint."""
         from lhotse.checkpoint import _rng_state_to_json
 
+        source_capabilities = self._restore_source_capabilities()
         bucket_tokens: List[List] = []
         for bucket in self.buckets:
             tokens = []
@@ -684,10 +694,14 @@ class DynamicBucketer:
                     cuts = item if isinstance(item, tuple) else (item,)
                     item_tokens = []
                     for cut_idx, cut in enumerate(cuts):
-                        source = None
-                        if self.restore_sources is not None:
-                            source = self.restore_sources[cut_idx]
-                        item_tokens.append(self._capture_item_token(cut, source))
+                        source_is_restorable = (
+                            source_capabilities[cut_idx]
+                            if cut_idx < len(source_capabilities)
+                            else False
+                        )
+                        item_tokens.append(
+                            self._capture_item_token(cut, source_is_restorable)
+                        )
                     tokens.append(item_tokens)
             bucket_tokens.append(tokens)
 
@@ -724,16 +738,27 @@ class DynamicBucketer:
                 "DynamicBucketer checkpoint is inconsistent: "
                 f"saved {len(bucket_tokens)} buckets, expected {len(self.buckets)}."
             )
+        source_capabilities = self._restore_source_capabilities()
         for bucket, tokens in zip(self.buckets, bucket_tokens):
             with bucket.mutex:
                 bucket.queue.clear()
             for item_tokens in tokens:
                 items = []
                 for cut_idx, token in enumerate(item_tokens):
-                    source = None
-                    if self.restore_sources is not None:
-                        source = self.restore_sources[cut_idx]
-                    items.append(self._restore_item_token(token, source))
+                    source = (
+                        self.restore_sources[cut_idx]
+                        if self.restore_sources is not None
+                        and cut_idx < len(self.restore_sources)
+                        else None
+                    )
+                    source_is_restorable = (
+                        source_capabilities[cut_idx]
+                        if cut_idx < len(source_capabilities)
+                        else False
+                    )
+                    items.append(
+                        self._restore_item_token(token, source, source_is_restorable)
+                    )
                 # Match the runtime ingestion format (`zip(*sources)` always
                 # yields tuples, even for the 1-source case), so the queue is
                 # type-uniform across initial fill, refill, and restore.

--- a/test/dataset/test_checkpoint_restore.py
+++ b/test/dataset/test_checkpoint_restore.py
@@ -7,6 +7,7 @@ Tests that:
 - Old state_dicts (without cuts_state) still work via legacy _fast_forward
 - IterableDatasetWrapper implements state_dict()/load_state_dict()
 """
+
 from copy import deepcopy
 
 import pytest
@@ -15,8 +16,11 @@ from lhotse import CutSet
 from lhotse.dataset.iterable_dataset import IterableDatasetWrapper
 from lhotse.dataset.sampling.base import CutSampler
 from lhotse.dataset.sampling.dynamic import DynamicCutSampler
-from lhotse.dataset.sampling.dynamic_bucketing import DynamicBucketingSampler
-from lhotse.lazy import IteratorNode, LazyRepeater
+from lhotse.dataset.sampling.dynamic_bucketing import (
+    DynamicBucketer,
+    DynamicBucketingSampler,
+)
+from lhotse.lazy import IteratorNode, LazyRepeater, attach_graph_origin
 from lhotse.testing.dummies import DummyManifest
 
 
@@ -54,6 +58,29 @@ class _IndexedCutsWithoutGraphOrigin(IteratorNode):
     def load_state_dict(self, sd):
         self.position = sd["position"]
         self._restored = True
+
+
+class _CountingGraphRestoreSource(IteratorNode):
+    is_indexed = True
+
+    def __init__(self, cuts):
+        self.cuts = list(cuts)
+        self.capability_checks = 0
+
+    @property
+    def has_constant_time_access(self):
+        self.capability_checks += 1
+        return True
+
+    def __iter__(self):
+        for idx, cut in enumerate(self.cuts):
+            yield attach_graph_origin(cut, idx)
+
+    def __getitem__(self, idx):
+        return attach_graph_origin(deepcopy(self.cuts[idx]), idx)
+
+    def __len__(self):
+        return len(self.cuts)
 
 
 class TestDynamicSamplerCheckpoint:
@@ -523,6 +550,59 @@ class TestIndexedSamplerStateCapture:
             match="indexed datasets should never use O\\(N\\) fast-forward",
         ):
             iter(sampler2)
+
+    @staticmethod
+    def _make_bucketer_with_buffer(cuts, num_buffered=20):
+        source = _CountingGraphRestoreSource(cuts)
+        bucketer = DynamicBucketer(
+            [],
+            duration_bins=[10.0],
+            world_size=1,
+            max_cuts=4,
+            buffer_size=num_buffered,
+            concurrent=False,
+            restore_sources=[source],
+        )
+        for idx in range(num_buffered):
+            cut = attach_graph_origin(deepcopy(source.cuts[idx]), idx)
+            bucketer.buckets[idx % len(bucketer.buckets)].put((cut,))
+        return bucketer, source
+
+    def test_dynamic_bucketer_snapshot_checks_each_source_once(self, cuts):
+        bucketer, source = self._make_bucketer_with_buffer(cuts)
+
+        state = bucketer.get_state()
+
+        assert source.capability_checks == 1
+        assert sum(len(tokens) for tokens in state["bucket_tokens"]) == 20
+
+    def test_dynamic_bucketer_snapshot_revalidates_sources(self, cuts):
+        bucketer, source = self._make_bucketer_with_buffer(cuts)
+
+        bucketer.get_state()
+        bucketer.get_state()
+
+        assert source.capability_checks == 2
+
+    def test_dynamic_bucketer_restore_checks_each_source_once(self, cuts):
+        bucketer, _ = self._make_bucketer_with_buffer(cuts)
+        state = bucketer.get_state()
+        restored_source = _CountingGraphRestoreSource(cuts)
+        restored = DynamicBucketer(
+            [],
+            duration_bins=[10.0],
+            world_size=1,
+            max_cuts=4,
+            buffer_size=20,
+            concurrent=False,
+            restore_sources=[restored_source],
+        )
+        restored.set_state(state)
+
+        restored._restore_from_saved_state()
+
+        assert restored_source.capability_checks == 1
+        assert sum(bucket.qsize() for bucket in restored.buckets) == 20
 
 
 class TestMixedSourceConstantTimeAccessRaises:


### PR DESCRIPTION
## Summary

- compute graph-restore capability once per positional source during each DynamicBucketer save/restore operation
- retain graph-origin validation for every buffered item
- revalidate capabilities on every later snapshot or restore rather than persisting a cache
- add regression coverage for save, repeated snapshots, and restore

Reported by Albert Zeyer. Thank you for identifying the repeated dataset-graph traversal in sampler snapshots and providing the initial monkeypatch demonstrating the fix.

## Performance

Synthetic DynamicBucketer snapshot with 10,000 buffered items and 1,000 graph leaves:

- before: 10,000,000 capability checks, approximately 1.28 s
- after: 1,000 capability checks, approximately 2.1 ms

This changes capability-check work from O(buffered items x graph size) to O(buffered items + graph size).

## Tests

- `pytest -q test/dataset/test_checkpoint_restore.py`: 24 passed
- `pytest -q test/dataset/sampling --ignore=test/dataset/sampling/test_stateless_sampler.py test/dataset/test_checkpoint_restore.py`: 391 passed, 2 skipped, 13 xfailed
- the 11 excluded StatelessSampler failures reproduce on the unchanged pre-update feature checkout and are unrelated to this patch